### PR TITLE
Separate out conditional generation scoring

### DIFF
--- a/explainaboard/processors/conditional_generation.py
+++ b/explainaboard/processors/conditional_generation.py
@@ -107,7 +107,7 @@ class ConditionalGenerationProcessor(Processor):
         )
 
     def _complete_features(
-        self, sys_info: SysOutputInfo, sys_output: List[dict], statistics=None
+        self, sys_info: SysOutputInfo, sys_output: List[dict], external_stats=None
     ) -> List[str]:
         """
         This function is used to calculate features used for bucketing, such as sentence_length
@@ -139,7 +139,7 @@ class ConditionalGenerationProcessor(Processor):
         bucket_feature_funcs = {}
         for bucket_feature in sys_info.features.get_bucket_features():
             if bucket_feature in sys_info.features.keys() and (
-                statistics is not None
+                external_stats is not None
                 or not sys_info.features[bucket_feature].require_training_set
             ):
                 bucket_feature_funcs[bucket_feature] = (
@@ -160,7 +160,7 @@ class ConditionalGenerationProcessor(Processor):
             ) in bucket_feature_funcs.items():
                 # TODO(pengfei): should check the feature value type
                 if training_dependent:
-                    dict_sysout[bucket_key] = bucket_func(dict_sysout, statistics)
+                    dict_sysout[bucket_key] = bucket_func(dict_sysout, external_stats)
                 else:
                     dict_sysout[bucket_key] = bucket_func(dict_sysout)
                     # print(dict_sysout[bucket_key])

--- a/explainaboard/processors/extractive_qa.py
+++ b/explainaboard/processors/extractive_qa.py
@@ -162,6 +162,7 @@ class QAExtractiveProcessor(Processor):
         self,
         sys_info: SysOutputInfo,
         sys_output: List[dict],
+        scoring_stats: Any = None,
     ) -> Dict[str, Performance]:
         predicted_answers, true_answers = [], []
 
@@ -190,6 +191,7 @@ class QAExtractiveProcessor(Processor):
         sys_info: SysOutputInfo,
         sys_output: List[dict],
         samples_over_bucket: Dict[str, List[int]],
+        scoring_stats: Any = None,
     ) -> Dict[str, List[BucketPerformance]]:
         """
         This function defines how to get bucket-level performance w.r.t a given feature (e.g., sentence length)

--- a/explainaboard/processors/extractive_qa.py
+++ b/explainaboard/processors/extractive_qa.py
@@ -93,7 +93,7 @@ class QAExtractiveProcessor(Processor):
         self._statistics_func = get_statistics
 
     # TODO(gneubig) to be deduplicated
-    def _init_statistics(self, sys_info: SysOutputInfo, statistics_func: Callable):
+    def _gen_external_stats(self, sys_info: SysOutputInfo, statistics_func: Callable):
         """Take in information about the system outputs and a statistic calculating function and return a dictionary
         of statistics.
 

--- a/explainaboard/processors/hellaswag.py
+++ b/explainaboard/processors/hellaswag.py
@@ -1,4 +1,4 @@
-from typing import List, Dict
+from typing import List, Dict, Any
 
 import explainaboard.metric
 from explainaboard import feature
@@ -115,6 +115,7 @@ class HellaswagProcessor(Processor):
         sys_info: SysOutputInfo,
         sys_output: List[dict],
         samples_over_bucket: Dict[str, List[int]],
+        scoring_stats: Any = None,
     ) -> Dict[str, List[BucketPerformance]]:
         """
         This function defines how to get bucket-level performance w.r.t a given feature (e.g., sentence length)

--- a/explainaboard/processors/kg_link_tail_prediction.py
+++ b/explainaboard/processors/kg_link_tail_prediction.py
@@ -156,7 +156,7 @@ class KGLinkTailPredictionProcessor(Processor):
 
         return super().process(metadata, sys_output)
 
-    def _init_statistics(self, sys_info: SysOutputInfo, statistics_func: Callable):
+    def _gen_external_stats(self, sys_info: SysOutputInfo, statistics_func: Callable):
 
         # TODO(gneubig): this will be reloaded for every dataset, maybe should be fixed for multiple analysis
         if sys_info.dataset_name != "fb15k_237":  # to be generalized

--- a/explainaboard/processors/kg_link_tail_prediction.py
+++ b/explainaboard/processors/kg_link_tail_prediction.py
@@ -1,7 +1,6 @@
 import json
 import os
-from typing import Callable
-from typing import Dict, List
+from typing import Callable, Dict, List, Any
 
 from datalabs import load_dataset
 from datalabs import aggregating
@@ -260,6 +259,7 @@ class KGLinkTailPredictionProcessor(Processor):
         self,
         sys_info: SysOutputInfo,
         sys_output: List[dict],
+        scoring_stats: Any = None,
     ) -> Dict[str, Performance]:
         predicted_labels, true_labels = [], []
 
@@ -293,6 +293,7 @@ class KGLinkTailPredictionProcessor(Processor):
         sys_info: SysOutputInfo,
         sys_output: List[dict],
         samples_over_bucket: Dict[str, List[int]],
+        scoring_stats: Any = None,
     ) -> Dict[str, List[BucketPerformance]]:
         """
         This function defines how to get bucket-level performance w.r.t a given feature (e.g., sentence length)

--- a/explainaboard/processors/named_entity_recognition.py
+++ b/explainaboard/processors/named_entity_recognition.py
@@ -268,7 +268,7 @@ class NERProcessor(Processor):
         return span_dics
 
     def _complete_features(
-        self, sys_info: SysOutputInfo, sys_output: List[dict], statistics=None
+        self, sys_info: SysOutputInfo, sys_output: List[dict], external_stats=None
     ) -> List[str]:
         """
         This function takes in meta-data about system outputs, system outputs, and a few other optional pieces of
@@ -276,7 +276,7 @@ class NERProcessor(Processor):
 
         :param sys_info: Information about the system output
         :param sys_output: The system output itself
-        :param statistics: Training set statistics that are used to calculate training set specific features
+        :param external_stats: Training set statistics that are used to calculate training set specific features
         :return: The features that are active (e.g. skipping training set features when no training set available)
         """
         for _id, dict_sysout in tqdm(enumerate(sys_output), desc="featurizing"):
@@ -287,16 +287,16 @@ class NERProcessor(Processor):
             dict_sysout["sentence_length"] = len(tokens)
 
             # sentence-level training set dependent features
-            if statistics is not None:
-                dict_sysout["num_oov"] = self._get_num_oov(tokens, statistics)
-                dict_sysout["fre_rank"] = self._get_fre_rank(tokens, statistics)
+            if external_stats is not None:
+                dict_sysout["num_oov"] = self._get_num_oov(tokens, external_stats)
+                dict_sysout["fre_rank"] = self._get_fre_rank(tokens, external_stats)
 
             # span features for true and predicted spans
             dict_sysout["true_entity_info"] = self._complete_span_features(
-                tokens, dict_sysout["true_tags"], statistics=statistics
+                tokens, dict_sysout["true_tags"], statistics=external_stats
             )
             dict_sysout["pred_entity_info"] = self._complete_span_features(
-                tokens, dict_sysout["pred_tags"], statistics=statistics
+                tokens, dict_sysout["pred_tags"], statistics=external_stats
             )
         # This should return a list, but this list isn't used in the overridden function so ignore for now
         return None  # noqa

--- a/explainaboard/processors/named_entity_recognition.py
+++ b/explainaboard/processors/named_entity_recognition.py
@@ -305,6 +305,7 @@ class NERProcessor(Processor):
         self,
         sys_info: SysOutputInfo,
         sys_output: List[dict],
+        scoring_stats: Any = None,
     ) -> Dict[str, Performance]:
         """
         Get the overall performance according to metrics
@@ -365,6 +366,7 @@ class NERProcessor(Processor):
         sys_info: SysOutputInfo,
         sys_output: List[dict],
         active_features: List[str],
+        scoring_stats: Any = None,
     ) -> Tuple[dict, dict]:
 
         features = sys_info.features

--- a/explainaboard/processors/processor.py
+++ b/explainaboard/processors/processor.py
@@ -1,7 +1,7 @@
 import json
-from typing import List, Tuple, Dict, Any
+from typing import List, Tuple, Dict, Any, Mapping, Optional
 
-from datalabs import load_dataset, aggregating
+from datalabs import load_dataset, aggregating, Dataset
 
 from explainaboard.utils.async_eaas import AsyncEaaSClient
 from eaas.config import Config
@@ -36,6 +36,14 @@ class Processor:
         self._statistics_func = None
         self._tokenizer = SingleSpaceTokenizer()
         self._user_defined_feature_config = None
+
+    def _get_statistics_resources(
+        self, dataset_split: Dataset
+    ) -> Optional[Mapping[str, Any]]:
+        """
+        From a DataLab dataset split, get resources necessary to calculate statistics
+        """
+        return None
 
     def _gen_external_stats(
         self, sys_info: SysOutputInfo, statistics_func: aggregating
@@ -72,7 +80,7 @@ class Processor:
                     == "the dataset does not include the information of _stat"
                 ):
                     dataset = load_dataset(sys_info.dataset_name, sub_dataset)
-                    statistics_func.resources = self._get_urces(dataset)
+                    statistics_func.resources = self._get_statistics_resources(dataset)
                     new_train = dataset[split_name].apply(statistics_func, mode="local")
                     statistics = new_train._stat
                     eprint("saving to database")

--- a/explainaboard/processors/processor.py
+++ b/explainaboard/processors/processor.py
@@ -1,7 +1,7 @@
 import json
-from typing import List, Tuple, Dict, Optional, Mapping, Any
+from typing import List, Tuple, Dict, Any
 
-from datalabs import load_dataset, aggregating, Dataset
+from datalabs import load_dataset, aggregating
 
 from explainaboard.utils.async_eaas import AsyncEaaSClient
 from eaas.config import Config
@@ -36,12 +36,6 @@ class Processor:
         self._statistics_func = None
         self._tokenizer = SingleSpaceTokenizer()
         self._user_defined_feature_config = None
-
-    def _get_urces(self, dataset_split: Dataset) -> Optional[Mapping[str, Any]]:
-        """
-        From a DataLab dataset split, get resources necessary to calculate statistics
-        """
-        return None
 
     def _gen_external_stats(
         self, sys_info: SysOutputInfo, statistics_func: aggregating

--- a/explainaboard/processors/qa_multiple_choice.py
+++ b/explainaboard/processors/qa_multiple_choice.py
@@ -87,7 +87,7 @@ class QAMultipleChoiceProcessor(Processor):
         self._statistics_func = get_statistics
 
     # TODO(gneubig): this should be deduplicated
-    def _init_statistics(self, sys_info: SysOutputInfo, statistics_func: Callable):
+    def _gen_external_stats(self, sys_info: SysOutputInfo, statistics_func: Callable):
         """Take in information about the system outputs and a statistic calculating function and return a dictionary
         of statistics.
 

--- a/explainaboard/processors/text_pair_classification.py
+++ b/explainaboard/processors/text_pair_classification.py
@@ -10,6 +10,7 @@ from explainaboard.processors.processor import Processor
 from explainaboard.processors.processor_registry import register_processor
 from explainaboard.tasks import TaskType
 from explainaboard.utils.py_utils import eprint
+from explainaboard.utils.tokenizer import SingleSpaceTokenizer
 
 
 @register_processor(TaskType.text_pair_classification)
@@ -150,13 +151,19 @@ class TextPairClassificationProcessor(Processor):
     # training set dependent features
     def _get_num_oov(self, existing_features: dict, statistics: Any):
         return explainaboard.utils.feature_funcs.feat_num_oov(
-            existing_features, statistics, lambda x: x['text1'] + x['text2']
+            existing_features,
+            statistics,
+            lambda x: x['text1'] + x['text2'],
+            self._tokenizer,
         )
 
     # training set dependent features (this could be merged into the above one for further optimization)
     def _get_fre_rank(self, existing_features: dict, statistics: Any):
         return explainaboard.utils.feature_funcs.feat_freq_rank(
-            existing_features, statistics, lambda x: x['text1'] + x['text2']
+            existing_features,
+            statistics,
+            lambda x: x['text1'] + x['text2'],
+            self._tokenizer,
         )
 
     # --- End feature functions
@@ -178,6 +185,10 @@ def get_statistics(samples: Iterator):
      "label":
     }]
     """
+
+    # TODO(gneubig): BEWARE THIS IS HACKY. This should use the same tokenizer as the processor.
+    tokenizer = SingleSpaceTokenizer()
+
     return explainaboard.utils.feature_funcs.accumulate_vocab_from_samples(
-        samples, lambda x: x['text1'] + x['text2']
+        samples, lambda x: x['text1'] + x['text2'], tokenizer
     )

--- a/explainaboard/processors/text_pair_classification.py
+++ b/explainaboard/processors/text_pair_classification.py
@@ -97,7 +97,7 @@ class TextPairClassificationProcessor(Processor):
         super().__init__()
         self._statistics_func = get_statistics
 
-    def _init_statistics(self, sys_info: SysOutputInfo, statistics_func: Callable):
+    def _gen_external_stats(self, sys_info: SysOutputInfo, statistics_func: Callable):
         """Take in information about the system outputs and a statistic calculating function and return a dictionary
         of statistics.
 


### PR DESCRIPTION
As I started working on the conditional generation code to expand its functionality I realized it was saving `self.score_dict`, which made the processor stateful (and complicates the saving of statistics to the DB, as @OscarWang114 is working on). This PR splits off the calculation of scoring functions into a separate function.