### PR TITLE
fix-bugs-trainingset-dependent-features

### DIFF
--- a/explainaboard/processors/cloze_generative.py
+++ b/explainaboard/processors/cloze_generative.py
@@ -12,6 +12,7 @@ from explainaboard.metrics.metric import MetricConfig
 from explainaboard.processors.processor import Processor
 from explainaboard.processors.processor_registry import register_processor
 import explainaboard.utils.feature_funcs
+from explainaboard.utils.feature_funcs import accumulate_vocab_from_samples
 from explainaboard.utils.typing_utils import unwrap
 
 
@@ -152,25 +153,27 @@ class ClozeGenerativeProcessor(Processor):
     def _get_answer_length(self, sys_info: SysOutputInfo, existing_features: dict):
         return len(unwrap(sys_info.target_tokenizer)(existing_features["answers"]))
 
-    # training set dependent features
+        # training set dependent features
+
     def _get_num_oov(
         self, sys_info: SysOutputInfo, existing_features: dict, statistics: Any
     ):
         return explainaboard.utils.feature_funcs.feat_num_oov(
             existing_features,
-            statistics,
+            statistics['source_vocab'],
             lambda x: x['context'],
             unwrap(sys_info.source_tokenizer),
         )
 
-    # training set dependent features
-    # (this could be merged into the above one for further optimization)
+        # training set dependent features
+        # (this could be merged into the above one for further optimization)
+
     def _get_fre_rank(
         self, sys_info: SysOutputInfo, existing_features: dict, statistics: Any
     ):
         return explainaboard.utils.feature_funcs.feat_freq_rank(
             existing_features,
-            statistics,
+            statistics['source_vocab_rank'],
             lambda x: x['context'],
             unwrap(sys_info.source_tokenizer),
         )
@@ -195,6 +198,8 @@ class ClozeGenerativeProcessor(Processor):
 
     @aggregating()
     def _statistics_func(self, samples: Iterator, sys_info: SysOutputInfo):
-        return explainaboard.utils.feature_funcs.accumulate_vocab_from_samples(
+        source_vocab, source_vocab_rank = accumulate_vocab_from_samples(
             samples, lambda x: x['context'], unwrap(sys_info.source_tokenizer)
         )
+
+        return {'source_vocab': source_vocab, 'source_vocab_rank': source_vocab_rank}

--- a/explainaboard/processors/conditional_generation.py
+++ b/explainaboard/processors/conditional_generation.py
@@ -607,15 +607,15 @@ class ConditionalGenerationProcessor(Processor):
     @aggregating()
     def _statistics_func(self, samples: Iterator, sys_info: SysOutputInfo):
         source_vocab, source_vocab_rank = accumulate_vocab_from_samples(
-                samples, lambda x: x['source'], unwrap(sys_info.source_tokenizer)
-            )
+            samples, lambda x: x['source'], unwrap(sys_info.source_tokenizer)
+        )
 
         target_vocab, target_vocab_rank = accumulate_vocab_from_samples(
-                samples, lambda x: x['reference'], unwrap(sys_info.target_tokenizer)
-            )
+            samples, lambda x: x['reference'], unwrap(sys_info.target_tokenizer)
+        )
         return {
             'source_vocab': source_vocab,
             'source_vocab_rank': source_vocab_rank,
             'target_vocab': target_vocab,
-            'target_vocab_rank':target_vocab_rank
+            'target_vocab_rank': target_vocab_rank,
         }

--- a/explainaboard/processors/conditional_generation.py
+++ b/explainaboard/processors/conditional_generation.py
@@ -264,7 +264,7 @@ class ConditionalGenerationProcessor(Processor):
     ):
         return explainaboard.utils.feature_funcs.feat_freq_rank(
             existing_features,
-            statistics['source_vocab'],
+            statistics['source_vocab_rank'],
             lambda x: x['source'],
             unwrap(sys_info.source_tokenizer),
         )
@@ -284,7 +284,7 @@ class ConditionalGenerationProcessor(Processor):
     ):
         return explainaboard.utils.feature_funcs.feat_freq_rank(
             existing_features,
-            statistics['target_vocab'],
+            statistics['target_vocab_rank'],
             lambda x: x['reference'],
             unwrap(sys_info.target_tokenizer),
         )
@@ -606,11 +606,16 @@ class ConditionalGenerationProcessor(Processor):
 
     @aggregating()
     def _statistics_func(self, samples: Iterator, sys_info: SysOutputInfo):
-        return {
-            'source_vocab': accumulate_vocab_from_samples(
+        source_vocab, source_vocab_rank = accumulate_vocab_from_samples(
                 samples, lambda x: x['source'], unwrap(sys_info.source_tokenizer)
-            ),
-            'target_vocab': accumulate_vocab_from_samples(
+            )
+
+        target_vocab, target_vocab_rank = accumulate_vocab_from_samples(
                 samples, lambda x: x['reference'], unwrap(sys_info.target_tokenizer)
-            ),
+            )
+        return {
+            'source_vocab': source_vocab,
+            'source_vocab_rank': source_vocab_rank,
+            'target_vocab': target_vocab,
+            'target_vocab_rank':target_vocab_rank
         }

--- a/explainaboard/processors/machine_translation.py
+++ b/explainaboard/processors/machine_translation.py
@@ -77,15 +77,25 @@ class MachineTranslationProcessor(ConditionalGenerationProcessor):
             )
         src = FileLoaderField(('translation', sys_info.source_language), '', str)
         trg = FileLoaderField(('translation', sys_info.target_language), '', str)
-        return {
-            'source_vocab': accumulate_vocab_from_samples(
+
+
+        source_vocab, source_vocab_rank = accumulate_vocab_from_samples(
                 samples,
                 lambda x: FileLoader.find_field(x, src),
                 unwrap(sys_info.source_tokenizer),
-            ),
-            'target_vocab': accumulate_vocab_from_samples(
+            )
+
+        target_vocab, target_vocab_rank = accumulate_vocab_from_samples(
                 samples,
                 lambda x: FileLoader.find_field(x, trg),
                 unwrap(sys_info.target_tokenizer),
-            ),
+            )
+        return {
+            'source_vocab': source_vocab,
+            'source_vocab_rank': source_vocab_rank,
+            'target_vocab': target_vocab,
+            'target_vocab_rank':target_vocab_rank
         }
+
+
+

--- a/explainaboard/processors/machine_translation.py
+++ b/explainaboard/processors/machine_translation.py
@@ -78,24 +78,20 @@ class MachineTranslationProcessor(ConditionalGenerationProcessor):
         src = FileLoaderField(('translation', sys_info.source_language), '', str)
         trg = FileLoaderField(('translation', sys_info.target_language), '', str)
 
-
         source_vocab, source_vocab_rank = accumulate_vocab_from_samples(
-                samples,
-                lambda x: FileLoader.find_field(x, src),
-                unwrap(sys_info.source_tokenizer),
-            )
+            samples,
+            lambda x: FileLoader.find_field(x, src),
+            unwrap(sys_info.source_tokenizer),
+        )
 
         target_vocab, target_vocab_rank = accumulate_vocab_from_samples(
-                samples,
-                lambda x: FileLoader.find_field(x, trg),
-                unwrap(sys_info.target_tokenizer),
-            )
+            samples,
+            lambda x: FileLoader.find_field(x, trg),
+            unwrap(sys_info.target_tokenizer),
+        )
         return {
             'source_vocab': source_vocab,
             'source_vocab_rank': source_vocab_rank,
             'target_vocab': target_vocab,
-            'target_vocab_rank':target_vocab_rank
+            'target_vocab_rank': target_vocab_rank,
         }
-
-
-

--- a/explainaboard/processors/qa_multiple_choice.py
+++ b/explainaboard/processors/qa_multiple_choice.py
@@ -12,6 +12,7 @@ from explainaboard.metrics.metric import MetricConfig
 from explainaboard.processors.processor import Processor
 from explainaboard.processors.processor_registry import register_processor
 import explainaboard.utils.feature_funcs
+from explainaboard.utils.feature_funcs import accumulate_vocab_from_samples
 from explainaboard.utils.typing_utils import unwrap
 
 
@@ -132,7 +133,7 @@ class QAMultipleChoiceProcessor(Processor):
     ):
         return explainaboard.utils.feature_funcs.feat_num_oov(
             existing_features,
-            statistics,
+            statistics['source_vocab'],
             lambda x: x['context'],
             unwrap(sys_info.source_tokenizer),
         )
@@ -144,7 +145,7 @@ class QAMultipleChoiceProcessor(Processor):
     ):
         return explainaboard.utils.feature_funcs.feat_freq_rank(
             existing_features,
-            statistics,
+            statistics['source_vocab_rank'],
             lambda x: x['context'],
             unwrap(sys_info.source_tokenizer),
         )
@@ -169,6 +170,8 @@ class QAMultipleChoiceProcessor(Processor):
 
     @aggregating()
     def _statistics_func(self, samples: Iterator, sys_info: SysOutputInfo):
-        return explainaboard.utils.feature_funcs.accumulate_vocab_from_samples(
+        source_vocab, source_vocab_rank = accumulate_vocab_from_samples(
             samples, lambda x: x['context'], unwrap(sys_info.source_tokenizer)
         )
+
+        return {'source_vocab': source_vocab, 'source_vocab_rank': source_vocab_rank}

--- a/explainaboard/processors/summarization.py
+++ b/explainaboard/processors/summarization.py
@@ -18,7 +18,7 @@ from explainaboard.processors.conditional_generation import (
     ConditionalGenerationProcessor,
 )
 from explainaboard.processors.processor_registry import register_processor
-import explainaboard.utils.feature_funcs
+from explainaboard.utils.feature_funcs import accumulate_vocab_from_samples
 from explainaboard.utils.py_utils import hash_dict
 from explainaboard.utils.typing_utils import unwrap
 
@@ -106,26 +106,26 @@ class SummarizationProcessor(ConditionalGenerationProcessor):
                             setting=(),
                         ),
                     ),
-                    "oracle_score": feature.Value(
-                        dtype="float",
-                        description="the sample-level oracle score",
-                        is_bucket=True,
-                        bucket_info=feature.BucketInfo(
-                            method="bucket_attribute_specified_bucket_value",
-                            number=4,
-                            setting=(),
-                        ),
-                    ),
-                    "oracle_position": feature.Value(
-                        dtype="float",
-                        description="the sample-level oracle position",
-                        is_bucket=True,
-                        bucket_info=feature.BucketInfo(
-                            method="bucket_attribute_specified_bucket_value",
-                            number=4,
-                            setting=(),
-                        ),
-                    ),
+                    # "oracle_score": feature.Value(
+                    #     dtype="float",
+                    #     description="the sample-level oracle score",
+                    #     is_bucket=True,
+                    #     bucket_info=feature.BucketInfo(
+                    #         method="bucket_attribute_specified_bucket_value",
+                    #         number=4,
+                    #         setting=(),
+                    #     ),
+                    # ),
+                    # "oracle_position": feature.Value(
+                    #     dtype="float",
+                    #     description="the sample-level oracle position",
+                    #     is_bucket=True,
+                    #     bucket_info=feature.BucketInfo(
+                    #         method="bucket_attribute_specified_bucket_value",
+                    #         number=4,
+                    #         setting=(),
+                    #     ),
+                    # ),
                 }
             )
         )
@@ -190,6 +190,16 @@ class SummarizationProcessor(ConditionalGenerationProcessor):
 
     @aggregating()
     def _statistics_func(self, samples: Iterator, sys_info: SysOutputInfo):
-        return explainaboard.utils.feature_funcs.accumulate_vocab_from_samples(
+        source_vocab, source_vocab_rank = accumulate_vocab_from_samples(
+            samples, lambda x: x['text'], unwrap(sys_info.source_tokenizer)
+        )
+
+        target_vocab, target_vocab_rank = accumulate_vocab_from_samples(
             samples, lambda x: x['summary'], unwrap(sys_info.target_tokenizer)
         )
+        return {
+            'source_vocab': source_vocab,
+            'source_vocab_rank': source_vocab_rank,
+            'target_vocab': target_vocab,
+            'target_vocab_rank': target_vocab_rank,
+        }

--- a/explainaboard/processors/summarization.py
+++ b/explainaboard/processors/summarization.py
@@ -106,6 +106,8 @@ class SummarizationProcessor(ConditionalGenerationProcessor):
                             setting=(),
                         ),
                     ),
+                    # TODO: these are commented out because the
+                    #  implementation is currently
                     # "oracle_score": feature.Value(
                     #     dtype="float",
                     #     description="the sample-level oracle score",

--- a/explainaboard/processors/text_pair_classification.py
+++ b/explainaboard/processors/text_pair_classification.py
@@ -118,11 +118,22 @@ class TextPairClassificationProcessor(Processor):
 
         source_vocab, source_vocab_rank = accumulate_vocab_from_samples(
             samples,
-            lambda x: x['text1'] + x["text2"],
+            lambda x: x['text1'],
             unwrap(sys_info.source_tokenizer),
         )
 
-        return {'source_vocab': source_vocab, 'source_vocab_rank': source_vocab_rank}
+        target_vocab, target_vocab_rank = accumulate_vocab_from_samples(
+            samples,
+            lambda x: x["text2"],
+            unwrap(sys_info.target_tokenizer),
+        )
+
+        return {
+            'source_vocab': source_vocab,
+            'source_vocab_rank': source_vocab_rank,
+            'target_vocab': target_vocab,
+            'target_vocab_rank': target_vocab_rank,
+        }
 
     # --- Feature functions accessible by ExplainaboardBuilder._get_feature_func()
     def _get_similarity(self, sys_info: SysOutputInfo, existing_features: dict):
@@ -157,7 +168,7 @@ class TextPairClassificationProcessor(Processor):
             unwrap(sys_info.source_tokenizer),
         ) + feat_num_oov(
             existing_features,
-            statistics['source_vocab'],
+            statistics['target_vocab'],
             lambda x: x['text2'],
             unwrap(sys_info.target_tokenizer),
         )
@@ -174,7 +185,7 @@ class TextPairClassificationProcessor(Processor):
             unwrap(sys_info.source_tokenizer),
         ) + feat_freq_rank(
             existing_features,
-            statistics['source_vocab_rank'],
+            statistics['target_vocab_rank'],
             lambda x: x['text2'],
             unwrap(sys_info.target_tokenizer),
         )

--- a/explainaboard/processors/text_pair_classification.py
+++ b/explainaboard/processors/text_pair_classification.py
@@ -157,7 +157,7 @@ class TextPairClassificationProcessor(Processor):
             unwrap(sys_info.source_tokenizer),
         ) + feat_num_oov(
             existing_features,
-            statistics['target_vocab'],
+            statistics['source_vocab'],
             lambda x: x['text2'],
             unwrap(sys_info.target_tokenizer),
         )

--- a/explainaboard/processors/text_pair_classification.py
+++ b/explainaboard/processors/text_pair_classification.py
@@ -115,14 +115,14 @@ class TextPairClassificationProcessor(Processor):
 
     @aggregating()
     def _statistics_func(self, samples, sys_info: SysOutputInfo):
-        return {
-            'source_vocab': accumulate_vocab_from_samples(
-                samples, lambda x: x['text1'], unwrap(sys_info.source_tokenizer)
-            ),
-            'target_vocab': accumulate_vocab_from_samples(
-                samples, lambda x: x['text2'], unwrap(sys_info.target_tokenizer)
-            ),
-        }
+
+        source_vocab, source_vocab_rank = accumulate_vocab_from_samples(
+            samples,
+            lambda x: x['text1'] + x["text2"],
+            unwrap(sys_info.source_tokenizer),
+        )
+
+        return {'source_vocab': source_vocab, 'source_vocab_rank': source_vocab_rank}
 
     # --- Feature functions accessible by ExplainaboardBuilder._get_feature_func()
     def _get_similarity(self, sys_info: SysOutputInfo, existing_features: dict):
@@ -169,12 +169,12 @@ class TextPairClassificationProcessor(Processor):
     ):
         return feat_freq_rank(
             existing_features,
-            statistics['source_vocab'],
+            statistics['source_vocab_rank'],
             lambda x: x['text1'],
             unwrap(sys_info.source_tokenizer),
         ) + feat_freq_rank(
             existing_features,
-            statistics['target_vocab'],
+            statistics['source_vocab_rank'],
             lambda x: x['text2'],
             unwrap(sys_info.target_tokenizer),
         )

--- a/explainaboard/tests/test_summarization.py
+++ b/explainaboard/tests/test_summarization.py
@@ -2,10 +2,8 @@ import os
 import unittest
 
 from explainaboard import FileType, get_processor, Source, TaskType
-from explainaboard.loaders import get_custom_dataset_loader, get_datalab_loader
-from explainaboard.loaders.file_loader import DatalabLoaderOption
+from explainaboard.loaders import get_custom_dataset_loader
 from explainaboard.tests.utils import test_artifacts_path
-from explainaboard.utils import cache_api
 
 
 class TestSummarization(unittest.TestCase):
@@ -70,33 +68,34 @@ class TestSummarization(unittest.TestCase):
         # condgen features are a subset of sum features
         self.assertDictEqual(sum_features, {**sum_features, **condgen_features_1})
 
-    def test_datalab_loader(self):
-
-        json_output_customized = cache_api.cache_online_file(
-            'http://www.phontron.com/download/cnndm-bart-output.txt',
-            'predictions/summarization/cnndm-bart-output.txt',
-        )
-
-        loader = get_datalab_loader(
-            TaskType.summarization,
-            dataset=DatalabLoaderOption("cnn_dailymail", "3.0.0"),
-            output_data=json_output_customized,
-            output_source=Source.local_filesystem,
-            output_file_type=FileType.text,
-        )
-        data = loader.load()
-
-        metadata = {
-            "task_name": TaskType.summarization.value,
-            "dataset_name": "cnn_dailymail",
-            "sub_dataset_name": "3.0.0",
-            "metric_names": ["rouge1"],
-        }
-        processor = get_processor(TaskType.summarization)
-        sys_info = processor.process(metadata, data)
-
-        self.assertIsNotNone(sys_info.results.fine_grained)
-        self.assertGreater(len(sys_info.results.overall), 0)
+    # Commented out following code since it's too slow for unittest
+    # def test_datalab_loader(self):
+    #
+    #     json_output_customized = cache_api.cache_online_file(
+    #         'http://www.phontron.com/download/cnndm-bart-output.txt',
+    #         'predictions/summarization/cnndm-bart-output.txt',
+    #     )
+    #
+    #     loader = get_datalab_loader(
+    #         TaskType.summarization,
+    #         dataset=DatalabLoaderOption("cnn_dailymail", "3.0.0"),
+    #         output_data=json_output_customized,
+    #         output_source=Source.local_filesystem,
+    #         output_file_type=FileType.text,
+    #     )
+    #     data = loader.load()
+    #
+    #     metadata = {
+    #         "task_name": TaskType.summarization.value,
+    #         "dataset_name": "cnn_dailymail",
+    #         "sub_dataset_name": "3.0.0",
+    #         "metric_names": ["rouge1"],
+    #     }
+    #     processor = get_processor(TaskType.summarization)
+    #     sys_info = processor.process(metadata, data)
+    #
+    #     self.assertIsNotNone(sys_info.results.fine_grained)
+    #     self.assertGreater(len(sys_info.results.overall), 0)
 
 
 if __name__ == '__main__':

--- a/explainaboard/tests/test_summarization.py
+++ b/explainaboard/tests/test_summarization.py
@@ -2,8 +2,10 @@ import os
 import unittest
 
 from explainaboard import FileType, get_processor, Source, TaskType
-from explainaboard.loaders import get_custom_dataset_loader
+from explainaboard.loaders import get_custom_dataset_loader, get_datalab_loader
+from explainaboard.loaders.file_loader import DatalabLoaderOption
 from explainaboard.tests.utils import test_artifacts_path
+from explainaboard.utils import cache_api
 
 
 class TestSummarization(unittest.TestCase):
@@ -67,6 +69,34 @@ class TestSummarization(unittest.TestCase):
         self.assertDictEqual(condgen_features_1, condgen_features_2)
         # condgen features are a subset of sum features
         self.assertDictEqual(sum_features, {**sum_features, **condgen_features_1})
+
+    def test_datalab_loader(self):
+
+        json_output_customized = cache_api.cache_online_file(
+            'http://www.phontron.com/download/cnndm-bart-output.txt',
+            'predictions/summarization/cnndm-bart-output.txt',
+        )
+
+        loader = get_datalab_loader(
+            TaskType.summarization,
+            dataset=DatalabLoaderOption("cnn_dailymail", "3.0.0"),
+            output_data=json_output_customized,
+            output_source=Source.local_filesystem,
+            output_file_type=FileType.text,
+        )
+        data = loader.load()
+
+        metadata = {
+            "task_name": TaskType.summarization.value,
+            "dataset_name": "cnn_dailymail",
+            "sub_dataset_name": "3.0.0",
+            "metric_names": ["rouge1"],
+        }
+        processor = get_processor(TaskType.summarization)
+        sys_info = processor.process(metadata, data)
+
+        self.assertIsNotNone(sys_info.results.fine_grained)
+        self.assertGreater(len(sys_info.results.overall), 0)
 
 
 if __name__ == '__main__':

--- a/explainaboard/tests/test_summarization.py
+++ b/explainaboard/tests/test_summarization.py
@@ -2,8 +2,10 @@ import os
 import unittest
 
 from explainaboard import FileType, get_processor, Source, TaskType
-from explainaboard.loaders import get_custom_dataset_loader
-from explainaboard.tests.utils import test_artifacts_path
+from explainaboard.loaders import get_custom_dataset_loader, get_datalab_loader
+from explainaboard.loaders.file_loader import DatalabLoaderOption
+from explainaboard.tests.utils import OPTIONAL_TEST_SUITES, test_artifacts_path
+from explainaboard.utils import cache_api
 
 
 class TestSummarization(unittest.TestCase):
@@ -69,33 +71,34 @@ class TestSummarization(unittest.TestCase):
         self.assertDictEqual(sum_features, {**sum_features, **condgen_features_1})
 
     # Commented out following code since it's too slow for unittest
-    # def test_datalab_loader(self):
-    #
-    #     json_output_customized = cache_api.cache_online_file(
-    #         'http://www.phontron.com/download/cnndm-bart-output.txt',
-    #         'predictions/summarization/cnndm-bart-output.txt',
-    #     )
-    #
-    #     loader = get_datalab_loader(
-    #         TaskType.summarization,
-    #         dataset=DatalabLoaderOption("cnn_dailymail", "3.0.0"),
-    #         output_data=json_output_customized,
-    #         output_source=Source.local_filesystem,
-    #         output_file_type=FileType.text,
-    #     )
-    #     data = loader.load()
-    #
-    #     metadata = {
-    #         "task_name": TaskType.summarization.value,
-    #         "dataset_name": "cnn_dailymail",
-    #         "sub_dataset_name": "3.0.0",
-    #         "metric_names": ["rouge1"],
-    #     }
-    #     processor = get_processor(TaskType.summarization)
-    #     sys_info = processor.process(metadata, data)
-    #
-    #     self.assertIsNotNone(sys_info.results.fine_grained)
-    #     self.assertGreater(len(sys_info.results.overall), 0)
+    @unittest.skipUnless('test_sum' in OPTIONAL_TEST_SUITES, reason='time consuming')
+    def test_datalab_loader(self):
+
+        json_output_customized = cache_api.cache_online_file(
+            'http://www.phontron.com/download/cnndm-bart-output.txt',
+            'predictions/summarization/cnndm-bart-output.txt',
+        )
+
+        loader = get_datalab_loader(
+            TaskType.summarization,
+            dataset=DatalabLoaderOption("cnn_dailymail", "3.0.0"),
+            output_data=json_output_customized,
+            output_source=Source.local_filesystem,
+            output_file_type=FileType.text,
+        )
+        data = loader.load()
+
+        metadata = {
+            "task_name": TaskType.summarization.value,
+            "dataset_name": "cnn_dailymail",
+            "sub_dataset_name": "3.0.0",
+            "metric_names": ["rouge1"],
+        }
+        processor = get_processor(TaskType.summarization)
+        sys_info = processor.process(metadata, data)
+
+        self.assertIsNotNone(sys_info.results.fine_grained)
+        self.assertGreater(len(sys_info.results.overall), 0)
 
 
 if __name__ == '__main__':

--- a/explainaboard/utils/feature_funcs.py
+++ b/explainaboard/utils/feature_funcs.py
@@ -61,10 +61,12 @@ def accumulate_vocab_from_samples(
         for rank, key in enumerate(sorted(set(vocab.values()), reverse=True), 1)
     }
     vocab_rank = {k: sorted_dict[v] for k, v in vocab.items()}
-    return {
-        "vocab": vocab,
-        "vocab_rank": vocab_rank,
-    }
+    # return vocab
+    return vocab, vocab_rank
+    # return {
+    #     "vocab": vocab,
+    #     "vocab_rank": vocab_rank,
+    # }
 
 
 def feat_freq_rank(
@@ -77,10 +79,10 @@ def feat_freq_rank(
 
     tokens = tokenizer(text_from_sample(existing_features))
     for w in tokens:
-        if w not in statistics['vocab_rank']:
-            fre_rank += len(statistics['vocab_rank'])
+        if w not in statistics:
+            fre_rank += len(statistics)
         else:
-            fre_rank += statistics['vocab_rank'][w]
+            fre_rank += statistics[w]
 
     return fre_rank * 1.0 / len(tokens)
 
@@ -93,7 +95,7 @@ def feat_num_oov(
 ):
     num_oov = 0
     for w in tokenizer(text_from_sample(existing_features)):
-        if w not in statistics['vocab'].keys():
+        if w not in statistics.keys():
             num_oov += 1
     return num_oov
 

--- a/explainaboard/utils/feature_funcs.py
+++ b/explainaboard/utils/feature_funcs.py
@@ -61,12 +61,7 @@ def accumulate_vocab_from_samples(
         for rank, key in enumerate(sorted(set(vocab.values()), reverse=True), 1)
     }
     vocab_rank = {k: sorted_dict[v] for k, v in vocab.items()}
-    # return vocab
     return vocab, vocab_rank
-    # return {
-    #     "vocab": vocab,
-    #     "vocab_rank": vocab_rank,
-    # }
 
 
 def feat_freq_rank(


### PR DESCRIPTION
#### Problem description:  explainaboard_web failed to deal with system outputs of generation tasks from named datasets -> training set dependent features are not supported -> SDK bug

This PR fixed this, but it is still very slow when dealing with system outputs from the test set of `cnn_dailymail`