### PR TITLE
added open_cached_file function to cache_api.py

### DIFF
--- a/explainaboard/utils/cache_api.py
+++ b/explainaboard/utils/cache_api.py
@@ -88,3 +88,14 @@ def cache_online_file(
         os.makedirs(path_dir)
     urllib.request.urlretrieve(online_path, file_path)
     return file_path
+
+
+def open_cached_file(relative_path, lifetime):
+    sanitized_path = sanitize_path(relative_path)
+    file_path = os.path.join(get_cache_dir(), sanitized_path)
+    if os.path.exists(file_path):
+        mod_time = datetime.datetime.fromtimestamp(os.path.getmtime(file_path))
+        age = datetime.datetime.now() - mod_time
+        if lifetime is None or age < lifetime:
+            return file_path
+    return None


### PR DESCRIPTION
I added an `open_cached_file` function to cache_api.py; this is done in order to better cache benchmark results (goes hand in hand with changes made in explainaboard_web). The `open_cached_file` function does the following:
opens the file only if it exists at get_cache_dir() + relative_path and is no older than timeout. Otherwise it will return None.