### PR TITLE
feat: make ner faster

### DIFF
--- a/explainaboard/processors/aspect_based_sentiment_classification.py
+++ b/explainaboard/processors/aspect_based_sentiment_classification.py
@@ -2,7 +2,7 @@ from explainaboard import feature
 from explainaboard.tasks import TaskType
 from explainaboard.processors.processor import Processor
 from explainaboard.processors.processor_registry import register_processor
-from explainaboard.utils.spacy_loader import spacy_loader
+from explainaboard.utils.spacy_loader import get_named_entities
 
 
 @register_processor(TaskType.aspect_based_sentiment_classification)
@@ -82,7 +82,6 @@ class AspectBasedSentimentClassificationProcessor(Processor):
 
     def __init__(self):
         super().__init__()
-        self._spacy_nlp = spacy_loader.get_model("en_core_web_sm")
 
     # --- Feature functions accessible by ExplainaboardBuilder._get_feature_func()
     def _get_sentence_length(self, existing_features: dict):
@@ -92,7 +91,7 @@ class AspectBasedSentimentClassificationProcessor(Processor):
         return len(existing_feature["text"])
 
     def _get_entity_number(self, existing_feature: dict):
-        return len(self._spacy_nlp(existing_feature["text"]).ents)
+        return len(get_named_entities(existing_feature["text"]))
 
     def _get_label(self, existing_feature: dict):
         return existing_feature["true_label"]

--- a/explainaboard/processors/processor.py
+++ b/explainaboard/processors/processor.py
@@ -2,7 +2,8 @@ import json
 from typing import Callable, List, Tuple, Dict
 
 from datalabs import load_dataset
-from eaas import Config, Client
+from explainaboard.utils.async_eaas import AsyncEaaSClient
+from eaas.config import Config
 from tqdm import tqdm
 
 import explainaboard.metric
@@ -98,7 +99,7 @@ class Processor:
     def _get_eaas_client(self):
         if not self._eaas_client:
             self._eaas_config = Config()
-            self._eaas_client = Client()
+            self._eaas_client = AsyncEaaSClient()
             self._eaas_client.load_config(
                 self._eaas_config
             )  # The config you have created above

--- a/explainaboard/processors/text_classification.py
+++ b/explainaboard/processors/text_classification.py
@@ -11,7 +11,7 @@ from explainaboard.processors.processor import Processor
 from explainaboard.processors.processor_registry import register_processor
 from explainaboard.tasks import TaskType
 from explainaboard.utils.feature_funcs import get_basic_words, get_lexical_richness
-from explainaboard.utils.spacy_loader import spacy_loader
+from explainaboard.utils.spacy_loader import get_named_entities
 
 
 @register_processor(TaskType.text_classification)
@@ -129,9 +129,7 @@ class TextClassificationProcessor(Processor):
         return len(existing_feature["text"])
 
     def _get_entity_number(self, existing_feature: dict):
-        return len(
-            spacy_loader.get_model("en_core_web_sm")(existing_feature["text"]).ents
-        )
+        return len(get_named_entities(existing_feature["text"]))
 
     def _get_label(self, existing_feature: dict):
         return existing_feature["true_label"]

--- a/explainaboard/utils/async_eaas.py
+++ b/explainaboard/utils/async_eaas.py
@@ -1,0 +1,51 @@
+from typing import Any, Dict, List
+from eaas import Client
+from threading import Thread
+import uuid
+
+
+class AsyncEaaSClient(Client):
+    """
+    A wrapper class to support async requests for EaaS. It uses threads so there is a limit to the maximum number of parallel requests it can make.
+    Example usage:
+      1. `request_id = client.score([])` to start a new thread and make a request
+      2. `client.wait_and_get_result(request_id)` to join the thread and get the result, this method can be called only once for each request_id
+    """
+
+    def __init__(self):
+        super().__init__()
+        self._threads: Dict[int, Thread] = {}
+        self._results: Dict[int, Any] = {}
+
+    def _run_thread(self, original_fn) -> str:
+        request_id = str(uuid.uuid1())
+
+        def fn():
+            self._results[request_id] = original_fn()
+
+        self._threads[request_id] = Thread(target=fn)
+        self._threads[request_id].start()
+        return request_id
+
+    def async_score(
+        self,
+        inputs: List[Dict],
+        task="sum",
+        metrics=None,
+        lang="en",
+        cal_attributes=False,
+    ):
+        return self._run_thread(
+            lambda: super(AsyncEaaSClient, self).score(
+                inputs, task, metrics, lang, cal_attributes
+            )
+        )
+
+    def wait_and_get_result(self, request_id: str):
+        if request_id not in self._threads:
+            raise Exception(f"thread_id {request_id} doesn't exist")
+        self._threads[request_id].join()
+        result = self._results[request_id]
+        self._results.pop(request_id)
+        self._threads.pop(request_id)
+        return result

--- a/explainaboard/utils/spacy_loader.py
+++ b/explainaboard/utils/spacy_loader.py
@@ -1,4 +1,4 @@
-from typing import Dict
+from typing import Dict, Tuple
 import spacy
 from spacy.language import Language
 
@@ -27,3 +27,10 @@ class SpacyLoader:
 
 # singleton spacy loader to keep one copy of each model in memory
 spacy_loader = SpacyLoader()
+
+
+def get_named_entities(text: str, model_name="en_core_web_sm") -> Tuple[str]:
+    """Use spacy to extract named entities from `text`. All other spacy components are disabled to improve speed."""
+    return spacy_loader.get_model(model_name)(
+        text, disable=["tok2vec", "tagger", "parser", "attribute_ruler", "lemmatizer"]
+    ).ents


### PR DESCRIPTION
1. disable irrelevant spacy components when running ner
    - NER takes up 84% of the time when running text classification (got the number using `tests/artifacts/test-classification`). This change will reduce the overall latency by a little less than 50%. 
    - aspect-based sentiment classification also uses NER so it's also affected.
    - spaCy supports parallel processing out of the box so this can be improved further if we run NER for all samples at the same time. I didn't make this change because it makes the assumption that all the samples can be loaded into the memory. Do we want to leave room to handle datasets that are too large to be loaded into the memory at once? If not, it'll be easy to make some small changes to the processor so it can take advantage of the multiprocessing ability of spaCy.
    - before:
<br/><img width="600" alt="Screen Shot 2022-03-16 at 9 13 02 PM" src="https://user-images.githubusercontent.com/22896307/158718325-b053d626-935b-4cec-97a2-96593f96bed6.png">
    - after:
<br/><img width="600" alt="Screen Shot 2022-03-16 at 9 28 27 PM" src="https://user-images.githubusercontent.com/22896307/158718508-03afb9ae-d92d-4402-8372-b6ae5af2aa9d.png">
    - to reproduce: `python -m cProfile -o text-classification-disable-irrelevant-spacy-components.pstats explainaboard/explainaboard_main.py --task text-classification --system_outputs /Users/lyuyangh/Developer/ExplainaBoard/explainaboard/tests/artifacts/test-classification.tsv --metrics F1score`

2. make eaas requests asynchronous for conditional generation tasks
    - `get_oracle` and the eaas request takes up 90% of the time. This change makes the eaas request execute on another thread so the overall latency is reduced by a little less than 50%.
    - The asyc logic is implemented in `AsyncEaaSClient`. If you think this is useful, I think we can move it to the eaas client itself. The current implementation uses threading which means there's a limit to the number of parallel requests it can make. I think a better solution would be to use coroutine which will scale a lot better. But it requires more changes to the SDK and the web app codebase because I need to turn a bunch of functions to be asyc. 
    - I didn't apply the same improvement to extractive QA because with the current design, parallelization wouldn't help.
    - before:
<br/><img width="600" alt="Screen Shot 2022-03-17 at 12 50 24 AM" src="https://user-images.githubusercontent.com/22896307/158741067-a7bfefa6-4be9-4617-b9c7-95b06b0bfa48.png">
   - after:
   <br/><img width="600" alt="Screen Shot 2022-03-17 at 12 56 51 AM" src="https://user-images.githubusercontent.com/22896307/158741111-ee0406c6-f8d9-4a6b-b196-1701c345d3d6.png">
   - to reproduce: `python -m cProfile -o profile_results/mt-parallel.pstats explainaboard/explainaboard_main.py --task machine-translation --system_outputs cnndm_mini.bart --metrics bleu`
3. I also profiled this [larger file (cnndm_base)](https://drive.google.com/drive/folders/1TPE2M3R38_ugCAMJ05lEalqErkLhIeBr).
    - 75% of the time is spent on tokenization. Out of which 90% is on porter and the rest is mostly regex matching. I think this is kinda interesting because I didn't know stemming would take up all the time. Could we cache the stemming results so we can do a lookup for seen words? I guess we can also use multiprocessing here?
<br/><img width="600" alt="Screen Shot 2022-03-17 at 1 42 16 AM" src="https://user-images.githubusercontent.com/22896307/158745974-a0dc97a1-b6a6-4a29-b649-97d9df0d5cc4.png">
   - reproduce: `python -m cProfile -o profile_results/mt-parallel-huge.pstats explainaboard/explainaboard_main.py --task machine-translation --system_outputs cnndm_base.tsv --metrics bleu`