### PR TITLE
Small bug fixes: TSV loading + required system outputs

### DIFF
--- a/explainaboard/explainaboard_main.py
+++ b/explainaboard/explainaboard_main.py
@@ -27,7 +27,7 @@ def main():
     parser.add_argument(
         '--system_outputs',
         type=str,
-        required=False,
+        required=True,
         nargs="+",
         help=(
             "the directories of system outputs. Multiple one should be separated by "

--- a/explainaboard/loaders/file_loader.py
+++ b/explainaboard/loaders/file_loader.py
@@ -165,11 +165,11 @@ class TSVFileLoader(FileLoader):
     def load_raw(cls, data: str, source: Source) -> Iterable:
         if source == Source.in_memory:
             file = StringIO(data)
-            return csv.reader(file, delimiter='\t')
+            return csv.reader(file, delimiter='\t', quoting=csv.QUOTE_NONE)
         elif source == Source.local_filesystem:
             content: list[list[str]] = []
             with open(data, "r", encoding="utf8") as fin:
-                for record in csv.reader(fin, delimiter='\t'):
+                for record in csv.reader(fin, delimiter='\t', quoting=csv.QUOTE_NONE):
                     content.append(record)
             return content
         raise NotImplementedError


### PR DESCRIPTION
Just some fixes to small bugs I encountered when trying to use the software.
* I believe system outputs should be required because ExplainaBoard can't work without them (and throws an opaque error)
* I removed quoting in the TSV loader, as it through an opaque error if there was a TSV file that contained quotes.