### PR TITLE
fix: duplicate task category name

### DIFF
--- a/explainaboard/tasks.py
+++ b/explainaboard/tasks.py
@@ -157,13 +157,7 @@ https://github.com/neulab/ExplainaBoard/blob/main/data/system_outputs/conll2003/
                     TaskType.named_entity_recognition
                 ),
                 supported_datasets=[],
-            )
-        ],
-    ),
-    TaskCategory(
-        "structure-prediction",
-        "predicting structural properties of the text, such as syntax",
-        [
+            ),
             Task(
                 name=TaskType.word_segmentation,
                 description="""
@@ -175,7 +169,7 @@ identify word boundaries of some languages (e.g., Chinese).
                     TaskType.word_segmentation
                 ),
                 supported_datasets=[],
-            )
+            ),
         ],
     ),
     TaskCategory(

--- a/explainaboard/tests/test_get_tasks.py
+++ b/explainaboard/tests/test_get_tasks.py
@@ -7,6 +7,12 @@ class TestTasks(unittest.TestCase):
     def test_get_task_categories(self):
         task_categories = get_task_categories()
         self.assertTrue(isinstance(task_categories, list))
+        task_category_names = [category.name for category in task_categories]
+        self.assertEqual(
+            len(task_category_names),
+            len(set(task_category_names)),
+            "task category names should be unique",
+        )
         for task_category in task_categories:
             self.assertIsNotNone(task_category.description)
             self.assertIsNotNone(task_category.name)


### PR DESCRIPTION
Related to the "strange behavior of task drop-down box when submitting a system output" bug reported in https://github.com/neulab/explainaboard_web/issues/127
A fix has already been provided in https://github.com/neulab/explainaboard_web/pull/135 (the frontend) so we don't necessarily have to enforce task category names to be unique in the SDK but I think this may be a convenient assumption for the tasks list?