### PR TITLE
Store overall result in dataclass Result instead of a separate field

### DIFF
--- a/explainaboard/info.py
+++ b/explainaboard/info.py
@@ -60,9 +60,9 @@ class BucketPerformance:
 
 @dataclass
 class Result:
-    overall: Any = None
+    overall: Optional[dict[str, Performance]] = None
     calibration: Optional[list[Performance]] = None
-    fine_grained: Any = None
+    fine_grained: Optional[dict] = None
 
 
 @dataclass
@@ -202,7 +202,6 @@ class OverallStatistics:
     sys_info: SysOutputInfo
     metric_stats: list[MetricStats]
     active_features: list[str]
-    overall_results: dict[str, Performance]
 
 
 @dataclass

--- a/explainaboard/processors/processor.py
+++ b/explainaboard/processors/processor.py
@@ -535,9 +535,10 @@ https://github.com/ExpressAI/DataLab/blob/main/docs/SDK/add_new_datasets_into_sd
         overall_results = self.get_overall_performance(
             sys_info, sys_output, metric_stats=metric_stats
         )
-        return OverallStatistics(
-            sys_info, metric_stats, active_features, overall_results
+        sys_info.results = Result(
+            overall=overall_results, calibration=None, fine_grained=None
         )
+        return OverallStatistics(sys_info, metric_stats, active_features)
 
     def sort_bucket_info(
         self, performance_over_bucket, sort_by='value', sort_by_metric='first'
@@ -649,7 +650,7 @@ https://github.com/ExpressAI/DataLab/blob/main/docs/SDK/add_new_datasets_into_sd
         sys_info = unwrap(overall_statistics.sys_info)
         metric_stats = overall_statistics.metric_stats
         active_features = unwrap(overall_statistics.active_features)
-        overall_results = overall_statistics.overall_results
+        overall_results = sys_info.results.overall
         samples_over_bucket, performance_over_bucket = self._bucketing_samples(
             sys_info, sys_output, active_features, metric_stats=metric_stats
         )


### PR DESCRIPTION
Small modification: 
- Stores the overall analysis result in dataclass `Result`, which is the proper way, instead of `OverallStatistics`.
- Added typing for `Result`