### PR TITLE
refactor: move custom feature config parsing logic to base Loader

### DIFF
--- a/explainaboard/loaders/file_loader_test.py
+++ b/explainaboard/loaders/file_loader_test.py
@@ -1,0 +1,13 @@
+from unittest import TestCase
+
+from explainaboard.loaders.file_loader import FileLoaderField, TSVFileLoader
+
+
+class FileLoaderTests(TestCase):
+    def test_tsv_validation(self):
+        self.assertRaises(
+            ValueError,
+            lambda: TSVFileLoader(
+                [FileLoaderField("0", "field0", str)], use_idx_as_id=True
+            ),
+        )

--- a/explainaboard/processors/kg_link_tail_prediction.py
+++ b/explainaboard/processors/kg_link_tail_prediction.py
@@ -149,7 +149,6 @@ class KGLinkTailPredictionProcessor(Processor):
     def __init__(self):
         super().__init__()
         self.entity_type_level_map = None
-        self._user_defined_feature_config = None
 
     @aggregating()
     def _statistics_func(self, samples: Iterator[dict[str, str]]):

--- a/explainaboard/tests/test_loaders.py
+++ b/explainaboard/tests/test_loaders.py
@@ -27,16 +27,6 @@ class BaseLoaderTests(TestCase):
         self.assertEqual(set(samples[0].keys()), {"id", "field0"})
 
 
-class FileLoaderTests(TestCase):
-    def test_tsv_validation(self):
-        self.assertRaises(
-            ValueError,
-            lambda: TSVFileLoader(
-                [FileLoaderField("0", "field0", str)], use_idx_as_id=True
-            ),
-        )
-
-
 class TextClassificationLoader(TestCase):
     def test_load_in_memory_tsv(self):
         loader = get_loader(

--- a/explainaboard/tests/test_qa_multiple_choice.py
+++ b/explainaboard/tests/test_qa_multiple_choice.py
@@ -46,6 +46,7 @@ class TestQAMultipleChoice(unittest.TestCase):
             FileType.json,
         )
         data = list(loader.load())
+        self.assertIn("commonsense_category", data[0], "fails to load custom field")
 
         metadata = {
             "task_name": TaskType.qa_multiple_choice.value,


### PR DESCRIPTION
- FileLoader is designed to only have knowledge of the file type so I moved the custom feature parsing logic to the base Loader. It will parse the config dict and add custom fields to the fields list. Then, `JSONFileLoader` can load these custom features as if they are the default ones.
- Defined a dataclass for `CustomFeature` in loader.py. I'm not sure if it's the best place so please let me know if you want me to move it.
- Added type hints for https://github.com/neulab/ExplainaBoard/blob/27c30fa06f77883a4fe92d8fb778e1b79e874342/explainaboard/processors/processor.py#L257 just so it passes mypy. `_complete_features` is quite complicated, I think it maybe helpful if we can refactor some of the logic in there when we get a chance.