### PR TITLE
Unify typing of metric_stats, fix mypy errors

### DIFF
--- a/explainaboard/info.py
+++ b/explainaboard/info.py
@@ -9,6 +9,7 @@ from typing import Any, Optional
 
 from explainaboard import config
 from explainaboard.feature import Features
+from explainaboard.metric import MetricStats
 from explainaboard.utils.logging import get_logger
 from explainaboard.utils.py_utils import eprint
 
@@ -186,9 +187,9 @@ class SysOutputInfo:
 @dataclass
 class OverallStatistics:
     sys_info: SysOutputInfo
-    metric_stats: Any = None
-    active_features: Optional[list[str]] = None
-    overall_results: Optional[dict[str, Performance]] = None
+    metric_stats: list[MetricStats]
+    active_features: list[str]
+    overall_results: dict[str, Performance]
 
 
 @dataclass

--- a/explainaboard/loaders/file_loader.py
+++ b/explainaboard/loaders/file_loader.py
@@ -31,7 +31,7 @@ class FileLoaderField:
 
     src_name: Union[int, str]
     target_name: str
-    dtype: Union[type[int], type[float], type[str], type[dict]] = None
+    dtype: Optional[Union[type[int], type[float], type[str], type[dict]]] = None
     strip_before_parsing: Optional[bool] = None
     parser: Optional[Callable] = None
 

--- a/explainaboard/loaders/loader.py
+++ b/explainaboard/loaders/loader.py
@@ -44,10 +44,11 @@ class Loader:
             self._source: Source = source or self._default_source
         if not file_type and not self._default_file_type:
             raise Exception("no file_type is provided for the loader")
-        elif not self._default_file_type:
-            self._file_type = unwrap(file_type)
         elif not file_type:
-            self._file_type = self._default_file_type
+            self._file_type = unwrap(self._default_file_type)
+        else:
+            self._file_type = unwrap(file_type)
+
         self.file_loaders: dict[FileType, FileLoader] = (
             file_loaders or self._default_file_loaders
         )

--- a/explainaboard/loaders/loader.py
+++ b/explainaboard/loaders/loader.py
@@ -7,6 +7,7 @@ from typing import List, Mapping, Optional, Union
 from explainaboard.constants import FileType, Source
 from explainaboard.loaders.file_loader import FileLoader
 from explainaboard.tasks import TaskType
+from explainaboard.utils.typing_utils import unwrap
 
 JSON = Union[  # type: ignore
     str, int, float, bool, None, Mapping[str, 'JSON'], List['JSON']  # type: ignore
@@ -33,17 +34,23 @@ class Loader:
         data: str,
         source: Optional[Source] = None,
         file_type: Optional[FileType] = None,
-        file_loaders: dict[FileType, FileLoader] = None,
+        file_loaders: Optional[dict[FileType, FileLoader]] = None,
     ):
         if file_loaders is None:
             file_loaders = {}
         if not source and not self._default_source:
             raise Exception("no source is provided for the loader")
+        else:
+            self._source: Source = source or self._default_source
         if not file_type and not self._default_file_type:
             raise Exception("no file_type is provided for the loader")
-        self._source = source or self._default_source
-        self._file_type = file_type or self._default_file_type
-        self.file_loaders = file_loaders or self._default_file_loaders
+        elif not self._default_file_type:
+            self._file_type = unwrap(file_type)
+        elif not file_type:
+            self._file_type = self._default_file_type
+        self.file_loaders: dict[FileType, FileLoader] = (
+            file_loaders or self._default_file_loaders
+        )
         self._data = data  # base64 or filepath
 
         if self._file_type not in self.file_loaders:

--- a/explainaboard/processors/conditional_generation.py
+++ b/explainaboard/processors/conditional_generation.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 from collections.abc import Callable
-from typing import Any, Optional
+from typing import Any
 
 import numpy as np
 from tqdm import tqdm
@@ -10,6 +10,7 @@ from tqdm import tqdm
 from explainaboard import feature
 from explainaboard.info import BucketPerformance, Performance, SysOutputInfo
 import explainaboard.metric
+from explainaboard.metric import MetricStats
 from explainaboard.processors.processor import Processor
 from explainaboard.processors.processor_registry import register_processor
 from explainaboard.tasks import TaskType
@@ -205,7 +206,9 @@ class ConditionalGenerationProcessor(Processor):
     def _get_predicted_label(self, data_point: dict):
         return data_point["hypothesis"]
 
-    def _gen_metric_stats(self, sys_info: SysOutputInfo, sys_output: list[dict]) -> Any:
+    def _gen_metric_stats(
+        self, sys_info: SysOutputInfo, sys_output: list[dict]
+    ) -> list[MetricStats]:
         """Generate sufficient statistics for scoring.
 
         :param sys_info: Information about the system outputs
@@ -259,7 +262,7 @@ class ConditionalGenerationProcessor(Processor):
 
     def _complete_features(
         self, sys_info: SysOutputInfo, sys_output: list[dict], external_stats=None
-    ) -> Optional[list[str]]:
+    ) -> list[str]:
         """
         This function is used to calculate features used for bucketing, such as
         sentence_length
@@ -368,7 +371,7 @@ class ConditionalGenerationProcessor(Processor):
         sys_info: SysOutputInfo,
         sys_output: list[dict],
         active_features: list[str],
-        metric_stats: Any = None,
+        metric_stats: list[MetricStats],
     ) -> tuple[dict, dict]:
 
         features = unwrap(sys_info.features)

--- a/explainaboard/processors/named_entity_recognition.py
+++ b/explainaboard/processors/named_entity_recognition.py
@@ -11,7 +11,7 @@ from tqdm import tqdm
 from explainaboard import feature
 from explainaboard.info import BucketPerformance, Performance, SysOutputInfo
 import explainaboard.metric
-from explainaboard.metric import Metric
+from explainaboard.metric import Metric, MetricStats
 from explainaboard.processors.processor import Processor
 from explainaboard.processors.processor_registry import register_processor
 from explainaboard.tasks import TaskType
@@ -361,7 +361,7 @@ class NERProcessor(Processor):
 
     def _complete_features(
         self, sys_info: SysOutputInfo, sys_output: list[dict], external_stats=None
-    ) -> Optional[list[str]]:
+    ) -> list[str]:
         """
         This function takes in meta-data about system outputs, system outputs, and a few
         other optional pieces of information, then calculates feature functions and
@@ -433,7 +433,7 @@ class NERProcessor(Processor):
         sys_info: SysOutputInfo,
         sys_output: list[dict],
         active_features: list[str],
-        metric_stats: Any = None,
+        metric_stats: list[MetricStats],
     ) -> tuple[dict, dict]:
 
         features = unwrap(sys_info.features)

--- a/explainaboard/processors/processor.py
+++ b/explainaboard/processors/processor.py
@@ -144,7 +144,7 @@ https://github.com/ExpressAI/DataLab/blob/main/docs/SDK/add_new_datasets_into_sd
 
     def _gen_metric_stats(
         self, sys_info: SysOutputInfo, sys_output: list[dict]
-    ) -> Optional[list[MetricStats]]:
+    ) -> list[MetricStats]:
         """Generate sufficient statistics for scoring different metrics.
 
         :param sys_info: Information about the system outputs
@@ -233,7 +233,7 @@ https://github.com/ExpressAI/DataLab/blob/main/docs/SDK/add_new_datasets_into_sd
 
     def _complete_features(
         self, sys_info: SysOutputInfo, sys_output: list[dict], external_stats=None
-    ) -> Optional[list[str]]:
+    ) -> list[str]:
         """
         This function takes in meta-data about system outputs, system outputs, and a few
         other optional pieces of information, then calculates feature functions and
@@ -315,7 +315,7 @@ https://github.com/ExpressAI/DataLab/blob/main/docs/SDK/add_new_datasets_into_sd
         sys_info: SysOutputInfo,
         sys_output: list[dict],
         active_features: list[str],
-        metric_stats=None,
+        metric_stats: list[MetricStats],
     ) -> tuple[dict, dict]:
         """
         Separate samples into buckets and calculate performance over them
@@ -363,7 +363,7 @@ https://github.com/ExpressAI/DataLab/blob/main/docs/SDK/add_new_datasets_into_sd
         sys_info: SysOutputInfo,
         sys_output: list[dict],
         samples_over_bucket: dict[str, list[int]],
-        metric_stats: Optional[list[MetricStats]] = None,
+        metric_stats: list[MetricStats],
     ) -> dict[str, list[BucketPerformance]]:
         """
         This function defines how to get bucket-level performance w.r.t a given feature


### PR DESCRIPTION
## Done
Resolves #210. Also fixes the following mypy errors:
<img width="1440" alt="Screen Shot 2022-04-04 at 10 35 23 PM" src="https://user-images.githubusercontent.com/30998659/161670199-224d227e-e5ec-40e6-90a1-4281baf2dd0b.png">

## Question:
The following 2 failed tests are from early PRs. Is there an issue for fixing them?
FAIL: test_eaas_decomposabiltiy (explainaboard.tests.test_metric.TestMetric) [bleu]
FAIL: test_eaas_decomposabiltiy (explainaboard.tests.test_metric.TestMetric) [chrf]
