### PR TITLE
Added CI for multiple versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,12 +9,15 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ '3.8', '3.9', '3.10' ]
     steps:
       - uses: actions/checkout@v3
-      - name: Install Python 3
+      - name: Install Python ${{ matrix.python-version }}
         uses: actions/setup-python@v3
         with:
-          python-version: 3.9
+          python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
   pull_request:
-    branches: ["*"]
+    branches: ["**"]
 
 jobs:
   tests:

--- a/explainaboard/loaders/aspect_based_sentiment_classification.py
+++ b/explainaboard/loaders/aspect_based_sentiment_classification.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from explainaboard.constants import FileType
 from explainaboard.loaders.file_loader import (
     FileLoader,

--- a/explainaboard/loaders/conditional_generation.py
+++ b/explainaboard/loaders/conditional_generation.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from explainaboard.constants import FileType
 from explainaboard.loaders.file_loader import (
     FileLoader,

--- a/explainaboard/loaders/extractive_qa.py
+++ b/explainaboard/loaders/extractive_qa.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from explainaboard.constants import FileType
 from explainaboard.loaders.file_loader import (
     DatalabFileLoader,

--- a/explainaboard/loaders/file_loader.py
+++ b/explainaboard/loaders/file_loader.py
@@ -5,14 +5,14 @@ import csv
 from dataclasses import dataclass
 from io import StringIO
 import json
-from typing import Any, final, Optional, Union
+from typing import Any, final, Optional, Type, Union
 
 from datalabs import load_dataset
 
 from explainaboard.constants import Source
 from explainaboard.utils.typing_utils import narrow
 
-DType = Union[type[int], type[float], type[str], type[dict]]
+DType = Union[Type[int], Type[float], Type[str], Type[dict]]
 
 
 @dataclass

--- a/explainaboard/loaders/named_entity_recognition.py
+++ b/explainaboard/loaders/named_entity_recognition.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from explainaboard.constants import FileType
 from explainaboard.loaders.file_loader import (
     CoNLLFileLoader,

--- a/explainaboard/loaders/text_classification.py
+++ b/explainaboard/loaders/text_classification.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from explainaboard.constants import FileType
 from explainaboard.loaders.file_loader import (
     DatalabFileLoader,

--- a/explainaboard/loaders/text_pair_classification.py
+++ b/explainaboard/loaders/text_pair_classification.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from explainaboard.constants import FileType
 from explainaboard.loaders.file_loader import (
     FileLoader,

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         ],
     },
     install_requires=[
-        "datalabs>=0.3.7",
+        "datalabs>=0.3.10",
         "datasets>=2.0.0",
         "eaas>=0.3.8",
         "lexicalrichness",


### PR DESCRIPTION
We discussed compatibility of ExplainaBoard with multiple Python versions, and I think we should probably support at least 3.8, 3.9, and 3.10. This PR adds CI for these versions.