### PR TITLE
Generalize decorator for the `get_statistics` function

### DIFF
--- a/explainaboard/processors/conditional_generation.py
+++ b/explainaboard/processors/conditional_generation.py
@@ -4,8 +4,8 @@ from typing import Iterator, Dict, List
 import numpy
 from tqdm import tqdm
 
-# TODO(gneubig) we should try to remove this task-specific dependency with Datalab
-from datalabs.operations.aggregate.summarization import summarization_aggregating
+
+from datalabs import aggregating
 import explainaboard.utils.feature_funcs
 from explainaboard import feature
 from explainaboard.info import SysOutputInfo, Performance, BucketPerformance
@@ -275,7 +275,7 @@ class ConditionalGenerationProcessor(Processor):
 # TODO(gneubig) we should try to git rid of this task-specific decorator
 # TODO(gneubig) should be conditional generation, not summarization
 # Aggregate training set statistics
-@summarization_aggregating(
+@aggregating(
     name="get_statistics",
     contributor="datalab",
     task="summarization",

--- a/explainaboard/processors/extractive_qa.py
+++ b/explainaboard/processors/extractive_qa.py
@@ -2,7 +2,7 @@ from typing import Callable, Any
 from typing import Iterator, Dict, List
 
 from datalabs import load_dataset
-from datalabs.operations.aggregate.qa_extractive import qa_extractive_aggregating
+from datalabs import aggregating
 
 import explainaboard.utils.eval_basic_qa
 import explainaboard.utils.feature_funcs
@@ -253,7 +253,7 @@ class QAExtractiveProcessor(Processor):
         return sort_dict(bucket_name_to_performance)
 
 
-@qa_extractive_aggregating(
+@aggregating(
     name="get_statistics",
     contributor="datalab",
     task="qa-extractive",

--- a/explainaboard/processors/kg_link_tail_prediction.py
+++ b/explainaboard/processors/kg_link_tail_prediction.py
@@ -4,9 +4,7 @@ from typing import Callable
 from typing import Dict, List
 
 from datalabs import load_dataset
-from datalabs.operations.aggregate.kg_link_prediction import (
-    kg_link_prediction_aggregating,
-)
+from datalabs import aggregating
 from tqdm import tqdm
 
 import explainaboard.metric
@@ -348,7 +346,7 @@ class KGLinkTailPredictionProcessor(Processor):
         return sort_dict(bucket_name_to_performance)
 
 
-@kg_link_prediction_aggregating(
+@aggregating(
     name="get_statistics",
     contributor="datalab",
     task="kg-link-prediction",

--- a/explainaboard/processors/named_entity_recognition.py
+++ b/explainaboard/processors/named_entity_recognition.py
@@ -3,9 +3,7 @@ from typing import Callable, Tuple
 from typing import Iterator, Dict, List
 
 from datalabs import load_dataset
-from datalabs.operations.aggregate.sequence_labeling import (
-    sequence_labeling_aggregating,
-)
+from datalabs import aggregating
 from tqdm import tqdm
 
 import explainaboard.utils.bucketing
@@ -795,7 +793,7 @@ def get_efre_dic(train_word_sequences, tag_sequences_train):
     return efre_dic_keep
 
 
-@sequence_labeling_aggregating(
+@aggregating(
     name="get_statistics",
     contributor="datalab",
     task="sequence-labeling, named-entity-recognition, structure-prediction",

--- a/explainaboard/processors/qa_multiple_choice.py
+++ b/explainaboard/processors/qa_multiple_choice.py
@@ -2,9 +2,7 @@ from typing import Callable, Any
 from typing import Iterator
 
 from datalabs import load_dataset
-from datalabs.operations.aggregate.qa_multiple_choice import (
-    qa_multiple_choice_aggregating,
-)
+from datalabs import aggregating
 
 import explainaboard.utils.feature_funcs
 from explainaboard import feature
@@ -157,7 +155,7 @@ class QAMultipleChoiceProcessor(Processor):
         return data_point["predicted_answers"]["option_index"]
 
 
-@qa_multiple_choice_aggregating(
+@aggregating(
     name="get_statistics",
     contributor="datalab",
     task="qa-multiple-choice",

--- a/explainaboard/processors/text_classification.py
+++ b/explainaboard/processors/text_classification.py
@@ -1,8 +1,4 @@
 from typing import Iterator, Any
-
-from datalabs.operations.aggregate.text_classification import (
-    text_classification_aggregating,
-)
 from tqdm import tqdm
 
 import explainaboard.utils.feature_funcs
@@ -12,6 +8,8 @@ from explainaboard.processors.processor_registry import register_processor
 from explainaboard.tasks import TaskType
 from explainaboard.utils.feature_funcs import get_basic_words, get_lexical_richness
 from explainaboard.utils.spacy_loader import get_named_entities
+
+from datalabs import aggregating
 
 
 @register_processor(TaskType.text_classification)
@@ -165,7 +163,7 @@ class TextClassificationProcessor(Processor):
     # --- End feature functions
 
 
-@text_classification_aggregating(
+@aggregating(
     name="get_statistics",
     contributor="datalab",
     task="text-classification",

--- a/explainaboard/processors/text_pair_classification.py
+++ b/explainaboard/processors/text_pair_classification.py
@@ -1,7 +1,7 @@
 from typing import Callable, Iterator, Any
 
 from datalabs import load_dataset
-from datalabs.operations.aggregate.text_matching import text_matching_aggregating
+from datalabs import aggregating
 
 import explainaboard.utils.feature_funcs
 from explainaboard import feature
@@ -158,7 +158,7 @@ class TextPairClassificationProcessor(Processor):
     # --- End feature functions
 
 
-@text_matching_aggregating(
+@aggregating(
     name="get_statistics",
     contributor="datalab",
     task="text-matching, natural-language-inference",


### PR DESCRIPTION
This is based the previous PR: https://github.com/neulab/ExplainaBoard/pull/146#issue-1174672854
 
Previous decorator for the function `get_statistics` is task-specific, which will be unified into `aggregating` in this PR.
Note that: the latest `datalabs`  should be installed in pypi.
