### PR TITLE
Add tokenizers

### DIFF
--- a/explainaboard/processors/aspect_based_sentiment_classification.py
+++ b/explainaboard/processors/aspect_based_sentiment_classification.py
@@ -85,7 +85,7 @@ class AspectBasedSentimentClassificationProcessor(Processor):
 
     # --- Feature functions accessible by ExplainaboardBuilder._get_feature_func()
     def _get_sentence_length(self, existing_features: dict):
-        return len(existing_features["text"].split(" "))
+        return len(self._tokenizer(existing_features["text"]))
 
     def _get_token_number(self, existing_feature: dict):
         return len(existing_feature["text"])
@@ -97,7 +97,7 @@ class AspectBasedSentimentClassificationProcessor(Processor):
         return existing_feature["true_label"]
 
     def _get_aspect_length(self, existing_features: dict):
-        return len(existing_features["aspect"].split(" "))
+        return len(self._tokenizer(existing_features["aspect"]))
 
     def _get_aspect_index(self, existing_features: dict):
         return existing_features["text"].find(existing_features["aspect"])

--- a/explainaboard/processors/extractive_qa.py
+++ b/explainaboard/processors/extractive_qa.py
@@ -124,16 +124,16 @@ class QAExtractiveProcessor(Processor):
 
     # --- Feature functions accessible by ExplainaboardBuilder._get_feature_func()
     def _get_context_length(self, existing_features: dict):
-        return len(existing_features["context"].split(" "))
+        return len(self._tokenizer(existing_features["context"]))
 
     def _get_question_length(self, existing_features: dict):
-        return len(existing_features["question"].split(" "))
+        return len(self._tokenizer(existing_features["question"]))
 
     def _get_answer_length(self, existing_features: dict):
         if isinstance(existing_features["answers"]["text"], list):
-            return len(existing_features["answers"]["text"][0].split(" "))
+            return len(self._tokenizer(existing_features["answers"]["text"][0]))
         else:
-            return len(existing_features["answers"]["text"].split(" "))
+            return len(self._tokenizer(existing_features["answers"]["text"]))
 
     def _get_sim_context_question(self, existing_features: dict):
 
@@ -146,12 +146,12 @@ class QAExtractiveProcessor(Processor):
     # training set dependent features (could be merged for optimization?)
     def _get_num_oov(self, existing_features: dict, statistics: Any):
         return explainaboard.utils.feature_funcs.feat_num_oov(
-            existing_features, statistics, lambda x: x['context']
+            existing_features, statistics, lambda x: x['context'], self._tokenizer
         )
 
     def _get_fre_rank(self, existing_features: dict, statistics: Any):
         return explainaboard.utils.feature_funcs.feat_freq_rank(
-            existing_features, statistics, lambda x: x['context']
+            existing_features, statistics, lambda x: x['context'], self._tokenizer
         )
 
     # --- End feature functions

--- a/explainaboard/processors/extractive_qa.py
+++ b/explainaboard/processors/extractive_qa.py
@@ -12,6 +12,7 @@ from explainaboard.processors.processor import Processor
 from explainaboard.processors.processor_registry import register_processor
 from explainaboard.tasks import TaskType
 from explainaboard.utils.py_utils import eprint, sort_dict
+from explainaboard.utils.tokenizer import SingleSpaceTokenizer
 
 
 @register_processor(TaskType.question_answering_extractive)
@@ -271,6 +272,10 @@ def get_statistics(samples: Iterator):
      "options"
     }]
     """
+
+    # TODO(gneubig): BEWARE THIS IS HACKY. This should use the same tokenizer as the processor.
+    tokenizer = SingleSpaceTokenizer()
+
     return explainaboard.utils.feature_funcs.accumulate_vocab_from_samples(
-        samples, lambda x: x['context']
+        samples, lambda x: x['context'], tokenizer
     )

--- a/explainaboard/processors/hellaswag.py
+++ b/explainaboard/processors/hellaswag.py
@@ -86,20 +86,20 @@ class HellaswagProcessor(Processor):
 
     # define function for incomplete features
     def _get_ctx_length(self, existing_features: dict):
-        return len(existing_features["ctx"].split(" "))
+        return len(self._tokenizer(existing_features["ctx"]))
 
     # define function for incomplete features
     def _get_ctx_a_length_divided_b(self, existing_features: dict):
         return (
-            len(existing_features["ctx_a"].split(" "))
+            len(self._tokenizer(existing_features["ctx_a"]))
             * 1.0
-            / len(existing_features["ctx_b"].split(" "))
+            / len(self._tokenizer(existing_features["ctx_b"]))
         )
 
     def _get_true_answer_length(self, existing_features: dict):
         true_label = int(existing_features["true_label"])
         true_answer = existing_features["endings"][true_label]
-        return len(true_answer.split(" "))
+        return len(self._tokenizer(true_answer))
 
     def _get_activity_label(self, existing_feature: dict):
         return str(existing_feature["activity_label"])

--- a/explainaboard/processors/kg_link_tail_prediction.py
+++ b/explainaboard/processors/kg_link_tail_prediction.py
@@ -183,10 +183,10 @@ class KGLinkTailPredictionProcessor(Processor):
         return str(most_specific_level)
 
     def _get_tail_entity_length(self, existing_features: dict):
-        return len(existing_features["true_tail"].split(" "))
+        return len(self._tokenizer(existing_features["true_tail"]))
 
     def _get_head_entity_length(self, existing_features: dict):
-        return len(existing_features["true_head"].split(" "))
+        return len(self._tokenizer(existing_features["true_head"]))
 
     def _get_tail_fre(self, existing_features: dict):
         if (

--- a/explainaboard/processors/machine_translation.py
+++ b/explainaboard/processors/machine_translation.py
@@ -31,6 +31,6 @@ class MachineTranslationProcessor(ConditionalGenerationProcessor):
         )
 
     def _get_attr_compression(self, existing_features: dict):
-        return len(existing_features["source"].split(" ")) / len(
-            existing_features["reference"].split(" ")
+        return len(self._tokenizer(existing_features["source"])) / len(
+            self._tokenizer(existing_features["reference"])
         )

--- a/explainaboard/processors/processor.py
+++ b/explainaboard/processors/processor.py
@@ -17,6 +17,7 @@ from explainaboard.utils.py_utils import (
     print_dict,
     sort_dict,
 )
+from explainaboard.utils.tokenizer import SingleSpaceTokenizer
 
 
 class Processor:
@@ -32,6 +33,7 @@ class Processor:
         self._eaas_config = None
         self._eaas_client = None
         self._statistics_func = None
+        self._tokenizer = SingleSpaceTokenizer()
 
     def _init_statistics(self, sys_info: SysOutputInfo, statistics_func: Callable):
         """Take in information about the system outputs and a statistic calculating function and return a dictionary

--- a/explainaboard/processors/qa_multiple_choice.py
+++ b/explainaboard/processors/qa_multiple_choice.py
@@ -116,24 +116,24 @@ class QAMultipleChoiceProcessor(Processor):
 
     # --- Feature functions accessible by ExplainaboardBuilder._get_feature_func()
     def _get_context_length(self, existing_features: dict):
-        return len(existing_features["context"].split(" "))
+        return len(self._tokenizer(existing_features["context"]))
 
     def _get_question_length(self, existing_features: dict):
-        return len(existing_features["question"].split(" "))
+        return len(self._tokenizer(existing_features["question"]))
 
     def _get_answer_length(self, existing_features: dict):
-        return len(existing_features["answers"]["text"].split(" "))
+        return len(self._tokenizer(existing_features["answers"]["text"]))
 
     # training set dependent features
     def _get_num_oov(self, existing_features: dict, statistics: Any):
         return explainaboard.utils.feature_funcs.feat_num_oov(
-            existing_features, statistics, lambda x: x['context']
+            existing_features, statistics, lambda x: x['context'], self._tokenizer
         )
 
     # training set dependent features (this could be merged into the above one for further optimization)
     def _get_fre_rank(self, existing_features: dict, statistics: Any):
         return explainaboard.utils.feature_funcs.feat_freq_rank(
-            existing_features, statistics, lambda x: x['context']
+            existing_features, statistics, lambda x: x['context'], self._tokenizer
         )
 
     # --- End feature functions

--- a/explainaboard/processors/qa_multiple_choice.py
+++ b/explainaboard/processors/qa_multiple_choice.py
@@ -11,6 +11,7 @@ from explainaboard.processors.processor import Processor
 from explainaboard.processors.processor_registry import register_processor
 from explainaboard.tasks import TaskType
 from explainaboard.utils.py_utils import eprint
+from explainaboard.utils.tokenizer import SingleSpaceTokenizer
 
 
 @register_processor(TaskType.qa_multiple_choice)
@@ -173,6 +174,10 @@ def get_statistics(samples: Iterator):
      "options"
     }]
     """
+
+    # TODO(gneubig): BEWARE THIS IS HACKY. This should use the same tokenizer as the processor.
+    tokenizer = SingleSpaceTokenizer()
+
     return explainaboard.utils.feature_funcs.accumulate_vocab_from_samples(
-        samples, lambda x: x['context']
+        samples, lambda x: x['context'], tokenizer
     )

--- a/explainaboard/processors/text_pair_classification.py
+++ b/explainaboard/processors/text_pair_classification.py
@@ -131,13 +131,17 @@ class TextPairClassificationProcessor(Processor):
         )
 
     def _get_text1_length(self, existing_features: dict):
-        return len(existing_features["text1"].split(" "))
+        return len(self._tokenizer(existing_features["text1"]))
 
     def _get_text2_length(self, existing_feature: dict):
-        return len(existing_feature["text2"])
+        return len(self._tokenizer(existing_feature["text2"]))
 
     def _get_text1_divided_text2(self, existing_feature: dict):
-        return len(existing_feature["text1"]) * 1.0 / len(existing_feature["text2"])
+        return (
+            len(self._tokenizer(existing_feature["text1"]))
+            * 1.0
+            / len(self._tokenizer(existing_feature["text2"]))
+        )
 
     def _get_label(self, existing_feature: dict):
         # print(f"print_existing_feature: \t {existing_feature}")

--- a/explainaboard/utils/feature_funcs.py
+++ b/explainaboard/utils/feature_funcs.py
@@ -3,6 +3,7 @@ from lexicalrichness import LexicalRichness
 from tqdm import tqdm
 from typing import Iterator, Callable, Any
 
+from explainaboard.utils.tokenizer import Tokenizer
 
 BASIC_WORDS = (
     "a, about, above, across, act, actor, active, activity, add, afraid, after, again, age, ago, agree, air, all, alone, along, already, always, am, amount, an, and, angry, another, answer, any, anyone, anything, anytime, appear, apple, are, area, arm, army, around, arrive, art, as, ask, at, attack, aunt, autumn, away, baby, base, back, bad, bag, ball, bank, basket, bath, be, bean, bear, beautiful, beer, bed, bedroom, behave, before, begin, behind, bell, below, besides, best, better, between, big, bird, birth, birthday, bit, bite, black, bleed, block, blood, blow, blue, board, boat, body, boil, bone, book, border, born, borrow, both, bottle, bottom, bowl, box, boy, branch, brave, bread, break, breakfast, breathe, bridge, bright, bring, brother, brown, brush, build, burn, business, bus, busy, but, buy, by, cake, call, can, candle, cap, car, card, care, careful, careless, carry, case, cat, catch, central, century, certain, chair, chance, change, chase, cheap, cheese, chicken, child, children, chocolate, choice, choose, circle, city, class, clever, clean, clear, climb, clock, cloth, clothes, cloud, cloudy, close, coffee, coat, coin, cold, collect, colour, comb, come, comfortable, common, compare, complete, computer, condition, continue, control, cook, cool, copper, corn, corner, correct, cost, contain, count, country, course, cover, crash, cross, cry, cup, cupboard, cut, dance, danger, dangerous, dark, daughter, day, dead, decide, decrease, deep, deer, depend, desk, destroy, develop, die, different, difficult, dinner, direction, dirty, discover, dish, do, dog, door, double, down, draw, dream, dress, drink, drive, drop, dry, duck, dust, duty, each, ear, early, earn, earth, east, easy, eat, education, effect, egg, eight, either, electric, elephant, else, empty, end, enemy, enjoy, enough, enter, equal, entrance, escape, even, evening, event, ever, every, everyone, exact, everybody, examination, example, except, excited, exercise, expect, expensive, explain, extremely, eye, face, fact, fail, fall, false, family, famous, far, farm, father, fast, fat, fault, fear, feed, feel, female, fever, few, fight, fill, film, find, fine, finger, finish, fire, first, fit, five, fix, flag, flat, float, floor, flour, flower, fly, fold, food, fool, foot, football, for, force, foreign, forest, forget, forgive, fork, form, fox, four, free, freedom, freeze, fresh, friend, friendly, from, front, fruit, full, fun, funny, furniture, further, future, game, garden, gate, general, gentleman, get, gift, give, glad, glass, go, goat, god, gold, good, goodbye, grandfather, grandmother, grass, grave, great, green, grey, ground, group, grow, gun, hair, half, hall, hammer, hand, happen, happy, hard, hat, hate, have, he, head, healthy, hear, heavy, hello, help, heart, heaven, height, hen, her, here, hers, hide, high, hill, him, his, hit, hobby, hold, hole, holiday, home, hope, horse, hospital, hot, hotel, house, how, hundred, hungry, hour, hurry, husband, hurt, I, ice, idea, if, important, in, increase, inside, into, introduce, invent, iron, invite, is, island, it, its, jelly, job, join, juice, jump, just, keep, key, kid, kill, kind, king, kitchen, knee, knife, knock, know, ladder, lady, lamp, land, large, last, late, lately, laugh, lazy, lead, leaf, learn, leave, leg, left, lend, length, less, lesson, let, letter, library, lie, life, light, like, lion, lip, list, listen, little, live, lock, lonely, long, look, lose, lot, love, low, lower, luck, machine, main, make, male, man, many, map, mark, market, marry, matter, may, me, meal, mean, measure, meat, medicine, meet, member, mention, method, middle, milk, mill, million, mind, mine, minute, miss, mistake, mix, model, modern, moment, money, monkey, month, moon, more, morning, most, mother, mountain, mouse, mouth, move, much, music, must, my, name, narrow, nation, nature, near, nearly, neck, need, needle, neighbour, neither, net, never, new, news, newspaper, next, nice, night, nine, no, noble, noise, none, nor, north, nose, not, nothing, notice, now, number, obey, object, ocean, of, off, offer, office, often, oil, old, on, one, only, open, opposite, or, orange, order, other, our, out, outside, over, own, page, pain, paint, pair, pan, paper, parent, park, part, partner, party, pass, past, path, pay, peace, pen, pencil, people, pepper, per, perfect, period, person, petrol, photograph, piano, pick, picture, piece, pig, pill, pin, pink, place, plane, plant, plastic, plate, play, please, pleased, plenty, pocket, point, poison, police, polite, pool, poor, popular, position, possible, potato, pour, power, present, press, pretty, prevent, price, prince, prison, private, prize, probably, problem, produce, promise, proper, protect, provide, public, pull, punish, pupil, push, put, queen, question, quick, quiet, quite, radio, rain, rainy, raise, reach, read, ready, real, really, receive, record, red, remember, remind, remove, rent, repair, repeat, reply, report, rest, restaurant, result, return, rice, rich, ride, right, ring, rise, road, rob, rock, room, round, rubber, rude, rule, ruler, run, rush, sad, safe, sail, salt, same, sand, save, say, school, science, scissors, search, seat, second, see, seem, sell, send, sentence, serve, seven, several, sex, shade, shadow, shake, shape, share, sharp, she, sheep, sheet, shelf, shine, ship, shirt, shoe, shoot, shop, short, should, shoulder, shout, show, sick, side, signal, silence, silly, silver, similar, simple, single, since, sing, sink, sister, sit, six, size, skill, skin, skirt, sky, sleep, slip, slow, small, smell, smile, smoke, snow, so, soap, sock, soft, some, someone, something, sometimes, son, soon, sorry, sound, soup, south, space, speak, special, speed, spell, spend, spoon, sport, spread, spring, square, stamp, stand, star, start, station, stay, steal, steam, step, still, stomach, stone, stop, store, storm, story, strange, street, strong, structure, student, study, stupid, subject, substance, successful, such, sudden, sugar, suitable, summer, sun, sunny, support, sure, surprise, sweet, swim, sword, table, take, talk, tall, taste, taxi, tea, teach, team, tear, telephone, television, tell, ten, tennis, terrible, test, than, that, the, their, theirs, then, there, therefore, these, thick, thin, thing, think, third, this, those, though, threat, three, tidy, tie, title, to, today, toe, together, tomorrow, tonight, too, tool, tooth, top, total, touch, town, train, tram, travel, tree, trouble, true, trust, twice, try, turn, type, uncle, under, understand, unit, until, up, use, useful, usual, usually, vegetable, very, village, voice, visit, wait, wake, walk, want, warm, wash, waste, watch, water, way, we, weak, wear, weather, wedding, week, weight, welcome, well, west, wet, what, wheel, when, where, which, while, white, who, why, wide, wife, wild, will, win, wind, window, wine, winter, wire, wise, wish, with, without, woman, wonder, word, work, world, worry, worst, write, wrong, year, yellow, yes, yesterday, yet, you, young, your, yours, zero, "
@@ -53,10 +54,12 @@ def get_lexical_richness(sentence: str):
         return results
 
 
-def accumulate_vocab_from_samples(samples: Iterator, text_from_sample: Callable):
+def accumulate_vocab_from_samples(
+    samples: Iterator, text_from_sample: Callable, tokenizer: Tokenizer
+):
     vocab = {}
     for sample in tqdm(samples):
-        for w in text_from_sample(sample).split(" "):
+        for w in tokenizer(text_from_sample(sample)):
             vocab[w] = vocab.get(w, 0) + 1
     # the rank of each word based on its frequency
     sorted_dict = {
@@ -71,11 +74,14 @@ def accumulate_vocab_from_samples(samples: Iterator, text_from_sample: Callable)
 
 
 def feat_freq_rank(
-    existing_features: dict, statistics: Any, text_from_sample: Callable
+    existing_features: dict,
+    statistics: Any,
+    text_from_sample: Callable,
+    tokenizer: Tokenizer,
 ):
     fre_rank = 0
 
-    tokens = text_from_sample(existing_features).split(" ")
+    tokens = tokenizer(text_from_sample(existing_features))
     for w in tokens:
         if w not in statistics['vocab_rank']:
             fre_rank += len(statistics['vocab_rank'])
@@ -86,9 +92,14 @@ def feat_freq_rank(
     return fre_rank
 
 
-def feat_num_oov(existing_features: dict, statistics: Any, text_from_sample: Callable):
+def feat_num_oov(
+    existing_features: dict,
+    statistics: Any,
+    text_from_sample: Callable,
+    tokenizer: Tokenizer,
+):
     num_oov = 0
-    for w in text_from_sample(existing_features).split(" "):
+    for w in tokenizer(text_from_sample(existing_features)):
         if w not in statistics['vocab'].keys():
             num_oov += 1
     return num_oov

--- a/explainaboard/utils/tokenizer.py
+++ b/explainaboard/utils/tokenizer.py
@@ -1,0 +1,33 @@
+from typing import List
+from functools import lru_cache
+
+
+class Tokenizer:
+    def __call__(self, text: str) -> List[str]:
+        """
+        Tokenize a string into a list of tokens
+        :param text: The string to tokenize
+        :returns: The list of tokens
+        """
+        raise NotImplementedError
+
+    def detokenize(self, tokens: List[str]) -> str:
+        """
+        Detokenize a list of tokens into a string
+        :param tokens: A list of tokens
+        :returns: The detokenized string
+        """
+        raise NotImplementedError
+
+
+class SingleSpaceTokenizer(Tokenizer):
+    """
+    Split a string on a single ascii space
+    """
+
+    @lru_cache(maxsize=20)
+    def __call__(self, text: str) -> List[str]:
+        return text.split(' ')
+
+    def detokenize(self, tokens: List[str]) -> str:
+        return ' '.join(tokens)


### PR DESCRIPTION
This adds a tokenizer class in `tokenizer.py` that can easily be generalized to other tokenizers later.

Consultation for @pfliu-nlp: there are currently hacky parts in the `get_statistics()` functions where I'm forced to hard-code a tokenizer in there because I'm not sure of the best way for the `Processor` class to pass an argument to `get_statistics()` (which is not a member function): https://github.com/neulab/ExplainaBoard/blob/add_tokenizer_class/explainaboard/processors/conditional_generation.py#L293

Do you know if it would be possible to move the `get_statistics` function to be a member function of `Processor`? That would make it possible for it to use member variables of Processor.

(I think this PR can be merged before we do that though, as that would be a bigger change)