### PR TITLE
Refactor metric config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,4 @@ analyzer/fig/5.png
 
 # This is an example file downloaded in doc but not stored here
 data/system_outputs/cnndm/cnndm-bart-output.txt
+data/system_outputs/fb15k-237/larger/*

--- a/docs/task_kg_link_tail_prediction.md
+++ b/docs/task_kg_link_tail_prediction.md
@@ -74,14 +74,12 @@ Let's say we have one system output file:
 In order to perform your basic analysis, we can run the following command:
 
 ```shell
-    explainaboard --task kg-link-tail-prediction --system_outputs ./data/system_outputs/fb15k-237/test-kg-prediction-no-user-defined-new.json --dataset fb15k_237 > report.json
+explainaboard --task kg-link-tail-prediction --custom_dataset_paths ./data/system_outputs/fb15k-237/test-kg-prediction-no-user-defined-new.json --system_outputs ./data/system_outputs/fb15k-237/test-kg-prediction-no-user-defined-new.json > report.json
 
-or
-
-    explainaboard --task kg-link-tail-prediction --system_outputs ./data/system_outputs/fb15k-237/test-kg-prediction-no-user-defined-new.json > report.json
 ```
 where
 * `--task`: denotes the task name. 
+* `--custom_dataset_paths`: the path of test samples
 * `--system_outputs`: denote the path of system outputs. Multiple one should be 
   separated by space, for example, system1 system2
 * `--dataset`:optional, denotes the dataset name
@@ -163,11 +161,7 @@ ExplainaBoard also allows users to customize features, specifically to provide y
 An example system output is [provided](https://github.com/neulab/ExplainaBoard/blob/main/explainaboard/tests/artifacts/test-kg-prediction-user-defined-new.json), and you can test it using the following command:
 
 ```shell
-    explainaboard --task kg-link-tail-prediction --system_outputs ./data/system_outputs/fb15k-237/test-kg-prediction-user-defined-new.json --dataset fb15k_237 > report.json
-
-or
-
-    explainaboard --task kg-link-tail-prediction --system_outputs ./data/system_outputs/fb15k-237/test-kg-prediction-user-defined-new.json > report.json
+explainaboard --task kg-link-tail-prediction --custom_dataset_paths ./data/system_outputs/fb15k-237/test-kg-prediction-no-user-defined-new.json --system_outputs ./data/system_outputs/fb15k-237/test-kg-prediction-no-user-defined-new.json > report.json
 ```
 
 

--- a/explainaboard/explainaboard_main.py
+++ b/explainaboard/explainaboard_main.py
@@ -17,6 +17,7 @@ from explainaboard.analyzers.draw_hist import draw_bar_chart_from_report
 from explainaboard.constants import Source
 from explainaboard.info import SysOutputInfo
 from explainaboard.loaders.file_loader import DatalabLoaderOption
+from explainaboard.metric import metric_name_to_config
 from explainaboard.utils.tensor_analysis import (
     aggregate_score_tensor,
     filter_score_tensor,
@@ -392,7 +393,13 @@ def main():
         }
 
         if metric_names is not None:
-            metadata["metric_names"] = metric_names
+            if 'metric_configs' in metadata:
+                raise ValueError('Cannot specify both metric names and metric configs')
+            metric_configs = [metric_name_to_config(name) for name in metric_names]
+            if args.language is not None:
+                for metric_config in metric_configs:
+                    metric_config.language = args.language
+            metadata["metric_configs"] = metric_configs
 
         # Run analysis
         reports: list[SysOutputInfo] = []

--- a/explainaboard/info.py
+++ b/explainaboard/info.py
@@ -91,13 +91,12 @@ class SysOutputInfo:
     dataset_name: Optional[str] = None
     sub_dataset_name: Optional[str] = None
     dataset_split: Optional[str] = None
-    metric_names: Optional[list[str]] = None
     language: str = "en"
     reload_stat: bool = True
     is_print_case: bool = True
     conf_value: float = 0.05
     system_details: Optional[dict] = None
-    metric_configs: Optional[dict[str, MetricConfig]] = None
+    metric_configs: Optional[list[MetricConfig]] = None
     tokenizer: Tokenizer = SingleSpaceTokenizer()
 
     # set later

--- a/explainaboard/loaders/kg_link_tail_prediction.py
+++ b/explainaboard/loaders/kg_link_tail_prediction.py
@@ -79,6 +79,7 @@ class KgLinkTailPredictionLoader(Loader):
                     "true_tail": entity_dic[features_dict["gold_tail"]]["label"]
                     if features_dict["gold_tail"] in entity_dic.keys()
                     else features_dict["gold_tail"],
+                    "true_tail_anonymity": features_dict["gold_tail"],
                     "true_label": features_dict[
                         "gold_" + features_dict["predict"]
                     ],  # the entity to which we compare the predictions
@@ -106,6 +107,7 @@ class KgLinkTailPredictionLoader(Loader):
                         "true_tail": entity_dic[features_dict["gold_tail"]]["label"]
                         if features_dict["gold_tail"] in entity_dic.keys()
                         else features_dict["gold_tail"],
+                        "true_tail_anonymity": features_dict["gold_tail"],
                         "true_label": features_dict[
                             "gold_" + features_dict["predict"]
                         ],  # the entity to which we compare the predictions

--- a/explainaboard/metric.py
+++ b/explainaboard/metric.py
@@ -576,6 +576,86 @@ class Hits(Metric):
         )
 
 
+class Hit1(Hits):
+    @classmethod
+    def default_name(cls) -> str:
+        return 'Hit1'
+
+    def calc_stats_from_data(
+        self, true_data: list, pred_data: list, config: Optional[MetricConfig] = None
+    ) -> MetricStats:  # TODO(Pengfei): why do we need the 3rd argument?
+        config = cast(HitsConfig, self._get_config(config))
+        config.hits_k = 1
+        return MetricStats(
+            np.array(
+                [
+                    (1.0 if t in p[: config.hits_k] else 0.0)
+                    for t, p in zip(true_data, pred_data)
+                ]
+            )
+        )
+
+
+class Hit2(Hits):
+    @classmethod
+    def default_name(cls) -> str:
+        return 'Hit2'
+
+    def calc_stats_from_data(
+        self, true_data: list, pred_data: list, config: Optional[MetricConfig] = None
+    ) -> MetricStats:  # TODO(Pengfei): why do we need the 3rd argument?
+        config = cast(HitsConfig, self._get_config(config))
+        config.hits_k = 2
+        return MetricStats(
+            np.array(
+                [
+                    (1.0 if t in p[: config.hits_k] else 0.0)
+                    for t, p in zip(true_data, pred_data)
+                ]
+            )
+        )
+
+
+class Hit3(Hits):
+    @classmethod
+    def default_name(cls) -> str:
+        return 'Hit3'
+
+    def calc_stats_from_data(
+        self, true_data: list, pred_data: list, config: Optional[MetricConfig] = None
+    ) -> MetricStats:  # TODO(Pengfei): why do we need the 3rd argument?
+        config = cast(HitsConfig, self._get_config(config))
+        config.hits_k = 3
+        return MetricStats(
+            np.array(
+                [
+                    (1.0 if t in p[: config.hits_k] else 0.0)
+                    for t, p in zip(true_data, pred_data)
+                ]
+            )
+        )
+
+
+class Hit5(Hits):
+    @classmethod
+    def default_name(cls) -> str:
+        return 'Hit5'
+
+    def calc_stats_from_data(
+        self, true_data: list, pred_data: list, config: Optional[MetricConfig] = None
+    ) -> MetricStats:  # TODO(Pengfei): why do we need the 3rd argument?
+        config = cast(HitsConfig, self._get_config(config))
+        config.hits_k = 5
+        return MetricStats(
+            np.array(
+                [
+                    (1.0 if t in p[: config.hits_k] else 0.0)
+                    for t, p in zip(true_data, pred_data)
+                ]
+            )
+        )
+
+
 class MeanReciprocalRank(Metric):
     """
     Calculates the mean reciprocal rank, 1/rank(true_output) where rank(true_output) is

--- a/explainaboard/processors/aspect_based_sentiment_classification.py
+++ b/explainaboard/processors/aspect_based_sentiment_classification.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from explainaboard import feature, TaskType
 from explainaboard.info import SysOutputInfo
+from explainaboard.metric import AccuracyConfig, MetricConfig
 from explainaboard.processors.processor import Processor
 from explainaboard.processors.processor_registry import register_processor
 from explainaboard.utils.spacy_loader import get_named_entities
@@ -87,8 +88,8 @@ class AspectBasedSentimentClassificationProcessor(Processor):
         )
 
     @classmethod
-    def default_metrics(cls) -> list[str]:
-        return ["Accuracy"]
+    def default_metrics(cls, language=None) -> list[MetricConfig]:
+        return [AccuracyConfig(name="Accuracy", language=language)]
 
     # --- Feature functions accessible by ExplainaboardBuilder._get_feature_func()
     def _get_sentence_length(self, sys_info: SysOutputInfo, existing_features: dict):

--- a/explainaboard/processors/extractive_qa.py
+++ b/explainaboard/processors/extractive_qa.py
@@ -7,12 +7,11 @@ from datalabs import aggregating
 
 from explainaboard import feature, TaskType
 from explainaboard.info import SysOutputInfo
-import explainaboard.metric
+from explainaboard.metric import ExactMatchQAConfig, F1ScoreQAConfig, MetricConfig
 from explainaboard.processors.processor import Processor
 from explainaboard.processors.processor_registry import register_processor
 import explainaboard.utils.feature_funcs
 from explainaboard.utils.tokenizer import Tokenizer
-from explainaboard.utils.typing_utils import unwrap
 
 
 @register_processor(TaskType.question_answering_extractive)
@@ -90,16 +89,10 @@ class QAExtractiveProcessor(Processor):
         )
 
     @classmethod
-    def default_metrics(cls) -> list[str]:
-        return ["F1ScoreQA", "ExactMatchQA"]
-
-    def _get_metrics(
-        self, sys_info: SysOutputInfo
-    ) -> list[explainaboard.metric.Metric]:
-        config = explainaboard.metric.MetricConfig(language=sys_info.language)
+    def default_metrics(cls, language=None) -> list[MetricConfig]:
         return [
-            getattr(explainaboard.metric, name)(config=config)
-            for name in unwrap(sys_info.metric_names)
+            F1ScoreQAConfig(name='F1', language=language),
+            ExactMatchQAConfig(name='ExactMatch', language=language),
         ]
 
     @aggregating()

--- a/explainaboard/processors/kg_link_tail_prediction.py
+++ b/explainaboard/processors/kg_link_tail_prediction.py
@@ -112,7 +112,14 @@ class KGLinkTailPredictionProcessor(Processor):
 
     @classmethod
     def default_metrics(cls) -> list[str]:
-        return ["Hits", "MeanReciprocalRank", "MeanRank"]
+        return [
+            "Hit1",
+            "Hit2",
+            "Hit3",
+            "Hit5",
+            "MeanReciprocalRank",
+            "MeanRank",
+        ]
 
     @classmethod
     def default_metric_configs(cls) -> dict[str, explainaboard.metric.MetricConfig]:
@@ -189,15 +196,18 @@ class KGLinkTailPredictionProcessor(Processor):
         # TODO(gneubig):
         # this will be reloaded for every dataset, maybe should be fixed for multiple
         # analysis
-        if sys_info.dataset_name != "fb15k_237":  # to be generalized
-            self.entity_type_level_map = {}
-        else:
-            file_path = cache_api.cache_online_file(
-                'http://phontron.com/download/explainaboard/pre_computed/kg/entity_type_level_map.json',  # noqa
-                'pre_computed/kg/entity_type_level_map.json',
-            )
-            with open(file_path, 'r') as file:
-                self.entity_type_level_map = json.loads(file.read())
+        # TODO(Pengfei): uncomment following code once datalab loader
+        #  of this task  is introduced
+        # if sys_info.dataset_name != "fb15k_237":  # to be generalized
+        #     self.entity_type_level_map = {}
+        # else:
+        self.entity_type_level_map = {}
+        file_path = cache_api.cache_online_file(
+            'http://phontron.com/download/explainaboard/pre_computed/kg/entity_type_level_map.json',  # noqa
+            'pre_computed/kg/entity_type_level_map.json',
+        )
+        with open(file_path, 'r') as file:
+            self.entity_type_level_map = json.loads(file.read())
 
         # Calculate statistics of training set
         self.statistics = None
@@ -229,7 +239,7 @@ https://github.com/ExpressAI/DataLab/blob/main/docs/SDK/add_new_datasets_into_sd
         # [type_level_0, type_level_1, ... type_level_6]
         # e.g. ["Thing", "Agent", "Person", None, None, None, None]
         tail_entity_type_levels = self.entity_type_level_map.get(
-            existing_features['true_tail'], None
+            existing_features['true_tail_anonymity'], None
         )
         if tail_entity_type_levels is None:
             return "-1"  # entity types not found

--- a/explainaboard/processors/machine_translation.py
+++ b/explainaboard/processors/machine_translation.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from explainaboard import feature, TaskType
 from explainaboard.info import SysOutputInfo
+from explainaboard.metric import EaaSMetricConfig, MetricConfig
 from explainaboard.processors.conditional_generation import (
     ConditionalGenerationProcessor,
 )
@@ -37,8 +38,8 @@ class MachineTranslationProcessor(ConditionalGenerationProcessor):
         return f
 
     @classmethod
-    def default_metrics(cls) -> list[str]:
-        return ["bleu"]
+    def default_metrics(cls, language=None) -> list[MetricConfig]:
+        return [EaaSMetricConfig(name='bleu', language=language)]
 
     def _get_attr_compression(self, sys_info: SysOutputInfo, existing_features: dict):
         return len(sys_info.tokenize(existing_features["source"])) / len(

--- a/explainaboard/processors/qa_multiple_choice.py
+++ b/explainaboard/processors/qa_multiple_choice.py
@@ -7,6 +7,7 @@ from datalabs import aggregating
 
 from explainaboard import feature, TaskType
 from explainaboard.info import SysOutputInfo
+from explainaboard.metric import AccuracyConfig, MetricConfig
 from explainaboard.processors.processor import Processor
 from explainaboard.processors.processor_registry import register_processor
 import explainaboard.utils.feature_funcs
@@ -89,8 +90,8 @@ class QAMultipleChoiceProcessor(Processor):
         )
 
     @classmethod
-    def default_metrics(cls) -> list[str]:
-        return ["Accuracy"]
+    def default_metrics(cls, language=None) -> list[MetricConfig]:
+        return [AccuracyConfig(name='Accuracy', language=language)]
 
     def __init__(self):
         super().__init__()

--- a/explainaboard/processors/summarization.py
+++ b/explainaboard/processors/summarization.py
@@ -12,6 +12,7 @@ import numpy
 
 from explainaboard import feature, TaskType
 from explainaboard.info import SysOutputInfo
+from explainaboard.metric import EaaSMetricConfig, MetricConfig
 from explainaboard.processors.conditional_generation import (
     ConditionalGenerationProcessor,
 )
@@ -132,8 +133,12 @@ class SummarizationProcessor(ConditionalGenerationProcessor):
         return f
 
     @classmethod
-    def default_metrics(cls) -> list[str]:
-        return ["rouge1", "rouge2", "rougeL"]
+    def default_metrics(cls, language=None) -> list[MetricConfig]:
+        return [
+            EaaSMetricConfig(name='rouge1', language=language),
+            EaaSMetricConfig(name='rouge2', language=language),
+            EaaSMetricConfig(name='rougeL', language=language),
+        ]
 
     def _get_oracle_position(self, sys_info: SysOutputInfo, existing_features: dict):
         return get_oracle(existing_features)["oracle_position"]

--- a/explainaboard/processors/text_classification.py
+++ b/explainaboard/processors/text_classification.py
@@ -7,6 +7,7 @@ from tqdm import tqdm
 
 from explainaboard import feature, TaskType
 from explainaboard.info import SysOutputInfo
+from explainaboard.metric import AccuracyConfig, MetricConfig
 from explainaboard.processors.processor import Processor
 from explainaboard.processors.processor_registry import register_processor
 import explainaboard.utils.feature_funcs
@@ -117,8 +118,8 @@ class TextClassificationProcessor(Processor):
         )
 
     @classmethod
-    def default_metrics(cls) -> list[str]:
-        return ["Accuracy"]
+    def default_metrics(cls, language=None) -> list[MetricConfig]:
+        return [AccuracyConfig(name='Accuracy', language=language)]
 
     # --- Feature functions accessible by ExplainaboardBuilder._get_feature_func()
     def _get_sentence_length(self, sys_info: SysOutputInfo, existing_features: dict):

--- a/explainaboard/processors/text_pair_classification.py
+++ b/explainaboard/processors/text_pair_classification.py
@@ -6,6 +6,7 @@ from datalabs import aggregating
 
 from explainaboard import feature, TaskType
 from explainaboard.info import SysOutputInfo
+from explainaboard.metric import AccuracyConfig, MetricConfig
 from explainaboard.processors.processor import Processor
 from explainaboard.processors.processor_registry import register_processor
 import explainaboard.utils.feature_funcs
@@ -103,8 +104,8 @@ class TextPairClassificationProcessor(Processor):
         )
 
     @classmethod
-    def default_metrics(cls) -> list[str]:
-        return ["Accuracy"]
+    def default_metrics(cls, language=None) -> list[MetricConfig]:
+        return [AccuracyConfig(name='Accuracy', language=language)]
 
     @aggregating()
     def _statistics_func(self, samples, tokenizer: Tokenizer):

--- a/explainaboard/processors/word_segmentation.py
+++ b/explainaboard/processors/word_segmentation.py
@@ -9,8 +9,12 @@ from tqdm import tqdm
 
 from explainaboard import feature
 from explainaboard.info import BucketPerformance, Performance, SysOutputInfo
-import explainaboard.metric
-from explainaboard.metric import Metric, MetricStats
+from explainaboard.metric import (
+    BMESF1ScoreConfig,
+    F1ScoreConfig,
+    MetricConfig,
+    MetricStats,
+)
 from explainaboard.processors.processor import Processor
 from explainaboard.processors.processor_registry import register_processor
 from explainaboard.tasks import TaskType
@@ -118,8 +122,8 @@ class CWSProcessor(Processor):
         )
 
     @classmethod
-    def default_metrics(cls) -> list[str]:
-        return ["F1Score"]
+    def default_metrics(cls, language=None) -> list[MetricConfig]:
+        return [BMESF1ScoreConfig(name='F1', language=language)]
 
     def _get_true_label(self, data_point: dict):
         return data_point["true_tags"]
@@ -192,13 +196,6 @@ class CWSProcessor(Processor):
         return fre_rank
 
     # --- End feature functions
-
-    # These return none because NER is not yet in the main metric interface
-    def _get_metrics(self, sys_info: SysOutputInfo) -> list[Metric]:
-        return [
-            getattr(explainaboard.metric, f'BMES{name}')()
-            for name in unwrap(sys_info.metric_names)
-        ]
 
     def _complete_span_features(self, sentence, tags, statistics=None):
 
@@ -426,12 +423,7 @@ class CWSProcessor(Processor):
             bucket performance
         """
         # getattr(explainaboard.metric, f'BIO{name}')
-        metric_names = unwrap(sys_info.metric_names)
-        config = explainaboard.metric.F1ScoreConfig(ignore_classes=['O'])
-        bucket_metrics = [
-            getattr(explainaboard.metric, f'{name}')(config=config)
-            for name in metric_names
-        ]
+        bucket_metrics = [F1ScoreConfig(name='F1', ignore_classes=['O']).to_metric()]
 
         bucket_name_to_performance = {}
         for bucket_interval, spans_true in samples_over_bucket_true.items():
@@ -472,7 +464,7 @@ class CWSProcessor(Processor):
                     metric_val.conf_interval if metric_val.conf_interval else None
                 )
                 performance = Performance(
-                    metric_name=metric.name,
+                    metric_name=metric.config.name,
                     value=metric_val.value,
                     confidence_score_low=conf_low,
                     confidence_score_high=conf_high,

--- a/explainaboard/tasks.py
+++ b/explainaboard/tasks.py
@@ -244,7 +244,14 @@ See more details about the format of upload files:
 https://github.com/neulab/ExplainaBoard/blob/main/docs/task_kg_link_tail_prediction.md
 """,
                 supported=True,
-                supported_metrics=["Hits", "MeanReciprocalRank", "MeanRank"],
+                supported_metrics=[
+                    "Hit1",
+                    "Hit2",
+                    "Hit3",
+                    "Hit5",
+                    "MeanReciprocalRank",
+                    "MeanRank",
+                ],
                 supported_formats=get_supported_file_types_for_loader(
                     TaskType.kg_link_tail_prediction
                 ),

--- a/explainaboard/tests/test_dynamic_hits_metric.py
+++ b/explainaboard/tests/test_dynamic_hits_metric.py
@@ -27,8 +27,7 @@ class TestKgLinkTailPrediction(unittest.TestCase):
         metadata = {
             "task_name": TaskType.kg_link_tail_prediction.value,
             "dataset_name": "fb15k-237-subset",
-            "metric_names": ["Hits"],
-            "metric_configs": {"Hits": HitsConfig(hits_k=4)},
+            "metric_configs": [HitsConfig(name='Hits4', hits_k=4)],
         }
 
         processor = get_processor(TaskType.kg_link_tail_prediction.value)

--- a/explainaboard/tests/test_example_code.py
+++ b/explainaboard/tests/test_example_code.py
@@ -3,6 +3,7 @@ import unittest
 from explainaboard import FileType, get_processor, Source, TaskType
 from explainaboard.loaders import get_custom_dataset_loader, get_datalab_loader
 from explainaboard.loaders.file_loader import DatalabLoaderOption
+from explainaboard.tests.utils import top_path
 
 
 class TestExampleCode(unittest.TestCase):
@@ -14,7 +15,7 @@ class TestExampleCode(unittest.TestCase):
         loader = get_datalab_loader(
             TaskType.text_classification,
             dataset=DatalabLoaderOption("sst2"),
-            output_data="./explainaboard/tests/artifacts/text_classification/"
+            output_data=f"{top_path}/explainaboard/tests/artifacts/text_classification/"
             "output_sst2.txt",
             output_source=Source.local_filesystem,
             output_file_type=FileType.text,
@@ -25,8 +26,8 @@ class TestExampleCode(unittest.TestCase):
         analysis.write_to_directory("./")
 
     def test_readme_custom_dataset(self):
-        dataset = "./explainaboard/tests/artifacts/summarization/dataset.tsv"
-        output = "./explainaboard/tests/artifacts/summarization/output.txt"
+        dataset = f"{top_path}/explainaboard/tests/artifacts/summarization/dataset.tsv"
+        output = f"{top_path}/explainaboard/tests/artifacts/summarization/output.txt"
         loader = get_custom_dataset_loader(
             TaskType.summarization, dataset_data=dataset, output_data=output
         )

--- a/explainaboard/tests/test_extractive_qa.py
+++ b/explainaboard/tests/test_extractive_qa.py
@@ -45,16 +45,17 @@ class TestExtractiveQA(unittest.TestCase):
         # analysis.write_to_directory("./")
         self.assertIsNotNone(sys_info.results.fine_grained)
         self.assertGreater(len(sys_info.results.overall), 0)
+        print(f'OVERALL={sys_info.results.overall}')
         # should be 0.6974789915966386
         self.assertAlmostEqual(
-            sys_info.results.overall["ExactMatchQA"].value,
+            sys_info.results.overall["ExactMatch"].value,
             0.6974789915966386,
             2,
             "almost equal",
         )
         # should be 0.8235975260931867
         self.assertAlmostEqual(
-            sys_info.results.overall["F1ScoreQA"].value,
+            sys_info.results.overall["F1"].value,
             0.8235975260931867,
             2,
             "almost equal",
@@ -76,27 +77,28 @@ class TestExtractiveQA(unittest.TestCase):
         metadata = {
             "task_name": TaskType.question_answering_extractive.value,
             "dataset_name": "squad",
-            "metric_names": ["F1ScoreQA", "ExactMatchQA"],
+            "metric_names": ["F1Score", "ExactMatch"],
             "language": "zh",
         }
 
         processor = get_processor(TaskType.question_answering_extractive)
 
         sys_info = processor.process(metadata, data)
+        print(f'--------- sys_info.metric_configs {sys_info.metric_configs}')
 
         # analysis.write_to_directory("./")
         self.assertIsNotNone(sys_info.results.fine_grained)
         self.assertGreater(len(sys_info.results.overall), 0)
         # 0.6285714285714286
         self.assertAlmostEqual(
-            sys_info.results.overall["ExactMatchQA"].value,
+            sys_info.results.overall["ExactMatch"].value,
             0.6285714285714286,
             2,
             "almost equal",
         )
         # 0.7559651817716333
         self.assertAlmostEqual(
-            sys_info.results.overall["F1ScoreQA"].value,
+            sys_info.results.overall["F1"].value,
             0.7559651817716333,
             2,
             "almost equal",

--- a/explainaboard/tests/test_kg_link_tail_prediction.py
+++ b/explainaboard/tests/test_kg_link_tail_prediction.py
@@ -53,6 +53,7 @@ class TestKgLinkTailPrediction(unittest.TestCase):
                 "true_head",
                 "true_link",
                 "true_tail",
+                "true_tail_anonymity",
                 "true_label",
                 "predictions",
                 "rel_type",

--- a/explainaboard/tests/test_metric.py
+++ b/explainaboard/tests/test_metric.py
@@ -16,15 +16,16 @@ from explainaboard.tests.utils import test_artifacts_path
 
 class TestMetric(unittest.TestCase):
     def test_accuracy(self):
-        metric = explainaboard.metric.Accuracy()
+        metric = explainaboard.metric.AccuracyConfig(name='Accuracy').to_metric()
         true = ['a', 'b', 'a', 'b', 'a', 'b']
         pred = ['a', 'b', 'a', 'b', 'b', 'a']
         result = metric.evaluate(true, pred, conf_value=0.05)
         self.assertAlmostEqual(result.value, 2.0 / 3.0)
 
     def test_f1_micro(self):
-        config = explainaboard.metric.F1ScoreConfig(average='micro')
-        metric = explainaboard.metric.F1Score(config=config)
+        metric = explainaboard.metric.F1ScoreConfig(
+            name='F1', average='micro'
+        ).to_metric()
         true = ['a', 'b', 'a', 'b', 'a', 'a', 'c', 'c']
         pred = ['a', 'b', 'a', 'b', 'b', 'a', 'c', 'a']
 
@@ -33,8 +34,9 @@ class TestMetric(unittest.TestCase):
         self.assertAlmostEqual(result.value, sklearn_f1)
 
     def test_f1_macro(self):
-        config = explainaboard.metric.F1ScoreConfig(average='macro')
-        metric = explainaboard.metric.F1Score(config=config)
+        metric = explainaboard.metric.F1ScoreConfig(
+            name='F1', average='macro'
+        ).to_metric()
         true = ['a', 'b', 'a', 'b', 'a', 'a', 'c', 'c']
         pred = ['a', 'b', 'a', 'b', 'b', 'a', 'c', 'a']
         sklearn_f1 = sklearn.metrics.f1_score(true, pred, average='macro')
@@ -42,14 +44,14 @@ class TestMetric(unittest.TestCase):
         self.assertAlmostEqual(result.value, sklearn_f1)
 
     def test_hits(self):
-        metric = explainaboard.metric.Hits()
+        metric = explainaboard.metric.HitsConfig(name='Hits').to_metric()
         true = ['a', 'b', 'a', 'b', 'a', 'b']
         pred = [['a', 'b'], ['c', 'd'], ['c', 'a'], ['a', 'c'], ['b', 'a'], ['a', 'b']]
         result = metric.evaluate(true, pred, conf_value=0.05)
         self.assertAlmostEqual(result.value, 4.0 / 6.0)
 
     def test_mrr(self):
-        metric = explainaboard.metric.MeanReciprocalRank()
+        metric = explainaboard.metric.MeanReciprocalRankConfig(name='MRR').to_metric()
         true = ['a', 'b', 'a', 'b', 'a', 'b']
         pred = [['a', 'b'], ['c', 'd'], ['c', 'a'], ['a', 'c'], ['b', 'a'], ['a', 'b']]
         result = metric.evaluate(true, pred, conf_value=0.05)
@@ -66,13 +68,15 @@ class TestMetric(unittest.TestCase):
             ['B-PER', 'I-PER', 'O'],
         ]
 
-        config = explainaboard.metric.F1ScoreConfig(average='micro')
-        metric = explainaboard.metric.BIOF1Score(config=config)
+        metric = explainaboard.metric.BIOF1ScoreConfig(
+            name='MicroF1', average='micro'
+        ).to_metric()
         result = metric.evaluate(true, pred, conf_value=None)
         self.assertAlmostEqual(result.value, 2.0 / 3.0)
 
-        config = explainaboard.metric.F1ScoreConfig(average='macro')
-        metric = explainaboard.metric.BIOF1Score(config=config)
+        metric = explainaboard.metric.BIOF1ScoreConfig(
+            name='MacroF1', average='macro'
+        ).to_metric()
         result = metric.evaluate(true, pred, conf_value=None)
         self.assertAlmostEqual(result.value, 3.0 / 4.0)
 
@@ -121,7 +125,10 @@ class TestMetric(unittest.TestCase):
         # Uncomment the following line to test all metrics,
         # but beware that it will be very slow
         # metric_names = eaas_client._valid_metrics
-        metrics = [explainaboard.metric.EaaSMetric(name=name) for name in metric_names]
+        metrics = [
+            explainaboard.metric.EaaSMetricConfig(name=name).to_metric()
+            for name in metric_names
+        ]
 
         # Get results for full data and half data
         half_bound = int(len(sys_output) / 2)
@@ -190,14 +197,14 @@ class TestMetric(unittest.TestCase):
         self.assertIsNotNone(sys_info.results.fine_grained)
         self.assertGreater(len(sys_info.results.overall), 0)
         self.assertAlmostEqual(
-            sys_info.results.overall["ExactMatchQA"].value,
+            sys_info.results.overall["ExactMatch"].value,
             0.6974789915966386,
             2,
             "almost equal",
         )
         # should be 0.8235975260931867
         self.assertAlmostEqual(
-            sys_info.results.overall["F1ScoreQA"].value,
+            sys_info.results.overall["F1"].value,
             0.8235975260931867,
             2,
             "almost equal",

--- a/explainaboard/tests/test_word_segmentation.py
+++ b/explainaboard/tests/test_word_segmentation.py
@@ -6,7 +6,7 @@ from explainaboard.loaders.loader_registry import get_custom_dataset_loader
 from explainaboard.tests.utils import test_artifacts_path
 
 
-class TestNER(unittest.TestCase):
+class TestWordSegmentation(unittest.TestCase):
     artifact_path = os.path.join(test_artifacts_path, "cws")
     conll_dataset = os.path.join(artifact_path, "test.tsv")
     conll_output = os.path.join(artifact_path, "prediction.tsv")

--- a/explainaboard/utils/preprocessor.py
+++ b/explainaboard/utils/preprocessor.py
@@ -52,7 +52,7 @@ class QAPreprocessor(Preprocessor):
         """Lower text and remove punctuation, articles and extra whitespace."""
 
         def remove_articles(text, lang):
-            if lang == 'en':
+            if lang == 'en' or lang is None:
                 return re.sub(r'\b(a|an|the)\b', ' ', text)
             elif lang == 'es':
                 return re.sub(r'\b(un|una|unos|unas|el|la|los|las)\b', ' ', text)
@@ -76,7 +76,7 @@ class QAPreprocessor(Preprocessor):
                 raise Exception('Unknown Language {}'.format(lang))
 
         def white_space_fix(text, lang):
-            if lang in self.WHITESPACE_LANGS:
+            if lang in self.WHITESPACE_LANGS or lang is None:
                 tokens = self.ss_tokenizer(text)
             elif lang in self.MIXED_SEGMENTATION_LANGS:
                 tokens = self.mlqa_tokenizer(text)


### PR DESCRIPTION
In the revisit-KG pull request there was a place where Hits was copy-pasted multiple times, probably because it was difficult to specify the configuration appropriately.

This PR refactors metric configuration in an attempt to make configuring metrics easier. Basically it mostly removes the dependence on metric names, and specifies everything via the MetricConfig class. This class is created first, and then you use the `to_metric()` function to get the actual metric.

This should probably supersede #256