### PR TITLE
Add support for length ratio metric

### DIFF
--- a/explainaboard/metric.py
+++ b/explainaboard/metric.py
@@ -702,6 +702,10 @@ class EaaSMetric(Metric):
         elif self.config.name == 'chrf':
             chrf_class = sacrebleu.CHRF()
             return chrf_class._compute_score_from_stats(list(agg_stats)).score / 100.0
+        elif self.config.name == 'length_ratio':
+            return float(agg_stats[0]) / agg_stats[1]
+        elif self.config.name == 'length':
+            return float(agg_stats[0])
         else:
             return float(agg_stats)
 

--- a/explainaboard/processors/conditional_generation.py
+++ b/explainaboard/processors/conditional_generation.py
@@ -177,7 +177,7 @@ class ConditionalGenerationProcessor(Processor):
 
     @classmethod
     def default_metrics(cls, language=None) -> list[MetricConfig]:
-        defaults = ['rouge1', 'rouge2', 'rougeL', 'bleu']
+        defaults = ['rouge1', 'rouge2', 'rougeL', 'bleu', 'length_ratio']
         return [EaaSMetricConfig(name=x, language=language) for x in defaults]
 
     @classmethod
@@ -197,6 +197,8 @@ class ConditionalGenerationProcessor(Processor):
             "comet",
             "mover_score",
             "prism",
+            "length",
+            "length_ratio",
         ]
         return [EaaSMetricConfig(name=x, language=language) for x in full_metrics]
 

--- a/explainaboard/processors/machine_translation.py
+++ b/explainaboard/processors/machine_translation.py
@@ -39,7 +39,10 @@ class MachineTranslationProcessor(ConditionalGenerationProcessor):
 
     @classmethod
     def default_metrics(cls, language=None) -> list[MetricConfig]:
-        return [EaaSMetricConfig(name='bleu', language=language)]
+        return [
+            EaaSMetricConfig(name='bleu', language=language),
+            EaaSMetricConfig(name='length_ratio', language=language),
+        ]
 
     def _get_attr_compression(self, sys_info: SysOutputInfo, existing_features: dict):
         return len(sys_info.tokenize(existing_features["source"])) / len(

--- a/explainaboard/processors/summarization.py
+++ b/explainaboard/processors/summarization.py
@@ -138,6 +138,7 @@ class SummarizationProcessor(ConditionalGenerationProcessor):
             EaaSMetricConfig(name='rouge1', language=language),
             EaaSMetricConfig(name='rouge2', language=language),
             EaaSMetricConfig(name='rougeL', language=language),
+            EaaSMetricConfig(name='length_ratio', language=language),
         ]
 
     def _get_oracle_position(self, sys_info: SysOutputInfo, existing_features: dict):

--- a/explainaboard/tests/test_metric.py
+++ b/explainaboard/tests/test_metric.py
@@ -121,7 +121,7 @@ class TestMetric(unittest.TestCase):
 
         # Initialize client and decide which metrics to test
         eaas_client = AsyncClient(Config())
-        metric_names = ['rouge1', 'bleu', 'chrf']
+        metric_names = ['rouge1', 'bleu', 'chrf', 'length_ratio']
         # Uncomment the following line to test all metrics,
         # but beware that it will be very slow
         # metric_names = eaas_client._valid_metrics

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
     install_requires=[
         "datalabs>=0.3.10",
         "datasets>=2.0.0",
-        "eaas>=0.3.8",
+        "eaas>=0.3.9",
         "lexicalrichness",
         "matplotlib",
         "nltk>=3.2",


### PR DESCRIPTION
This adds support for a length ratio metric, which will be newly supported by EaaS after PRs are merged there.