### PR TITLE
[WIP] Split content in process(), expose _bucketing_samples()

### DIFF
--- a/explainaboard/processors/processor.py
+++ b/explainaboard/processors/processor.py
@@ -384,7 +384,9 @@ class Processor:
         active_features = self._complete_features(
             sys_info, sys_output, external_stats=external_stats
         )
-        overall_results = self.get_overall_performance(sys_info, sys_output)
+        overall_results = self.get_overall_performance(
+            sys_info, sys_output, scoring_stats=scoring_stats
+        )
         return {
             "sys_info": sys_info,
             "scoring_stats": scoring_stats,

--- a/explainaboard/processors/processor.py
+++ b/explainaboard/processors/processor.py
@@ -347,7 +347,7 @@ class Processor:
 
     def get_overall_statistics(self, metadata: dict, sys_output: List[dict]) -> dict:
         """
-        Get the overall statistics information of the system output
+        Get the overall statistics information, including performance, of the system output
         :param metadata: The metadata of the system
         :param sys_output: The system output itself
         """
@@ -371,7 +371,6 @@ class Processor:
             "overall_results": overall_results,
         }
 
-    # TODO(chihhao) this function is just a wrapper, expose _bucketing_samples properly
     def get_fine_grained_statistics(
         self,
         sys_info: SysOutputInfo,
@@ -381,14 +380,20 @@ class Processor:
         samples_over_bucket, performance_over_bucket = self._bucketing_samples(
             sys_info, sys_output, active_features
         )
-        return samples_over_bucket, performance_over_bucket
+        """
+        A wrapper function to expose _bucketing_samples for the web interface
+        """
+        return {
+            "samples_over_bucket": samples_over_bucket,
+            "performance_over_bucket": performance_over_bucket,
+        }
 
     def process(self, metadata: dict, sys_output: List[dict]):
         overall_statistics = self.get_overall_statistics(metadata, sys_output)
         sys_info = overall_statistics["sys_info"]
         active_features = overall_statistics["active_features"]
         overall_results = overall_statistics["overall_results"]
-        samples_over_bucket, performance_over_bucket = self.get_fine_grained_statistics(
+        samples_over_bucket, performance_over_bucket = self._bucketing_samples(
             sys_info, sys_output, active_features
         )
         self._print_bucket_info(performance_over_bucket)

--- a/explainaboard/processors/processor.py
+++ b/explainaboard/processors/processor.py
@@ -419,9 +419,6 @@ class Processor:
         samples_over_bucket, performance_over_bucket = self._bucketing_samples(
             sys_info, sys_output, active_features, scoring_stats=scoring_stats
         )
-        overall_results = self.get_overall_performance(
-            sys_info, sys_output, scoring_stats=scoring_stats
-        )
         self._print_bucket_info(performance_over_bucket)
         sys_info.results = Result(
             overall=overall_results, fine_grained=performance_over_bucket

--- a/explainaboard/processors/processor.py
+++ b/explainaboard/processors/processor.py
@@ -343,7 +343,7 @@ class Processor:
         for feature_name, feature_value in performances_over_bucket.items():
             print_dict(feature_value, feature_name)
 
-    def process(self, metadata: dict, sys_output: List[dict]) -> SysOutputInfo:
+    def process(self, metadata: dict, sys_output: List[dict]):
         if metadata is None:
             metadata = {}
         if "task_name" not in metadata.keys():
@@ -356,6 +356,13 @@ class Processor:
         active_features = self._complete_features(
             sys_info, sys_output, statistics=statistics
         )
+        print("SYS_INFO", sys_info)
+        print("STATS", statistics)
+        print("FEATS", active_features)
+        return sys_info, statistics, active_features
+
+
+    def get_result(self, sys_info: SysOutputInfo, sys_output: List[dict], active_features: List[str]) -> Result:
         samples_over_bucket, performance_over_bucket = self._bucketing_samples(
             sys_info, sys_output, active_features
         )


### PR DESCRIPTION
Update: Ready for review!

As the leaderboard in the web frontend needs an overall score for each system, I will also be saving the results from `get_overall_performance` in addition to sufficient statistics. 

Two functions are created:
1. `get_overall_statistics` for getting sufficient statistics and overall performance. It is also called by `process()` for reusability. For the web interface, the returned results are saved to the DB.
2. `get_fine_grained_statistics` exposes `_bucketing_samples` for the web interface to call on the fly, since we're not supposed to call underscore functions from outside.

Let me know if you have any concerns!