### PR TITLE
Vectorize bucketing

### DIFF
--- a/explainaboard/feature.py
+++ b/explainaboard/feature.py
@@ -307,8 +307,6 @@ class ClassLabel:
     names: Optional[list[str]] = None
     description: Optional[str] = None
     names_file: Optional[str] = None
-    max_value: Optional[int] = None
-    min_value: Optional[int] = None
     id: Optional[str] = None
     is_bucket: bool = False
     require_training_set: bool = False

--- a/explainaboard/metric.py
+++ b/explainaboard/metric.py
@@ -175,7 +175,7 @@ class Metric:
         self,
         stats: MetricStats,
         conf_value: float,
-        n_samples: int = 2000,
+        n_samples: int = 1000,
         prop_samples: float = 0.5,
         config: Optional[MetricConfig] = None,
     ) -> tuple[float, float]:

--- a/explainaboard/processors/named_entity_recognition.py
+++ b/explainaboard/processors/named_entity_recognition.py
@@ -461,12 +461,6 @@ class NERProcessor(Processor):
 
             samples_over_bucket_true[feature_name] = bucket_func(
                 dict_obj=feat_dict,
-                max_value=my_feature.max_value
-                if my_feature.dtype in set(["float", "float32", "int32", "int64"])
-                else None,
-                min_value=my_feature.min_value
-                if my_feature.dtype in set(["float", "float32", "int32", "int64"])
-                else None,
                 bucket_number=bucket_info.number,
                 bucket_setting=bucket_info.setting,
             )
@@ -479,12 +473,6 @@ class NERProcessor(Processor):
                 feature_name
             ] = bucketing.bucket_attribute_specified_bucket_interval(
                 dict_obj=feat_dict,
-                max_value=my_feature.max_value
-                if my_feature.dtype in set(["float", "float32", "int32", "int64"])
-                else None,
-                min_value=my_feature.min_value
-                if my_feature.dtype in set(["float", "float32", "int32", "int64"])
-                else None,
                 bucket_number=bucket_info.number,
                 bucket_setting=samples_over_bucket_true[feature_name].keys(),
             )

--- a/explainaboard/processors/named_entity_recognition.py
+++ b/explainaboard/processors/named_entity_recognition.py
@@ -346,15 +346,11 @@ class NERProcessor(Processor):
 
             # sentence_length
             dict_sysout["sentence_length"] = len(tokens)
-            self._get_max_min_value(sys_info, "sentence_length", len(tokens))
 
             # entity density
             dict_sysout["entity_density"] = len(
                 bio_span_ops.get_spans(tags=dict_sysout["true_tags"])
             ) / len(tokens)
-            self._get_max_min_value(
-                sys_info, "entity_density", dict_sysout["entity_density"]
-            )
 
             # sentence-level training set dependent features
             if external_stats is not None:
@@ -366,32 +362,9 @@ class NERProcessor(Processor):
                 tokens, dict_sysout["true_tags"], statistics=external_stats
             )
 
-            # store max and min value for bucket features with float and int type
-            for bucket_key in tok_feats:
-                for span in dict_sysout["true_entity_info"]:
-                    current_value = getattr(span, bucket_key)
-                    self._get_max_min_value(
-                        sys_info,
-                        bucket_key,
-                        current_value,
-                        token_feature_name="true_entity_info",
-                    )
-
             dict_sysout["pred_entity_info"] = self._complete_span_features(
                 tokens, dict_sysout["pred_tags"], statistics=external_stats
             )
-
-            # store max and min value for bucket features with float and int type
-            for bucket_key in tok_feats:
-                for span in dict_sysout["pred_entity_info"]:
-                    current_value = getattr(span, bucket_key)
-                    # token_feature_name should be true_entity_info
-                    self._get_max_min_value(
-                        sys_info,
-                        bucket_key,
-                        current_value,
-                        token_feature_name="true_entity_info",
-                    )
 
         # This is not used elsewhere, so just keep it as-is
         return active_features

--- a/explainaboard/processors/processor.py
+++ b/explainaboard/processors/processor.py
@@ -226,37 +226,6 @@ class Processor(metaclass=abc.ABCMeta):
                 else:
                     raise NotImplementedError
 
-    def _get_max_min_value(
-        self,
-        sys_info: SysOutputInfo,
-        bucket_key: str,
-        current_value,
-        token_feature_name: Optional[str] = None,
-    ) -> SysOutputInfo:
-        # Store max and min value for bucketable features with float and int type
-        # TODO(Pengfei): Use snakeviz to check if below is time-consuming
-        my_feature = (
-            sys_info.features[bucket_key]  # type: ignore
-            if token_feature_name is None
-            else sys_info.features[token_feature_name].feature.feature[  # type: ignore
-                bucket_key
-            ]
-        )
-
-        if my_feature.dtype in set(["float", "float32", "int32", "int64"]):
-            my_feature.max_value = (
-                current_value
-                if my_feature.max_value is None or my_feature.max_value < current_value
-                else my_feature.max_value
-            )
-
-            my_feature.min_value = (
-                current_value
-                if my_feature.min_value is None or my_feature.min_value > current_value
-                else my_feature.min_value
-            )
-        return sys_info
-
     def _complete_features(
         self, sys_info: SysOutputInfo, sys_output: list[dict], external_stats=None
     ) -> list[str]:
@@ -333,11 +302,6 @@ class Processor(metaclass=abc.ABCMeta):
                         if training_dependent
                         else bucket_func(sys_info, dict_sysout)
                     )
-
-                # Store max/min value for bucketable features with float/int type
-                sys_info = self._get_max_min_value(
-                    sys_info, bucket_key, dict_sysout[bucket_key]
-                )
 
         return list(bucket_feature_funcs.keys())
 

--- a/explainaboard/processors/processor.py
+++ b/explainaboard/processors/processor.py
@@ -375,14 +375,6 @@ class Processor(metaclass=abc.ABCMeta):
                 dict_obj={
                     x: sys_output[x][feature_name] for x in range(len(sys_output))
                 },
-                max_value=sys_info.features[feature_name].max_value  # type: ignore
-                if sys_info.features[feature_name].dtype  # type: ignore
-                in set(["float", "float32", "int32", "int64"])
-                else None,
-                min_value=sys_info.features[feature_name].min_value  # type: ignore
-                if sys_info.features[feature_name].dtype  # type: ignore
-                in set(["float", "float32", "int32", "int64"])
-                else None,
                 bucket_number=sys_features[feature_name].bucket_info.number,
                 bucket_setting=sys_features[feature_name].bucket_info.setting,
             )

--- a/explainaboard/tests/test_ner.py
+++ b/explainaboard/tests/test_ner.py
@@ -99,13 +99,13 @@ class TestNER(unittest.TestCase):
         )
         self.assertAlmostEqual(
             second_interval[1],
-            0.9565217391304348,
+            0.8603351955307262,
             4,
             "almost equal",
         )
         # 4. Unittest: test detailed bucket information: bucket samples
         self.assertEqual(
-            sys_info.results.fine_grained["span_econ"][second_interval].n_samples, 1428
+            sys_info.results.fine_grained["span_econ"][second_interval].n_samples, 999
         )
 
         # 5. Unittest: test detailed bucket information: metric
@@ -119,7 +119,7 @@ class TestNER(unittest.TestCase):
             sys_info.results.fine_grained["span_econ"][second_interval]
             .performances[0]
             .value,
-            0.9442300947036127,
+            0.9273461150353179,
             4,
             "almost equal",
         )

--- a/explainaboard/utils/analysis.py
+++ b/explainaboard/utils/analysis.py
@@ -1,4 +1,7 @@
+from __future__ import annotations
+
 import json
+from typing import TypeVar
 
 
 def cap_feature(s):
@@ -72,25 +75,15 @@ def find_key(dict_obj, x):
             return k
 
 
-def reverse_dict(dict_a2b):
+T1 = TypeVar('T1')
+T2 = TypeVar('T2')
+
+
+def reverse_dict(dict_a2b: dict[T1, T2]) -> dict[T2, list[T1]]:
     dict_b2a = {}
     for k, v in dict_a2b.items():
-        v = float(v)
-        if v not in dict_b2a.keys():
-            dict_b2a[float(v)] = [k]
-        else:
-            dict_b2a[float(v)].append(k)
-
-    return dict_b2a
-
-
-def reverse_dict_discrete(dict_a2b):
-    dict_b2a = {}
-    # print(dict_a2b)
-    for k, v in dict_a2b.items():
-        if v not in dict_b2a.keys():
+        if v not in dict_b2a:
             dict_b2a[v] = [k]
         else:
             dict_b2a[v].append(k)
-
     return dict_b2a

--- a/explainaboard/utils/bucketing.py
+++ b/explainaboard/utils/bucketing.py
@@ -33,7 +33,7 @@ def bucket_attribute_specified_bucket_value(
     n_examps = len(keys)
     sorted_idxs = np.argsort(vals)
     sorted_vals = vals[sorted_idxs]
-    max_val, min_val = sorted_vals[-1], sorted_vals[0]
+    max_val, min_val = conv(sorted_vals[-1]), conv(sorted_vals[0])
 
     start_val, last_val = min_val, min_val
     start_i, cutoff_i = 0, n_examps / float(bucket_number)

--- a/explainaboard/utils/bucketing.py
+++ b/explainaboard/utils/bucketing.py
@@ -25,14 +25,15 @@ def bucket_attribute_specified_bucket_value(
     vals = np.array(list(dict_obj.values()))
     # Function to convert numpy datatypes to Python native types
     conv = int if np.issubdtype(vals[0], int) else float
-    max_val, min_val = conv(np.max(vals)), conv(np.min(vals))
     # Special case of one bucket
     if bucket_number == 1:
+        max_val, min_val = conv(np.max(vals)), conv(np.min(vals))
         return {(min_val, max_val): keys}
 
     n_examps = len(keys)
     sorted_idxs = np.argsort(vals)
     sorted_vals = vals[sorted_idxs]
+    max_val, min_val = sorted_vals[-1], sorted_vals[0]
 
     start_val, last_val = min_val, min_val
     start_i, cutoff_i = 0, n_examps / float(bucket_number)

--- a/explainaboard/utils/bucketing.py
+++ b/explainaboard/utils/bucketing.py
@@ -1,73 +1,65 @@
-from explainaboard.utils.analysis import find_key, reverse_dict, reverse_dict_discrete
+from __future__ import annotations
+
+from typing import Any, TypeVar
+
+import numpy as np
+
+from explainaboard.utils.analysis import find_key, reverse_dict
 from explainaboard.utils.py_utils import sort_dict
+
+T = TypeVar('T')
 
 
 def bucket_attribute_specified_bucket_value(
-    dict_obj=None, max_value=None, min_value=None, bucket_number=4, bucket_setting=None
-):
-    if not dict_obj or len(dict_obj) == 0:
-        return None
+    dict_obj: dict[Any, T], bucket_number: int = 4, bucket_setting: Any = None
+) -> dict[tuple[T, T], list]:
+    if len(dict_obj) == 0:
+        return {}
+    if bucket_setting is not None and len(bucket_setting) > 0:
+        raise NotImplementedError(
+            'bucket_setting incompatible with '
+            'bucket_attribute_specified_bucket_value'
+        )
     # Bucketing different Attributes
-    dict_span2att_val = dict_obj
-    n_buckets = bucket_number
-    hardcoded_bucket_values = bucket_setting
-    p_infinity = max_value if max_value is not None else 100000
-    n_infinity = min_value if min_value is not None else -100000
-    n_spans = len(dict_span2att_val)
-    dict_att_val2span = reverse_dict(dict_span2att_val)
-    dict_att_val2span = sort_dict(dict_att_val2span)
-    dict_bucket2span = {}
+    keys = list(dict_obj.keys())
+    vals = np.array(list(dict_obj.values()))
+    # Function to convert numpy datatypes to Python native types
+    conv = int if np.issubdtype(vals[0], int) else float
+    max_val, min_val = conv(np.max(vals)), conv(np.min(vals))
+    # Special case of one bucket
+    if bucket_number == 1:
+        return {(min_val, max_val): keys}
 
-    for bucket_value in hardcoded_bucket_values:
-        if bucket_value in dict_att_val2span.keys():
-            dict_bucket2span[(bucket_value,)] = dict_att_val2span[bucket_value]
-            n_spans -= len(dict_att_val2span[bucket_value])
-            n_buckets -= 1
+    n_examps = len(keys)
+    sorted_idxs = np.argsort(vals)
+    sorted_vals = vals[sorted_idxs]
 
-    avg_entity = n_spans * 1.0 / n_buckets
-    n_tmp = 0
-    entity_list = []
-    val_list = []
+    start_val, last_val = min_val, min_val
+    start_i, cutoff_i = 0, n_examps / float(bucket_number)
+    bucket_dict: dict[tuple[T, T], list[Any]] = {}
+    for i, val in enumerate(sorted_vals):
+        # Return the final bucket
+        if bucket_number - len(bucket_dict) == 1 or val == max_val:
+            bucket_dict[(conv(start_val), max_val)] = [
+                keys[j] for j in sorted_idxs[start_i:]
+            ]
+            break
+        # If the last value is not the same, maybe make a new bucket
+        elif val != last_val:
+            if i >= cutoff_i:
+                bucket_dict[(conv(start_val), conv(last_val))] = [
+                    keys[j] for j in sorted_idxs[start_i:i]
+                ]
+                start_val = val
+                start_i = i
+                cutoff_i = i + (n_examps - i) / float(bucket_number - len(bucket_dict))
+            last_val = val
 
-    for att_val, entity in dict_att_val2span.items():
-        if att_val in hardcoded_bucket_values:
-            continue
-
-        val_list.append(att_val)
-        entity_list += entity
-        n_tmp += len(entity)
-
-        if n_tmp > avg_entity:
-
-            if len(val_list) >= 2:
-                key_bucket = (val_list[0], val_list[-1])
-                dict_bucket2span[key_bucket] = entity_list
-            # print("debug key bucket:\t", key_bucket)
-            else:
-                dict_bucket2span[(val_list[0],)] = entity_list
-            entity_list = []
-            n_tmp = 0
-            val_list = []
-    if n_tmp != 0:
-        if n_buckets == 1:
-            dict_bucket2span[(n_infinity, p_infinity)] = entity_list
-        else:
-            if val_list[0] <= 1:
-                p_infinity = 1.0
-            # print("!!!!!-debug-2")
-            if len(val_list) >= 2:
-                key_bucket = (val_list[0], p_infinity)
-                dict_bucket2span[key_bucket] = entity_list
-            else:
-                dict_bucket2span[(val_list[0], p_infinity)] = entity_list  # fix bugs
-
-    return dict_bucket2span
+    return bucket_dict
 
 
 def bucket_attribute_discrete_value(
     dict_obj=None,
-    max_value=None,
-    min_value=None,
     bucket_number=100000000,
     bucket_setting=1,
 ):
@@ -78,7 +70,7 @@ def bucket_attribute_discrete_value(
 
     dict_bucket2span = {}
 
-    dict_att_val2span = reverse_dict_discrete(dict_span2att_val)
+    dict_att_val2span = reverse_dict(dict_span2att_val)
     dict_att_val2span = sort_dict(dict_att_val2span, flag="value")
 
     n_total = 1
@@ -95,8 +87,6 @@ def bucket_attribute_discrete_value(
 
 def bucket_attribute_specified_bucket_interval(
     dict_obj=None,
-    max_value=None,
-    min_value=None,
     bucket_number=None,
     bucket_setting=None,
 ):
@@ -110,7 +100,7 @@ def bucket_attribute_specified_bucket_interval(
 
     dict_bucket2span = {}
     if isinstance(list(intervals)[0][0], str):  # discrete value, such as entity tags
-        dict_att_val2span = reverse_dict_discrete(dict_span2att_val)
+        dict_att_val2span = reverse_dict(dict_span2att_val)
         dict_att_val2span = sort_dict(dict_att_val2span, flag="value")
         for att_val, entity in dict_att_val2span.items():
             att_val_tuple = (att_val,)


### PR DESCRIPTION
I took a stab at converting bucketing to use numpy vectorization and calculates min/max within the bucketing function. Here are the metrics on NER processing:

Featurization time: 2.0iter/s -> 3.0iter/s (50% faster)
Bucketing time: 3.95s/iter -> 3.97s/iter (a little slower)
Code: simpler

in addition, I reduced the number of samples for bootstrap sampling from 2000 by default to 1000 by default. This changes
Bucketing time: 3.97s/iter -> 2.04s/iter