### PR TITLE
feat: extract user defined features code to the base loader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,3 +32,4 @@ gen_samples.py
 log.res
 gen_samples.py
 explainaboard/tests/test_api.py
+profile_results

--- a/explainaboard/explainaboard_main.py
+++ b/explainaboard/explainaboard_main.py
@@ -81,18 +81,24 @@ def main():
         )
 
     # Read in data and check validity
-    system_datasets = [list(get_loader(task, data=x).load()) for x in system_outputs]
+    loaders = [get_loader(task, data=x) for x in system_outputs]
+    system_datasets = [list(loader.load()) for loader in loaders]
 
-    # Get user_defined_features_configs (this should be generalized later
-    loader = get_loader(task, data=system_outputs[0])
-    user_defined_features_configs = loader.load_user_defined_features_configs()
-
-    if len(system_datasets) == 2 and len(system_datasets[0]) != len(system_datasets[1]):
-        num0 = len(system_datasets[0])
-        num1 = len(system_datasets[1])
-        raise ValueError(
-            f'Data must be identical for pairwise analysis, but length of files {system_datasets[0]} ({num0}) != {system_datasets[1]} ({num1})'
-        )
+    # validation
+    if len(system_datasets) == 2:
+        if len(system_datasets[0]) != len(system_datasets[1]):
+            num0 = len(system_datasets[0])
+            num1 = len(system_datasets[1])
+            raise ValueError(
+                f'Data must be identical for pairwise analysis, but length of files {system_datasets[0]} ({num0}) != {system_datasets[1]} ({num1})'
+            )
+        if (
+            loaders[0].user_defined_features_configs
+            != loaders[1].user_defined_features_configs
+        ):
+            raise ValueError(
+                "User defined features must be the same for pairwise analysis."
+            )
 
     # Setup metadata
     metadata = {
@@ -100,7 +106,7 @@ def main():
         "sub_dataset_name": sub_dataset,
         "task_name": task,
         "reload_stat": reload_stat,
-        "user_defined_features_configs": user_defined_features_configs,
+        "user_defined_features_configs": loaders[0].user_defined_features_configs,
     }
     if metric_names is not None:
         metadata["metric_names"] = metric_names

--- a/explainaboard/loaders/aspect_based_sentiment_classification.py
+++ b/explainaboard/loaders/aspect_based_sentiment_classification.py
@@ -1,6 +1,5 @@
 from typing import Dict, Iterable, List
 from explainaboard.constants import Source, FileType
-from enum import Enum
 from explainaboard.tasks import TaskType
 from .loader import register_loader
 from .loader import Loader
@@ -16,7 +15,7 @@ class AspectBasedSentimentClassificationLoader(Loader):
         please refer to `test_loaders.py`
     """
 
-    def __init__(self, source: Source, file_type: Enum, data: str = None):
+    def __init__(self, source: Source, file_type: FileType, data: str = None):
         if source is None:
             source = Source.local_filesystem
         if file_type is None:
@@ -30,10 +29,10 @@ class AspectBasedSentimentClassificationLoader(Loader):
         aspect \t text \t label \t predicted_label
         :return: class object
         """
-        raw_data = self._load_raw_data_points()
+        super().load()
         data: List[Dict] = []
         if self._file_type == FileType.tsv:
-            for id, dp in enumerate(raw_data):
+            for id, dp in enumerate(self._raw_data):
                 aspect, text, true_label, predicted_label = dp[:4]
                 data.append(
                     {
@@ -45,7 +44,7 @@ class AspectBasedSentimentClassificationLoader(Loader):
                     }
                 )
         elif self._file_type == FileType.json:
-            for id, info in enumerate(raw_data):
+            for id, info in enumerate(self._raw_data):
                 aspect, text, true_label, predicted_label = (
                     info["aspect"],
                     info["text"],

--- a/explainaboard/loaders/conditional_generation.py
+++ b/explainaboard/loaders/conditional_generation.py
@@ -1,6 +1,5 @@
 from typing import Dict, Iterable, List
 from explainaboard.constants import Source, FileType
-from enum import Enum
 from .loader import register_loader
 from .loader import Loader
 from explainaboard.tasks import TaskType
@@ -17,7 +16,7 @@ class ConditionalGenerationLoader(Loader):
         please refer to `test_loaders.py`
     """
 
-    def __init__(self, source: Source, file_type: Enum, data: str = None):
+    def __init__(self, source: Source, file_type: FileType, data: str = None):
 
         if source is None:
             source = Source.local_filesystem
@@ -28,13 +27,6 @@ class ConditionalGenerationLoader(Loader):
         self._file_type = file_type
         self._data = data
 
-    # def load_user_defined_features_configs(self):
-    #     return False
-    # raw_data = self._load_raw_data_points() # for json files: loads the entire json
-    # self.user_defined_features_configs = raw_data.get("user_defined_features_configs", None)
-
-    # return self.user_defined_features_configs
-
     def load(self) -> Iterable[Dict]:
         """
         :param path_system_output: the path of system output file with following format:
@@ -42,10 +34,10 @@ class ConditionalGenerationLoader(Loader):
         :return: class object
         """
 
-        raw_data = self._load_raw_data_points()
+        super().load()
         data: List[Dict] = []
         if self._file_type == FileType.tsv:
-            for id, dp in enumerate(raw_data):
+            for id, dp in enumerate(self._raw_data):
                 source, reference, hypothesis = dp[:3]
                 data.append(
                     {
@@ -56,7 +48,7 @@ class ConditionalGenerationLoader(Loader):
                     }
                 )
         elif self._file_type == FileType.json:  # This function has been unittested
-            for id, info in enumerate(raw_data):
+            for id, info in enumerate(self._raw_data):
                 source, reference, hypothesis = (
                     info["source"],
                     info["references"],

--- a/explainaboard/loaders/extractive_qa.py
+++ b/explainaboard/loaders/extractive_qa.py
@@ -1,6 +1,5 @@
 from typing import Dict, Iterable, List
 from explainaboard.constants import Source, FileType
-from enum import Enum
 from .loader import register_loader
 from .loader import Loader
 from explainaboard.tasks import TaskType
@@ -10,7 +9,7 @@ from explainaboard.tasks import TaskType
 class QAExtractiveLoader(Loader):
     """ """
 
-    def __init__(self, source: Source, file_type: Enum, data: str = None):
+    def __init__(self, source: Source, file_type: FileType, data: str = None):
 
         if source is None:
             source = Source.local_filesystem
@@ -27,7 +26,7 @@ class QAExtractiveLoader(Loader):
         text \t label \t predicted_label
         :return: class object
         """
-        raw_data = self._load_raw_data_points()
+        super().load()
 
         # if self._file_type == FileType.json:
         #     pred_json = raw_data
@@ -39,10 +38,9 @@ class QAExtractiveLoader(Loader):
         #     os.path.join(os.path.dirname(__file__), "../datasets/squad/testset-en.json")
         # )
 
-        raw_data = self._load_raw_data_points()  # for json files: loads the entire json
         data: List[Dict] = []
         if self._file_type == FileType.json:
-            for id, data_info in enumerate(raw_data):
+            for id, data_info in enumerate(self._raw_data):
                 data.append(
                     {
                         "id": str(id),  # should be string type
@@ -53,7 +51,7 @@ class QAExtractiveLoader(Loader):
                     }
                 )
         elif self._file_type == FileType.datalab:
-            for id, data_info in enumerate(raw_data):
+            for id, data_info in enumerate(self._raw_data):
                 data.append(
                     {
                         "id": str(id),  # should be string type
@@ -105,4 +103,3 @@ class QAExtractiveLoader(Loader):
         #                     }
         #                 )
         #                 key += 1
-        return data

--- a/explainaboard/loaders/hellaswag.py
+++ b/explainaboard/loaders/hellaswag.py
@@ -1,6 +1,5 @@
 from typing import Dict, Iterable, List
 from explainaboard.constants import Source, FileType
-from enum import Enum
 from .loader import register_loader
 from .loader import Loader
 from datasets import load_dataset
@@ -11,7 +10,7 @@ from explainaboard.tasks import TaskType
 class HellaswagLoader(Loader):
     """ """
 
-    def __init__(self, source: Source, file_type: Enum, data: str = None):
+    def __init__(self, source: Source, file_type: FileType, data: str = None):
 
         if source is None:
             source = Source.local_filesystem
@@ -28,12 +27,12 @@ class HellaswagLoader(Loader):
         text \t label \t predicted_label
         :return: class object
         """
+        super().load()
         dataset = load_dataset('hellaswag')['validation']
 
-        raw_data = self._load_raw_data_points()
         data: List[Dict] = []
         if self._file_type == FileType.tsv:
-            for id, dp in enumerate(raw_data):
+            for id, dp in enumerate(self._raw_data):
                 sample_id, predicted_label = dp[:2]
                 data.append(
                     {

--- a/explainaboard/loaders/kg_link_tail_prediction.py
+++ b/explainaboard/loaders/kg_link_tail_prediction.py
@@ -1,6 +1,5 @@
 from typing import Dict, Iterable, List
 from explainaboard.constants import Source, FileType
-from enum import Enum
 from explainaboard.tasks import TaskType
 from .loader import register_loader
 from .loader import Loader
@@ -16,7 +15,7 @@ class KgLinkTailPredictionLoader(Loader):
         please refer to `test_loaders.py`
     """
 
-    def __init__(self, source: Source, file_type: Enum, data: str = None):
+    def __init__(self, source: Source, file_type: FileType, data: str = None):
 
         if source is None:
             source = Source.local_filesystem
@@ -26,15 +25,6 @@ class KgLinkTailPredictionLoader(Loader):
         self._source = source
         self._file_type = file_type
         self._data = data
-        self.user_defined_features_configs = self.load_user_defined_features_configs()
-
-    def load_user_defined_features_configs(self):
-
-        raw_data = self._load_raw_data_points()  # for json files: loads the entire json
-        self.user_defined_features_configs = raw_data.get(
-            "user_defined_features_configs", None
-        )
-        return self.user_defined_features_configs
 
     def load(self) -> Iterable[Dict]:
         """
@@ -43,15 +33,11 @@ class KgLinkTailPredictionLoader(Loader):
 
         :return: class object
         """
-        raw_data = self._load_raw_data_points()  # for json files: loads the entire json
+        super().load()
         data: List[Dict] = []
         if self._file_type == FileType.json:
-            if (
-                self.user_defined_features_configs is not None
-            ):  # user defined features are present
-                for id, (link, features_dict) in enumerate(
-                    raw_data['predictions'].items()
-                ):
+            if self.user_defined_features_configs:  # user defined features are present
+                for id, (link, features_dict) in enumerate(self._raw_data.items()):
 
                     data_i = {
                         "id": str(id),  # should be string type
@@ -66,14 +52,13 @@ class KgLinkTailPredictionLoader(Loader):
                     data_i.update(
                         {
                             feature_name: features_dict[feature_name]
-                            for feature_name in self.user_defined_features_configs.keys()
+                            for feature_name in self.user_defined_features_configs
                         }
                     )
 
-                    # save
                     data.append(data_i)
             else:
-                for id, (link, predictions) in enumerate(raw_data.items()):
+                for id, (link, predictions) in enumerate(self._raw_data.items()):
                     data.append(
                         {
                             "id": str(id),  # should be string type

--- a/explainaboard/loaders/loader.py
+++ b/explainaboard/loaders/loader.py
@@ -1,7 +1,6 @@
-from typing import Dict, Iterable, List
+from typing import Dict, Iterable, List, Optional
 import typing as t
 import json
-from enum import Enum
 from io import StringIO
 import csv
 from explainaboard.constants import FileType, Source
@@ -13,29 +12,38 @@ JSON = t.Union[str, int, float, bool, None, t.Mapping[str, 'JSON'], t.List['JSON
 class Loader:
     """base class of loader"""
 
-    def __init__(self, source: Source, file_type: Enum, data: str):
+    def __init__(self, source: Source, file_type: FileType, data: str):
         self._source = source
         self._file_type = file_type
-        self._data = data
+        self._data = data  # base64 or filepath
+        self._raw_data: Optional[Iterable] = None  # loaded data
 
-    def load_user_defined_features_configs(self):
-        return {}
+        # None: uninitialized; {}: no custom features defined
+        self._user_defined_features_configs: Optional[dict] = None
+
+    @property
+    def user_defined_features_configs(self) -> dict:
+        if self._user_defined_features_configs is None:
+            raise Exception(
+                "User defined features configs are not available (data has not been loaded))"
+            )
+        return self._user_defined_features_configs
 
     def _load_raw_data_points(self) -> Iterable:
         """
         loads data and return an iterable of data points. element type depends on file_type
-        TODO: error handling
         """
+        raw_data: Optional[Iterable] = None
         if self._source == Source.in_memory:
             if self._file_type == FileType.tsv:
                 file = StringIO(self._data)
-                return csv.reader(file, delimiter='\t')
+                raw_data = csv.reader(file, delimiter='\t')
             elif self._file_type == FileType.conll:
-                return self._data.splitlines()
+                raw_data = self._data.splitlines()
             elif self._file_type == FileType.json:
-                return json.loads(self._data)
+                raw_data = json.loads(self._data)
             elif self._file_type == FileType.datalab:
-                return self._data
+                raw_data = self._data
             else:
                 raise NotImplementedError
 
@@ -45,23 +53,34 @@ class Loader:
                 with open(self._data, "r", encoding="utf8") as fin:
                     for record in csv.reader(fin, delimiter='\t'):
                         content.append(record)
-                return content
+                raw_data = content
             elif self._file_type == FileType.conll:
                 content = []
                 with open(self._data, "r", encoding="utf8") as fin:
                     for record in fin:
                         content.append(record)
-                return content
+                raw_data = content
             elif self._file_type == FileType.json:
                 with open(self._data, 'r', encoding="utf8") as json_file:
                     data = json_file.read()
-                obj = json.loads(data)
-                return obj
+                raw_data = json.loads(data)
             else:
                 raise NotImplementedError
 
-    def load(self) -> Iterable[Dict]:
-        raise NotImplementedError
+        # load user defined features if exists
+        if isinstance(raw_data, dict) and raw_data.get("user_defined_features_configs"):
+            self._user_defined_features_configs = raw_data[
+                "user_defined_features_configs"
+            ]
+            raw_data = raw_data["predictions"]
+
+        else:
+            self._user_defined_features_configs = {}
+        self._raw_data = raw_data
+        return raw_data
+
+    def load(self) -> Iterable[dict]:
+        return self._load_raw_data_points()
 
 
 # loader_registry is a global variable, storing all basic loading functions

--- a/explainaboard/loaders/named_entity_recognition.py
+++ b/explainaboard/loaders/named_entity_recognition.py
@@ -4,7 +4,6 @@ from .loader import register_loader
 from .loader import Loader
 from explainaboard.constants import FileType, Source
 from explainaboard.tasks import TaskType
-from enum import Enum
 
 
 @register_loader(TaskType.named_entity_recognition)
@@ -17,7 +16,7 @@ class NERLoader(Loader):
         please refer to `test_loaders.py`
     """
 
-    def __init__(self, source: Source, file_type: Enum, data: str = None):
+    def __init__(self, source: Source, file_type: FileType, data: str = None):
 
         if source is None:
             source = Source.local_filesystem
@@ -34,14 +33,14 @@ class NERLoader(Loader):
         token \t true_tag \t predicted_tag
         :return: class object
         """
-        raw_data = self._load_raw_data_points()
+        super().load()
         data: List[Dict] = []
         guid = 0
         tokens = []
         ner_true_tags = []
         ner_pred_tags = []
 
-        for id, line in enumerate(raw_data):
+        for id, line in enumerate(self._raw_data):
             if line.startswith("-DOCSTART-") or line == "" or line == "\n":
                 if tokens:
                     data.append(

--- a/explainaboard/loaders/qa_multiple_choice.py
+++ b/explainaboard/loaders/qa_multiple_choice.py
@@ -1,6 +1,5 @@
 from typing import Dict, Iterable, List
 from explainaboard.constants import Source, FileType
-from enum import Enum
 from explainaboard.tasks import TaskType
 from .loader import register_loader
 from .loader import Loader
@@ -16,7 +15,7 @@ class QAMultipleChoiceLoader(Loader):
         please refer to `test_loaders.py`
     """
 
-    def __init__(self, source: Source, file_type: Enum, data: str = None):
+    def __init__(self, source: Source, file_type: FileType, data: str = None):
 
         if source is None:
             source = Source.local_filesystem
@@ -34,10 +33,10 @@ class QAMultipleChoiceLoader(Loader):
 
         :return: class object
         """
-        raw_data = self._load_raw_data_points()  # for json files: loads the entire json
+        super().load()
         data: List[Dict] = []
         if self._file_type == FileType.json:
-            for id, data_info in enumerate(raw_data):
+            for id, data_info in enumerate(self._raw_data):
                 data.append(
                     {
                         "id": str(id),  # should be string type

--- a/explainaboard/loaders/text_classification.py
+++ b/explainaboard/loaders/text_classification.py
@@ -1,6 +1,5 @@
 from typing import Dict, Iterable, List
 from explainaboard.constants import Source, FileType
-from enum import Enum
 from explainaboard.tasks import TaskType
 from .loader import register_loader
 from .loader import Loader
@@ -16,7 +15,7 @@ class TextClassificationLoader(Loader):
         please refer to `test_loaders.py`
     """
 
-    def __init__(self, source: Source, file_type: Enum, data: str = None):
+    def __init__(self, source: Source, file_type: FileType, data: str = None):
 
         if source is None:
             source = Source.local_filesystem
@@ -33,10 +32,10 @@ class TextClassificationLoader(Loader):
         text \t label \t predicted_label
         :return: class object
         """
-        raw_data = self._load_raw_data_points()
+        super().load()
         data: List[Dict] = []
         if self._file_type == FileType.tsv:
-            for id, dp in enumerate(raw_data):
+            for id, dp in enumerate(self._raw_data):
                 text, true_label, predicted_label = dp[:3]
                 data.append(
                     {
@@ -47,7 +46,7 @@ class TextClassificationLoader(Loader):
                     }
                 )
         elif self._file_type == FileType.json:
-            for id, info in enumerate(raw_data):
+            for id, info in enumerate(self._raw_data):
                 text, true_label, predicted_label = (
                     info["text"],
                     info["true_label"],
@@ -62,7 +61,7 @@ class TextClassificationLoader(Loader):
                     }
                 )
         elif self._file_type == FileType.datalab:
-            for id, info in enumerate(raw_data):
+            for id, info in enumerate(self._raw_data):
                 text, true_label, predicted_label = (
                     info["text"],
                     info["label"],

--- a/explainaboard/loaders/text_pair_classification.py
+++ b/explainaboard/loaders/text_pair_classification.py
@@ -1,6 +1,5 @@
 from typing import Dict, Iterable, List
 from explainaboard.constants import Source, FileType
-from enum import Enum
 from explainaboard.tasks import TaskType
 from .loader import register_loader
 from .loader import Loader
@@ -16,7 +15,7 @@ class TextPairClassificationLoader(Loader):
         please refer to `test_loaders.py`
     """
 
-    def __init__(self, source: Source, file_type: Enum, data: str = None):
+    def __init__(self, source: Source, file_type: FileType, data: str = None):
 
         if source is None:
             source = Source.local_filesystem
@@ -33,10 +32,10 @@ class TextPairClassificationLoader(Loader):
         text \t label \t predicted_label
         :return: class object
         """
-        raw_data = self._load_raw_data_points()
+        super().load()
         data: List[Dict] = []
         if self._file_type == FileType.tsv:
-            for id, dp in enumerate(raw_data):
+            for id, dp in enumerate(self._raw_data):
                 text1, text2, true_label, predicted_label = dp[:4]
                 data.append(
                     {

--- a/explainaboard/processors/kg_link_tail_prediction.py
+++ b/explainaboard/processors/kg_link_tail_prediction.py
@@ -122,7 +122,7 @@ class KGLinkTailPredictionProcessor(Processor):
 
     def process(self, metadata: dict, sys_output: List[dict]) -> SysOutputInfo:
         self._user_defined_feature_config = metadata.get(
-            "user_defined_features_configs", None
+            "user_defined_features_configs"
         )
         return super().process(metadata, sys_output)
 

--- a/explainaboard/tests/artifacts/test-kg-link-tail-prediction-user-defined-features.json
+++ b/explainaboard/tests/artifacts/test-kg-link-tail-prediction-user-defined-features.json
@@ -1,0 +1,38 @@
+{
+  "user_defined_features_configs": {
+    "user_defined_feature_1": {
+      "dtype": "string",
+      "description": "just a toy string feature for testing",
+      "num_buckets": 8
+    },
+    "user_defined_feature_2": {
+      "dtype": "float",
+      "description": "just a toy float feature for testing",
+      "num_buckets": 4
+    }
+  },
+  "predictions": {
+    "Z\u00fcrich\t/travel/travel_destination/climate./travel/travel_destination_monthly_climate/month\tOctober": {
+      "predictions": [
+        "October",
+        "Fields Medal",
+        "pound sterling",
+        "Euro",
+        "Australian dollar"
+      ],
+      "user_defined_feature_1": "test1",
+      "user_defined_feature_2": 1.0
+    },
+    "autoharp\t/music/performance_role/regular_performances./music/group_membership/group\tHeart": {
+      "predictions": [
+        "The Mothers of Invention",
+        "The Decemberists",
+        "Ringo Starr & His All-Starr Band",
+        "Blondie",
+        "Little Feat"
+      ],
+      "user_defined_feature_1": "test",
+      "user_defined_feature_2": 1.2
+    }
+  }
+}

--- a/explainaboard/tests/test_kg_link_tail_prediction.py
+++ b/explainaboard/tests/test_kg_link_tail_prediction.py
@@ -7,7 +7,7 @@ artifacts_path = os.path.dirname(pathlib.Path(__file__)) + "/artifacts/"
 
 
 class TestKgLinkTailPrediction(unittest.TestCase):
-    def test_generate_system_analysis(self):
+    def test_no_user_defined_features(self):
 
         path_data = artifacts_path + "test-kg-link-tail-prediction.json"
         loader = get_loader(
@@ -17,6 +17,7 @@ class TestKgLinkTailPrediction(unittest.TestCase):
             path_data,
         )
         data = loader.load()
+        self.assertEqual(loader.user_defined_features_configs, {})
 
         metadata = {
             "task_name": TaskType.kg_link_tail_prediction.value,
@@ -31,6 +32,30 @@ class TestKgLinkTailPrediction(unittest.TestCase):
         # analysis.write_to_directory("./")
         self.assertIsNotNone(sys_info.results.fine_grained)
         self.assertGreater(len(sys_info.results.overall), 0)
+
+    def test_with_user_defined_features(self):
+        loader = get_loader(
+            TaskType.kg_link_tail_prediction,
+            Source.local_filesystem,
+            FileType.json,
+            artifacts_path + "test-kg-link-tail-prediction-user-defined-features.json",
+        )
+        data = loader.load()
+        self.assertEqual(len(loader.user_defined_features_configs), 2)
+        self.assertEqual(len(data), 2)
+        self.assertEqual(
+            set(data[0].keys()),
+            {
+                "id",
+                "link",
+                "relation",
+                "true_head",
+                "true_tail",
+                "predicted_tails",
+                "user_defined_feature_1",
+                "user_defined_feature_2",
+            },
+        )
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
I was going through the loader code to prepare it for #141 when I found this "user-defined features" code that's specific to kg link tail prediction tasks. This PR extracts this code to the base loader so all task types support it. This also makes it easier to abstract loader logic to something more general like TSVLoader. Please let me know if this is useful!

- The configs dict for user-defined features are passed into the processors as part of the metadata but I couldn't find the place where it is used. Is it intended for some feature we want to support in the future or am I missing something?