### PR TITLE
Added more options for tokenization

### DIFF
--- a/explainaboard/processors/aspect_based_sentiment_classification.py
+++ b/explainaboard/processors/aspect_based_sentiment_classification.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from explainaboard import feature
+from explainaboard.info import SysOutputInfo
 from explainaboard.processors.processor import Processor
 from explainaboard.processors.processor_registry import register_processor
 from explainaboard.tasks import TaskType
@@ -91,22 +92,22 @@ class AspectBasedSentimentClassificationProcessor(Processor):
         return ["Accuracy"]
 
     # --- Feature functions accessible by ExplainaboardBuilder._get_feature_func()
-    def _get_sentence_length(self, existing_features: dict):
-        return len(self._tokenizer(existing_features["text"]))
+    def _get_sentence_length(self, sys_info: SysOutputInfo, existing_features: dict):
+        return len(sys_info.tokenize(existing_features["text"]))
 
-    def _get_token_number(self, existing_feature: dict):
+    def _get_token_number(self, sys_info: SysOutputInfo, existing_feature: dict):
         return len(existing_feature["text"])
 
-    def _get_entity_number(self, existing_feature: dict):
+    def _get_entity_number(self, sys_info: SysOutputInfo, existing_feature: dict):
         return len(get_named_entities(existing_feature["text"]))
 
-    def _get_label(self, existing_feature: dict):
+    def _get_label(self, sys_info: SysOutputInfo, existing_feature: dict):
         return existing_feature["true_label"]
 
-    def _get_aspect_length(self, existing_features: dict):
-        return len(self._tokenizer(existing_features["aspect"]))
+    def _get_aspect_length(self, sys_info: SysOutputInfo, existing_features: dict):
+        return len(sys_info.tokenize(existing_features["aspect"]))
 
-    def _get_aspect_index(self, existing_features: dict):
+    def _get_aspect_index(self, sys_info: SysOutputInfo, existing_features: dict):
         return existing_features["text"].find(existing_features["aspect"])
 
     # --- End feature functions

--- a/explainaboard/processors/kg_link_tail_prediction.py
+++ b/explainaboard/processors/kg_link_tail_prediction.py
@@ -226,7 +226,7 @@ https://github.com/ExpressAI/DataLab/blob/main/docs/SDK/add_new_datasets_into_sd
                 )
 
     # --- Feature functions accessible by ExplainaboardBuilder._get_feature_func()
-    def _get_entity_type_level(self, existing_features: dict):
+    def _get_entity_type_level(self, sys_info: SysOutputInfo, existing_features: dict):
 
         # list of entity types at each level:
         # [type_level_0, type_level_1, ... type_level_6]
@@ -244,13 +244,13 @@ https://github.com/ExpressAI/DataLab/blob/main/docs/SDK/add_new_datasets_into_sd
             most_specific_level = len(tail_entity_type_levels) - 1
         return str(most_specific_level)
 
-    def _get_tail_entity_length(self, existing_features: dict):
-        return len(self._tokenizer(existing_features["true_tail"]))
+    def _get_tail_entity_length(self, sys_info: SysOutputInfo, existing_features: dict):
+        return len(sys_info.tokenize(existing_features["true_tail"]))
 
-    def _get_head_entity_length(self, existing_features: dict):
-        return len(self._tokenizer(existing_features["true_head"]))
+    def _get_head_entity_length(self, sys_info: SysOutputInfo, existing_features: dict):
+        return len(sys_info.tokenize(existing_features["true_head"]))
 
-    def _get_tail_fre(self, existing_features: dict):
+    def _get_tail_fre(self, sys_info: SysOutputInfo, existing_features: dict):
         if (
             self.statistics is None
             or existing_features["true_tail"] not in self.statistics['tail_fre'].keys()
@@ -259,7 +259,7 @@ https://github.com/ExpressAI/DataLab/blob/main/docs/SDK/add_new_datasets_into_sd
         else:
             return self.statistics['tail_fre'][existing_features["true_tail"]]
 
-    def _get_head_fre(self, existing_features: dict):
+    def _get_head_fre(self, sys_info: SysOutputInfo, existing_features: dict):
         if (
             self.statistics is None
             or existing_features["true_head"] not in self.statistics['head_fre'].keys()
@@ -268,7 +268,7 @@ https://github.com/ExpressAI/DataLab/blob/main/docs/SDK/add_new_datasets_into_sd
         else:
             return self.statistics['head_fre'][existing_features["true_head"]]
 
-    def _get_link_fre(self, existing_features: dict):
+    def _get_link_fre(self, sys_info: SysOutputInfo, existing_features: dict):
         if (
             self.statistics is None
             or existing_features["true_link"] not in self.statistics['link_fre'].keys()
@@ -277,7 +277,7 @@ https://github.com/ExpressAI/DataLab/blob/main/docs/SDK/add_new_datasets_into_sd
         else:
             return self.statistics['link_fre'][existing_features["true_link"]]
 
-    def _get_symmetry(self, existing_features: dict):
+    def _get_symmetry(self, sys_info: SysOutputInfo, existing_features: dict):
         if existing_features['true_link'] in self._symmetric_relations:
             return 'symmetric'
         else:

--- a/explainaboard/processors/machine_translation.py
+++ b/explainaboard/processors/machine_translation.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from explainaboard import feature
+from explainaboard.info import SysOutputInfo
 from explainaboard.processors.conditional_generation import (
     ConditionalGenerationProcessor,
 )
@@ -40,7 +41,7 @@ class MachineTranslationProcessor(ConditionalGenerationProcessor):
     def default_metrics(cls) -> list[str]:
         return ["bleu"]
 
-    def _get_attr_compression(self, existing_features: dict):
-        return len(self._tokenizer(existing_features["source"])) / len(
-            self._tokenizer(existing_features["reference"])
+    def _get_attr_compression(self, sys_info: SysOutputInfo, existing_features: dict):
+        return len(sys_info.tokenize(existing_features["source"])) / len(
+            sys_info.tokenize(existing_features["reference"])
         )

--- a/explainaboard/processors/named_entity_recognition.py
+++ b/explainaboard/processors/named_entity_recognition.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 from collections import defaultdict
-from collections.abc import Callable, Iterator, Mapping
+from collections.abc import Callable, Iterator
 import re
-from typing import Any, Optional
+from typing import Any
 
 from datalabs import aggregating, Dataset
 from tqdm import tqdm
@@ -215,12 +215,14 @@ class NERProcessor(Processor):
         return data_point["pred_tags"]
 
     def _get_statistics_resources(
-        self, dataset_split: Dataset
-    ) -> Optional[Mapping[str, Any]]:
+        self, sys_info: SysOutputInfo, dataset_split: Dataset
+    ) -> dict[str, Any]:
         """
         From a DataLab dataset split, get resources necessary to calculate statistics
         """
-        base_resources = unwrap(super()._get_statistics_resources(dataset_split))
+        base_resources = unwrap(
+            super()._get_statistics_resources(sys_info, dataset_split)
+        )
         task_specific_resources = {
             'tag_id2str': dataset_split._info.task_templates[0].labels
         }
@@ -280,7 +282,7 @@ class NERProcessor(Processor):
         }
 
     # --- Feature functions accessible by ExplainaboardBuilder._get_feature_func()
-    def _get_sentence_length(self, existing_features: dict):
+    def _get_sentence_length(self, sys_info: SysOutputInfo, existing_features: dict):
         return len(existing_features["tokens"])
 
     def _get_stat_values(

--- a/explainaboard/processors/qa_multiple_choice.py
+++ b/explainaboard/processors/qa_multiple_choice.py
@@ -6,6 +6,7 @@ from typing import Any
 from datalabs import aggregating
 
 from explainaboard import feature
+from explainaboard.info import SysOutputInfo
 from explainaboard.processors.processor import Processor
 from explainaboard.processors.processor_registry import register_processor
 from explainaboard.tasks import TaskType
@@ -97,26 +98,30 @@ class QAMultipleChoiceProcessor(Processor):
         # self._statistics_func = get_statistics
 
     # --- Feature functions accessible by ExplainaboardBuilder._get_feature_func()
-    def _get_context_length(self, existing_features: dict):
-        return len(self._tokenizer(existing_features["context"]))
+    def _get_context_length(self, sys_info: SysOutputInfo, existing_features: dict):
+        return len(sys_info.tokenize(existing_features["context"]))
 
-    def _get_question_length(self, existing_features: dict):
-        return len(self._tokenizer(existing_features["question"]))
+    def _get_question_length(self, sys_info: SysOutputInfo, existing_features: dict):
+        return len(sys_info.tokenize(existing_features["question"]))
 
-    def _get_answer_length(self, existing_features: dict):
-        return len(self._tokenizer(existing_features["answers"]["text"]))
+    def _get_answer_length(self, sys_info: SysOutputInfo, existing_features: dict):
+        return len(sys_info.tokenize(existing_features["answers"]["text"]))
 
     # training set dependent features
-    def _get_num_oov(self, existing_features: dict, statistics: Any):
+    def _get_num_oov(
+        self, sys_info: SysOutputInfo, existing_features: dict, statistics: Any
+    ):
         return explainaboard.utils.feature_funcs.feat_num_oov(
-            existing_features, statistics, lambda x: x['context'], self._tokenizer
+            existing_features, statistics, lambda x: x['context'], sys_info.tokenizer
         )
 
     # training set dependent features
     # (this could be merged into the above one for further optimization)
-    def _get_fre_rank(self, existing_features: dict, statistics: Any):
+    def _get_fre_rank(
+        self, sys_info: SysOutputInfo, existing_features: dict, statistics: Any
+    ):
         return explainaboard.utils.feature_funcs.feat_freq_rank(
-            existing_features, statistics, lambda x: x['context'], self._tokenizer
+            existing_features, statistics, lambda x: x['context'], sys_info.tokenizer
         )
 
     # --- End feature functions

--- a/explainaboard/processors/summarization.py
+++ b/explainaboard/processors/summarization.py
@@ -9,6 +9,7 @@ from datalabs.operations.featurize.summarization import get_oracle_summary
 import numpy
 
 from explainaboard import feature
+from explainaboard.info import SysOutputInfo
 from explainaboard.processors.conditional_generation import (
     ConditionalGenerationProcessor,
 )
@@ -130,31 +131,31 @@ class SummarizationProcessor(ConditionalGenerationProcessor):
     def default_metrics(cls) -> list[str]:
         return ["rouge1", "rouge2", "rougeL"]
 
-    def _get_oracle_position(self, existing_features: dict):
+    def _get_oracle_position(self, sys_info: SysOutputInfo, existing_features: dict):
         return get_oracle(existing_features)["oracle_position"]
 
-    def _get_oracle_score(self, existing_features: dict):
+    def _get_oracle_score(self, sys_info: SysOutputInfo, existing_features: dict):
         return get_oracle(existing_features)["oracle_score"]
 
-    def _get_attr_compression(self, existing_features: dict):
+    def _get_attr_compression(self, sys_info: SysOutputInfo, existing_features: dict):
         res = summary_attribute.cal_attributes_each(
             existing_features["source"], existing_features["reference"]
         )
         return res["attr_compression"]
 
-    def _get_attr_copy_len(self, existing_features: dict):
+    def _get_attr_copy_len(self, sys_info: SysOutputInfo, existing_features: dict):
         res = summary_attribute.cal_attributes_each(
             existing_features["source"], existing_features["reference"]
         )
         return res["attr_copy_len"]
 
-    def _get_attr_coverage(self, existing_features: dict):
+    def _get_attr_coverage(self, sys_info: SysOutputInfo, existing_features: dict):
         res = summary_attribute.cal_attributes_each(
             existing_features["source"], existing_features["reference"]
         )
         return res["attr_coverage"]
 
-    def _get_attr_novelty(self, existing_features: dict):
+    def _get_attr_novelty(self, sys_info: SysOutputInfo, existing_features: dict):
         res = summary_attribute.cal_attributes_each(
             existing_features["source"], existing_features["reference"]
         )

--- a/explainaboard/processors/text_pair_classification.py
+++ b/explainaboard/processors/text_pair_classification.py
@@ -5,10 +5,12 @@ from typing import Any
 from datalabs import aggregating
 
 from explainaboard import feature
+from explainaboard.info import SysOutputInfo
 from explainaboard.processors.processor import Processor
 from explainaboard.processors.processor_registry import register_processor
 from explainaboard.tasks import TaskType
 import explainaboard.utils.feature_funcs
+from explainaboard.utils.tokenizer import Tokenizer
 
 
 @register_processor(TaskType.text_pair_classification)
@@ -106,53 +108,54 @@ class TextPairClassificationProcessor(Processor):
         return ["Accuracy"]
 
     @aggregating()
-    def _statistics_func(self, samples):
-        # TODO(gneubig):
-        # BEWARE THIS IS HACKY. This should use the same tokenizer as the processor.
-        tokenizer = self._tokenizer
+    def _statistics_func(self, samples, tokenizer: Tokenizer):
 
         return explainaboard.utils.feature_funcs.accumulate_vocab_from_samples(
             samples, lambda x: x['text1'] + x['text2'], tokenizer
         )
 
     # --- Feature functions accessible by ExplainaboardBuilder._get_feature_func()
-    def _get_similarity(self, existing_features: dict):
+    def _get_similarity(self, sys_info: SysOutputInfo, existing_features: dict):
         return explainaboard.utils.feature_funcs.get_similarity_by_sacrebleu(
             existing_features["text1"], existing_features["text2"]
         )
 
-    def _get_text1_length(self, existing_features: dict):
-        return len(self._tokenizer(existing_features["text1"]))
+    def _get_text1_length(self, sys_info: SysOutputInfo, existing_features: dict):
+        return len(sys_info.tokenize(existing_features["text1"]))
 
-    def _get_text2_length(self, existing_feature: dict):
-        return len(self._tokenizer(existing_feature["text2"]))
+    def _get_text2_length(self, sys_info: SysOutputInfo, existing_feature: dict):
+        return len(sys_info.tokenize(existing_feature["text2"]))
 
-    def _get_text1_divided_text2(self, existing_feature: dict):
+    def _get_text1_divided_text2(self, sys_info: SysOutputInfo, existing_feature: dict):
         return (
-            len(self._tokenizer(existing_feature["text1"]))
+            len(sys_info.tokenize(existing_feature["text1"]))
             * 1.0
-            / len(self._tokenizer(existing_feature["text2"]))
+            / len(sys_info.tokenize(existing_feature["text2"]))
         )
 
-    def _get_label(self, existing_feature: dict):
+    def _get_label(self, sys_info: SysOutputInfo, existing_feature: dict):
         # print(f"print_existing_feature: \t {existing_feature}")
         return existing_feature["true_label"]
 
     # training set dependent features
-    def _get_num_oov(self, existing_features: dict, statistics: Any):
+    def _get_num_oov(
+        self, sys_info: SysOutputInfo, existing_features: dict, statistics: Any
+    ):
         return explainaboard.utils.feature_funcs.feat_num_oov(
             existing_features,
             statistics,
             lambda x: x['text1'] + x['text2'],
-            self._tokenizer,
+            sys_info.tokenizer,
         )
 
     # training set dependent features (this could be merged into the above one for
     # further optimization)
-    def _get_fre_rank(self, existing_features: dict, statistics: Any):
+    def _get_fre_rank(
+        self, sys_info: SysOutputInfo, existing_features: dict, statistics: Any
+    ):
         return explainaboard.utils.feature_funcs.feat_freq_rank(
             existing_features,
             statistics,
             lambda x: x['text1'] + x['text2'],
-            self._tokenizer,
+            sys_info.tokenizer,
         )

--- a/explainaboard/tests/test_tokenizers.py
+++ b/explainaboard/tests/test_tokenizers.py
@@ -1,0 +1,31 @@
+import unittest
+
+from explainaboard.utils.tokenizer import SacreBleuTokenizer, SingleSpaceTokenizer
+
+
+class TestTokenizers(unittest.TestCase):
+    def test_single_space_tokenizer(self):
+        src = 'this,  is an example '
+        gold_toks = ['this,', '', 'is', 'an', 'example', '']
+        tokenizer = SingleSpaceTokenizer()
+        out_toks = tokenizer(src)
+        self.assertEqual(gold_toks, out_toks)
+
+    def test_sacrebleu_intl_tokenizer(self):
+        src = '"this," she   said, is an example.'
+        gold_toks = [
+            '"',
+            'this',
+            ',',
+            '"',
+            'she',
+            'said',
+            ',',
+            'is',
+            'an',
+            'example',
+            '.',
+        ]
+        tokenizer = SacreBleuTokenizer()
+        out_toks = tokenizer(src)
+        self.assertEqual(gold_toks, out_toks)


### PR DESCRIPTION
This:
1. Makes the tokenizer a property of `sys_info` as opposed to `processor`
2. Adds the ability to switch default tokenizers based on task and language
3. Adds the SacreBLEU tokenizers, and makes them default for conditional generation analysis