### PR TITLE
introduce unwrap_or and remove Metric._get_config

### DIFF
--- a/explainaboard/metrics/extractive_qa.py
+++ b/explainaboard/metrics/extractive_qa.py
@@ -10,6 +10,7 @@ import numpy as np
 from explainaboard.metrics.metric import Metric, MetricConfig, MetricStats
 from explainaboard.metrics.registry import register_metric_config
 from explainaboard.utils.preprocessor import ExtractiveQAPreprocessor, Preprocessor
+from explainaboard.utils.typing_utils import unwrap_or
 
 
 class ExtractiveQAMetric(Metric):
@@ -26,7 +27,7 @@ class ExtractiveQAMetric(Metric):
         config: Optional[MetricConfig] = None,
     ) -> MetricStats:
         true_data = [[x] if isinstance(x, str) else x for x in true_data]
-        config = self._get_config(config)
+        config = unwrap_or(config, self.config)
         preprocessor = ExtractiveQAPreprocessor(language=config.source_language)
         return MetricStats(
             np.array(

--- a/explainaboard/metrics/f1_score.py
+++ b/explainaboard/metrics/f1_score.py
@@ -9,6 +9,7 @@ import numpy as np
 from explainaboard.metrics.metric import Metric, MetricConfig, MetricStats
 from explainaboard.metrics.registry import register_metric_config
 from explainaboard.utils.span_utils import BIOSpanOps, BMESSpanOps, SpanOps
+from explainaboard.utils.typing_utils import unwrap_or
 
 
 @dataclass
@@ -47,7 +48,7 @@ class F1Score(Metric):
             * c*stat_mult + 3: number of matches with the predicted output
                 (when self.separate_match=True only)
         """
-        config = cast(F1ScoreConfig, self._get_config(config))
+        config = cast(F1ScoreConfig, unwrap_or(config, self.config))
         stat_mult: int = 4 if config.separate_match else 3
 
         id_map: dict[str, int] = {}
@@ -84,7 +85,7 @@ class F1Score(Metric):
         if agg_stats.ndim == 1:
             agg_stats = agg_stats.reshape((1, agg_stats.shape[0]))
 
-        config = cast(F1ScoreConfig, self._get_config(config))
+        config = cast(F1ScoreConfig, unwrap_or(config, self.config))
         supported_averages = {'micro', 'macro'}
         stat_mult: int = 4 if config.separate_match else 3
         if config.average not in supported_averages:

--- a/explainaboard/metrics/log_prob.py
+++ b/explainaboard/metrics/log_prob.py
@@ -7,6 +7,7 @@ import numpy as np
 
 from explainaboard.metrics.metric import Metric, MetricConfig, MetricStats
 from explainaboard.metrics.registry import register_metric_config
+from explainaboard.utils.typing_utils import unwrap_or
 
 
 @dataclass
@@ -53,7 +54,7 @@ class LogProb(Metric):
         """
         if agg_stats.ndim == 1:
             agg_stats = agg_stats.reshape((1, agg_stats.shape[0]))
-        config = cast(LogProbConfig, self._get_config(config))
+        config = cast(LogProbConfig, unwrap_or(config, self.config))
         val = agg_stats if agg_stats.size == 1 else agg_stats[:, 0] / agg_stats[:, 1]
         if config.ppl:
             val = np.exp(-val)

--- a/explainaboard/metrics/metric.py
+++ b/explainaboard/metrics/metric.py
@@ -7,7 +7,7 @@ from typing import Optional, Union
 import numpy as np
 from scipy.stats import t as stats_t
 
-from explainaboard.utils.typing_utils import unwrap
+from explainaboard.utils.typing_utils import unwrap, unwrap_or
 
 
 @dataclass
@@ -121,15 +121,6 @@ class Metric:
         :param config: The configuration for the metric
         """
         self.config: MetricConfig = config
-
-    def _get_config(self, config: Optional[MetricConfig] = None) -> MetricConfig:
-        """
-        Get the configuration or overwritten configuration
-        :param config: Optional configuration to override the default configuration
-        :return: Either the default or overridden configuration
-        """
-        ret_config: MetricConfig = unwrap(config) if config is not None else self.config
-        return ret_config
 
     @abc.abstractmethod
     def calc_stats_from_data(
@@ -246,13 +237,13 @@ class Metric:
         :param config: a configuration to over-ride the default for this object
         :return: a resulting metric value
         """
-        config = self._get_config(config)
+        actual_config = unwrap_or(config, self.config)
         agg_stats = self.aggregate_stats(stats)
-        value = self.calc_metric_from_aggregate(agg_stats, config)
+        value = self.calc_metric_from_aggregate(agg_stats, actual_config)
         conf_interval = (
             self.calc_confidence_interval(stats, conf_value) if conf_value else None
         )
-        return MetricResult(config, float(value), conf_interval, conf_value)
+        return MetricResult(actual_config, float(value), conf_interval, conf_value)
 
     def evaluate(
         self,

--- a/explainaboard/metrics/ranking.py
+++ b/explainaboard/metrics/ranking.py
@@ -7,6 +7,7 @@ import numpy as np
 
 from explainaboard.metrics.metric import Metric, MetricConfig, MetricStats
 from explainaboard.metrics.registry import register_metric_config
+from explainaboard.utils.typing_utils import unwrap_or
 
 
 @dataclass
@@ -27,7 +28,7 @@ class Hits(Metric):
     def calc_stats_from_data(
         self, true_data: list, pred_data: list, config: Optional[MetricConfig] = None
     ) -> MetricStats:  # TODO(Pengfei): why do we need the 3rd argument?
-        config = cast(HitsConfig, self._get_config(config))
+        config = cast(HitsConfig, unwrap_or(config, self.config))
         return MetricStats(
             np.array(
                 [
@@ -40,7 +41,7 @@ class Hits(Metric):
     def calc_stats_from_rank(
         self, rank_data: list, config: Optional[MetricConfig] = None
     ) -> MetricStats:  # TODO(Pengfei): why do we need the 3rd argument?
-        config = cast(HitsConfig, self._get_config(config))
+        config = cast(HitsConfig, unwrap_or(self.config))
         return MetricStats(
             np.array([(1.0 if rank <= config.hits_k else 0.0) for rank in rank_data])
         )

--- a/explainaboard/metrics/ranking.py
+++ b/explainaboard/metrics/ranking.py
@@ -41,7 +41,7 @@ class Hits(Metric):
     def calc_stats_from_rank(
         self, rank_data: list, config: Optional[MetricConfig] = None
     ) -> MetricStats:  # TODO(Pengfei): why do we need the 3rd argument?
-        config = cast(HitsConfig, unwrap_or(self.config))
+        config = cast(HitsConfig, unwrap_or(config, self.config))
         return MetricStats(
             np.array([(1.0 if rank <= config.hits_k else 0.0) for rank in rank_data])
         )

--- a/explainaboard/utils/typing_utils.py
+++ b/explainaboard/utils/typing_utils.py
@@ -25,6 +25,22 @@ def unwrap(obj: Optional[T]) -> T:
     return obj
 
 
+def unwrap_or(obj: Optional[T], default: T) -> T:
+    '''Unwrap the ``Optional`` type hint, or return the default value.
+
+    This function takes an object wrapped with the ``Optional``, and returns itself
+    if the object is not ``None``. Otherwise this function returns ``default``.
+
+    :param obj: The object to unwrap.
+    :type obj: ``Optional[T]``
+    :param default: The default value.
+    :type default: ``T``
+    :return: ``obj`` or ``default`` according to the value of ``obj``.
+    :rtype: The underlying type ``T``.
+    '''
+    return obj if obj is not None else default
+
+
 def unwrap_generator(obj: Optional[Iterable[T]]) -> Generator[T, None, None]:
     '''Unwrap the ``Optional`` ``Iterable``s and provides its generator.
 


### PR DESCRIPTION
This pr introduces `typing_utils.unwrap_or`, which provides a similar semantics to Rust's `Optional.unwrap_or`.
This pr also removes `Metric._get_config` since this function does nothing else than `unwrap_or`.