### PR TITLE
Use pre-commit Black in CI.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,10 +32,9 @@ jobs:
         with:
           python-version: 3.9
       - name: format
-        uses: psf/black@stable
+        uses: pre-commit/action@v2.0.3
         with:
-          options: "--check --verbose"
-          version: "22.1.0"
+          extra_args: black --all-files
   isort:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
This change swaps the Black CI binary to that of pre-commit to use the same config.