### PR TITLE
Optimizes bootstrap sampling

### DIFF
--- a/explainaboard/metric.py
+++ b/explainaboard/metric.py
@@ -186,8 +186,10 @@ class Metric:
         n_elems = int(prop_samples * len(stats))
         samp_results = np.zeros(shape=(n_samples,))
         all_indices = np.array(range(len(stats)))
+        rng = np.random.default_rng()
+        all_indices = rng.choice(all_indices, size=(n_samples, n_elems), replace=True)
         for i in range(n_samples):
-            indices = np.random.choice(all_indices, size=n_elems, replace=True)
+            indices = all_indices[i]
             agg_stats = self.aggregate_stats(stats.filter(indices))
             samp_results[i] = self.calc_metric_from_aggregate(agg_stats, config)
         samp_results = np.sort(samp_results)


### PR DESCRIPTION
Some profiling showed that bootstrap sampling was a bottleneck in the speed of bucketing.

This small fix greatly improves the speed of bucketing:
Before: 1.6s on my macbook
After: 0.62s on my macbook