### PR TITLE
Updated requirements to remove seqeval version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,7 @@ interpret_eval/tasks/re/test_re.tsv
 interpret_eval/tasks/re/tensoreval-backup.py
 interpret_eval/tasks/re/a.json
 interpret_eval/tasks/re/instantiate.json
+instantiate.json
+out.json
+*.egg-info
+__pycache__

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,4 +3,4 @@ numpy
 scipy
 matplotlib
 scikit-learn
-seqeval==0.0.12
+seqeval


### PR DESCRIPTION
It seems that ExplainaBoard works with the most recent version of seqeval, so just removed the version specification.

Fixes https://github.com/neulab/ExplainaBoard/issues/12

Also makes a few small additions to `.gitignore`.