### PR TITLE
Fixes to condgen feature doc

### DIFF
--- a/explainaboard/processors/conditional_generation.py
+++ b/explainaboard/processors/conditional_generation.py
@@ -47,7 +47,7 @@ class ConditionalGenerationProcessor(Processor):
                 "hypothesis": feature.Value("string"),
                 "source_length": feature.Value(
                     dtype="float",
-                    description="the length of source document",
+                    description="length of the source",
                     is_bucket=True,
                     bucket_info=feature.BucketInfo(
                         method="bucket_attribute_specified_bucket_value",
@@ -57,7 +57,7 @@ class ConditionalGenerationProcessor(Processor):
                 ),
                 "reference_length": feature.Value(
                     dtype="float",
-                    description="the length of gold summary",
+                    description="length of the reference",
                     is_bucket=True,
                     bucket_info=feature.BucketInfo(
                         method="bucket_attribute_specified_bucket_value",
@@ -67,7 +67,7 @@ class ConditionalGenerationProcessor(Processor):
                 ),
                 "hypothesis_length": feature.Value(
                     dtype="float",
-                    description="the length of gold summary",
+                    description="length of the hypothesis",
                     is_bucket=True,
                     bucket_info=feature.BucketInfo(
                         method="bucket_attribute_specified_bucket_value",
@@ -77,7 +77,7 @@ class ConditionalGenerationProcessor(Processor):
                 ),
                 "src_num_oov": feature.Value(
                     dtype="float",
-                    description="the number of out-of-vocabulary words in the source",
+                    description="OOV words in the source",
                     is_bucket=True,
                     bucket_info=feature.BucketInfo(
                         method="bucket_attribute_specified_bucket_value",
@@ -89,8 +89,7 @@ class ConditionalGenerationProcessor(Processor):
                 "src_fre_rank": feature.Value(
                     dtype="float",
                     description=(
-                        "the average rank of each word in the source sentence based on "
-                        "its frequency in training set"
+                        "average training-set frequency rank of words in sentence"
                     ),
                     is_bucket=True,
                     bucket_info=feature.BucketInfo(
@@ -102,8 +101,7 @@ class ConditionalGenerationProcessor(Processor):
                 ),
                 "ref_num_oov": feature.Value(
                     dtype="float",
-                    description="the number of out-of-vocabulary words in the "
-                    "reference",
+                    description="number of OOV words in reference",
                     is_bucket=True,
                     bucket_info=feature.BucketInfo(
                         method="bucket_attribute_specified_bucket_value",
@@ -115,8 +113,7 @@ class ConditionalGenerationProcessor(Processor):
                 "ref_fre_rank": feature.Value(
                     dtype="float",
                     description=(
-                        "the average rank of each word in the reference sentence based "
-                        "on its frequency in training set"
+                        "average training-set frequency rank of words in sentence"
                     ),
                     is_bucket=True,
                     bucket_info=feature.BucketInfo(
@@ -143,12 +140,7 @@ class ConditionalGenerationProcessor(Processor):
                             ),
                             "tok_capitalness": feature.Value(
                                 dtype="string",
-                                description=(
-                                    "The capitalness of an token. For example, "
-                                    "first_caps represents only the first character of "
-                                    "the token is capital. full_caps denotes all "
-                                    "characters of the token are capital"
-                                ),
+                                description=("capitalness of token"),
                                 is_bucket=True,
                                 bucket_info=feature.BucketInfo(
                                     method="bucket_attribute_discrete_value",
@@ -158,9 +150,7 @@ class ConditionalGenerationProcessor(Processor):
                             ),
                             "tok_position": feature.Value(
                                 dtype="float",
-                                description=(
-                                    "The relative position of a token in a sentence"
-                                ),
+                                description=("relative position of token in sentence"),
                                 is_bucket=True,
                                 bucket_info=feature.BucketInfo(
                                     method="bucket_attribute_specified_bucket_value",
@@ -170,7 +160,7 @@ class ConditionalGenerationProcessor(Processor):
                             ),
                             "tok_chars": feature.Value(
                                 dtype="float",
-                                description="The number of characters in a token",
+                                description="number of characters in the token",
                                 is_bucket=True,
                                 bucket_info=feature.BucketInfo(
                                     method="bucket_attribute_specified_bucket_value",


### PR DESCRIPTION
The conditional generation feature documentation was (1) wrong in some places, and (2) very verbose in others. This fixes the errors and tries to make it as concise as possible to save screen space in our analyses.