### PR TITLE
Fix CI scripts.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,8 @@
 name: Continuous Integration
 on:
   push:
-    branches: ["*"]
+    branches:
+      - main
   pull_request:
     branches: ["*"]
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,4 +46,4 @@ jobs:
       - name: lint
         uses: pre-commit/action@v2.0.3
         with:
-          extra_args: frake8 --all-files
+          extra_args: flake8 --all-files

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,9 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install Python 3
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v3
         with:
           python-version: 3.9
       - name: Install dependencies
@@ -25,9 +25,9 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install Python 3
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v3
         with:
           python-version: 3.9
       - name: format
@@ -38,12 +38,12 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Install Python 3
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v3
         with:
           python-version: 3.9
       - name: lint
-        run: |
-          pip install flake8
-          flake8
+        uses: pre-commit/action@v2.0.3
+        with:
+          extra_args: frake8 --all-files

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,9 @@ setup(
         "Topic :: Text Processing",
         "Topic :: Scientific/Engineering :: Artificial Intelligence",
         "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3 :: Only",
     ],
     packages=find_packages(),
     # packages=find_packages("explainaboard"),
@@ -52,13 +54,8 @@ setup(
     ],
     extras_require={
         "dev": [
-            "black",
-            "flake8",
-            "flake8-absolute-import",
-            "flake8-black>=0.1.1",
-            "flake8-import-order",
             "pre-commit",
-        ]
+        ],
     },
     include_package_data=True,
 )


### PR DESCRIPTION
This change adjusts the CI script for the current repository.
- Apply the newest version of each action.
- Utilize pre-commit action for invoking flake8 instead of manually installing.

Also fixes the setup.py:
- Add appropriate Python version tags -- 3.9 or later, since `sort_dict` uses the feature introduced by 3.9, and CI also uses 3.9.
- Remove black and flake8 dependencies. They are installed by pre-commit or manually in CI.