### PR TITLE
Make CoNLL loader work with space-separated files

### DIFF
--- a/explainaboard/loaders/file_loader.py
+++ b/explainaboard/loaders/file_loader.py
@@ -236,22 +236,26 @@ class CoNLLFileLoader(FileLoader):
                     field.src_name: [] for field in self._fields
                 }  # reset
 
+        max_field: int = max([narrow(x.src_name, int) for x in self._fields])
         for line in raw_data:
             # at sentence boundary
             if line.startswith("-DOCSTART-") or line == "" or line == "\n":
                 add_sample()
             else:
                 splits = line.split("\t")
-                if len(splits) < len(self._fields):  # not separated by tabs
+                if len(splits) <= max_field:  # not separated by tabs
                     splits = line.split(" ")
-                    if len(splits) < len(self._fields):  # not separated by spaces
-                        raise ValueError(
-                            f"not enough fields for {line} (sentence index: {guid})"
-                        )
+                if len(splits) <= max_field:  # not separated by tabs or spaces
+                    raise ValueError(
+                        f"not enough fields for {line} (sentence index: {guid})"
+                    )
 
                 for field in self._fields:
+                    fid = narrow(field.src_name, int)
+                    if fid >= len(splits):
+                        raise ValueError(f'index {fid} out of range for {line}')
                     curr_sentence_fields[field.src_name].append(
-                        self.parse_data(splits[narrow(field.src_name, int)], field)
+                        self.parse_data(splits[fid], field)
                     )
 
         add_sample()  # add last example

--- a/explainaboard/loaders/file_loader.py
+++ b/explainaboard/loaders/file_loader.py
@@ -251,11 +251,8 @@ class CoNLLFileLoader(FileLoader):
                     )
 
                 for field in self._fields:
-                    fid = narrow(field.src_name, int)
-                    if fid >= len(splits):
-                        raise ValueError(f'index {fid} out of range for {line}')
                     curr_sentence_fields[field.src_name].append(
-                        self.parse_data(splits[fid], field)
+                        self.parse_data(splits[narrow(field.src_name, int)], field)
                     )
 
         add_sample()  # add last example

--- a/explainaboard/tests/artifacts/ner/dataset-space.tsv
+++ b/explainaboard/tests/artifacts/ner/dataset-space.tsv
@@ -1,0 +1,50 @@
+SOCCER O
+- O
+JAPAN B-LOC
+GET O
+LUCKY O
+WIN O
+, O
+CHINA B-PER
+IN O
+SURPRISE O
+DEFEAT O
+. O
+
+Nadim B-PER
+Ladki I-PER
+
+AL-AIN B-LOC
+, O
+United B-LOC
+Arab I-LOC
+Emirates I-LOC
+1996-12-06 O
+
+Japan B-LOC
+began O
+the O
+defence O
+of O
+their O
+Asian B-MISC
+Cup I-MISC
+title O
+with O
+a O
+lucky O
+2-1 O
+win O
+against O
+Syria B-LOC
+in O
+a O
+Group O
+C O
+championship O
+match O
+on O
+Friday O
+. O
+
+

--- a/explainaboard/tests/test_loaders.py
+++ b/explainaboard/tests/test_loaders.py
@@ -38,15 +38,23 @@ class BaseLoaderTests(TestCase):
     def test_conll_loader(self):
         tabs_path = os.path.join(test_artifacts_path, "ner", "dataset.tsv")
         spaces_path = os.path.join(test_artifacts_path, "ner", "dataset-space.tsv")
-        loader = CoNLLFileLoader(
+        loader_true = CoNLLFileLoader(
             [
                 FileLoaderField(0, 'tokens', str),
                 FileLoaderField(1, 'true_tags', str),
             ]
         )
-        tabs_data = loader.load(tabs_path, Source.local_filesystem)
-        spaces_data = loader.load(spaces_path, Source.local_filesystem)
-        self.assertEqual(tabs_data, spaces_data)
+        loader_pred = CoNLLFileLoader(
+            [
+                FileLoaderField(1, 'pred_tags', str),
+            ]
+        )
+        tabs_true = loader_true.load(tabs_path, Source.local_filesystem)
+        spaces_true = loader_true.load(spaces_path, Source.local_filesystem)
+        self.assertEqual(tabs_true, spaces_true)
+        tabs_pred = loader_pred.load(tabs_path, Source.local_filesystem)
+        spaces_pred = loader_pred.load(spaces_path, Source.local_filesystem)
+        self.assertEqual(tabs_pred, spaces_pred)
 
     def test_missing_loader(self):
         """raises ValueError because a tsv file loader is not provided by default"""

--- a/explainaboard/tests/test_loaders.py
+++ b/explainaboard/tests/test_loaders.py
@@ -3,6 +3,7 @@ from unittest import TestCase
 
 from explainaboard import FileType, get_datalab_loader, Source, TaskType
 from explainaboard.loaders.file_loader import (
+    CoNLLFileLoader,
     DatalabLoaderOption,
     FileLoaderField,
     TextFileLoader,
@@ -33,6 +34,19 @@ class BaseLoaderTests(TestCase):
         samples = [sample for sample in loader.load()]
         self.assertEqual(len(samples), 10)
         self.assertEqual(set(samples[0].keys()), {"id", "field0", "output"})
+
+    def test_conll_loader(self):
+        tabs_path = os.path.join(test_artifacts_path, "ner", "dataset.tsv")
+        spaces_path = os.path.join(test_artifacts_path, "ner", "dataset-space.tsv")
+        loader = CoNLLFileLoader(
+            [
+                FileLoaderField(0, 'tokens', str),
+                FileLoaderField(1, 'true_tags', str),
+            ]
+        )
+        tabs_data = loader.load(tabs_path, Source.local_filesystem)
+        spaces_data = loader.load(spaces_path, Source.local_filesystem)
+        self.assertEqual(tabs_data, spaces_data)
 
     def test_missing_loader(self):
         """raises ValueError because a tsv file loader is not provided by default"""


### PR DESCRIPTION
The CoNLL loader wasn't working with space-separated files for predictions, so this PR fixes and tests this.