### PR TITLE
Refactor typing_utils.narrow

### DIFF
--- a/explainaboard/loaders/file_loader.py
+++ b/explainaboard/loaders/file_loader.py
@@ -367,7 +367,7 @@ class TSVFileLoader(FileLoader):
     def load_raw(
         self, data: str | DatalabLoaderOption, source: Source
     ) -> FileLoaderReturn:
-        data = narrow(data, str)
+        data = narrow(str, data)
         if source == Source.in_memory:
             file = StringIO(data)
             lines = list(csv.reader(file, delimiter='\t', quoting=csv.QUOTE_NONE))
@@ -396,7 +396,7 @@ class CoNLLFileLoader(FileLoader):
     def load_raw(
         self, data: str | DatalabLoaderOption, source: Source
     ) -> FileLoaderReturn:
-        data = narrow(data, str)
+        data = narrow(str, data)
         if source == Source.in_memory:
             return FileLoaderReturn(data.splitlines())
         elif source == Source.local_filesystem:
@@ -431,7 +431,7 @@ class CoNLLFileLoader(FileLoader):
                     field.src_name: [] for field in self._fields
                 }  # reset
 
-        max_field: int = max([narrow(x.src_name, int) for x in self._fields])
+        max_field: int = max([narrow(int, x.src_name) for x in self._fields])
         for line in raw_data.samples:
             # at sentence boundary
             if line.startswith("-DOCSTART-") or line == "" or line == "\n":
@@ -447,7 +447,7 @@ class CoNLLFileLoader(FileLoader):
 
                 for field in self._fields:
                     curr_sentence_fields[field.src_name].append(
-                        self.parse_data(splits[narrow(field.src_name, int)], field)
+                        self.parse_data(splits[narrow(int, field.src_name)], field)
                     )
 
         add_sample()  # add last example
@@ -458,7 +458,7 @@ class JSONFileLoader(FileLoader):
     def load_raw(
         self, data: str | DatalabLoaderOption, source: Source
     ) -> FileLoaderReturn:
-        data = narrow(data, str)
+        data = narrow(str, data)
         if source == Source.in_memory:
             loaded = json.loads(data)
         elif source == Source.local_filesystem:
@@ -524,7 +524,7 @@ class DatalabFileLoader(FileLoader):
     def load_raw(
         self, data: str | DatalabLoaderOption, source: Source
     ) -> FileLoaderReturn:
-        config = narrow(data, DatalabLoaderOption)
+        config = narrow(DatalabLoaderOption, data)
         dataset = load_dataset(
             config.dataset, config.subdataset, split=config.split, streaming=False
         )
@@ -594,7 +594,7 @@ class TextFileLoader(FileLoader):
     def load_raw(
         cls, data: str | DatalabLoaderOption, source: Source
     ) -> FileLoaderReturn:
-        data = narrow(data, str)
+        data = narrow(str, data)
         if source == Source.in_memory:
             return FileLoaderReturn(data.splitlines())
         elif source == Source.local_filesystem:

--- a/explainaboard/utils/typing_utils.py
+++ b/explainaboard/utils/typing_utils.py
@@ -54,6 +54,8 @@ def narrow(obj: Any, subcls: type[T]) -> T:
     :raises TypeError: ``obj`` is not an object of ``T``.
     """
     if not isinstance(obj, subcls):
-        raise TypeError(f"{obj} is not an object of {subcls.__name__}")
+        raise TypeError(
+            f"{obj.__class__.__name__} is not an object of {subcls.__name__}"
+        )
 
     return cast(obj, subcls)

--- a/explainaboard/utils/typing_utils.py
+++ b/explainaboard/utils/typing_utils.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Generator, Iterable
-from typing import Any, cast, Optional, TypeVar
+from typing import Any, Optional, TypeVar
 
 T = TypeVar('T')
 
@@ -62,4 +62,7 @@ def narrow(subcls: type[T], obj: Any) -> T:
             f"{obj.__class__.__name__} is not a subclass of {subcls.__name__}"
         )
 
-    return cast(subcls, obj)
+    # NOTE(odashi): typing.cast() does not work with TypeVar.
+    # Simply returning the obj is correct because we already narrowed its type
+    # by the previous if-statement.
+    return obj

--- a/explainaboard/utils/typing_utils.py
+++ b/explainaboard/utils/typing_utils.py
@@ -42,13 +42,17 @@ def unwrap_generator(obj: Optional[Iterable[T]]) -> Generator[T, None, None]:
         yield from obj
 
 
-def narrow(obj: Any, subcls: type[T]) -> T:
+def narrow(subcls: type[T], obj: Any) -> T:
     """Narrow (downcast) an object with a type-safe manner.
 
-    :param obj: The object to be casted.
-    :type obj: ``Any``
+    This function does the same type casting with ``typing.cast()``, but additionally
+    checks the actual type of the given object. If the type of the given object is not
+    castable to the given type, this funtion raises a ``TypeError``.
+
     :param subcls: The type that ``obj`` is casted to.
     :type subcls: ``type[T]``
+    :param obj: The object to be casted.
+    :type obj: ``Any``
     :return: ``obj`` itself
     :rtype: ``T``
     :raises TypeError: ``obj`` is not an object of ``T``.

--- a/explainaboard/utils/typing_utils.py
+++ b/explainaboard/utils/typing_utils.py
@@ -55,7 +55,7 @@ def narrow(obj: Any, subcls: type[T]) -> T:
     """
     if not isinstance(obj, subcls):
         raise TypeError(
-            f"{obj.__class__.__name__} is not an object of {subcls.__name__}"
+            f"{obj.__class__.__name__} is not a subclass of {subcls.__name__}"
         )
 
     return cast(obj, subcls)

--- a/explainaboard/utils/typing_utils.py
+++ b/explainaboard/utils/typing_utils.py
@@ -42,10 +42,10 @@ def unwrap_generator(obj: Optional[Iterable[T]]) -> Generator[T, None, None]:
         yield from obj
 
 
-def downcast(obj: Any, subcls: type[T]) -> T:
-    """Downcast the object.
+def narrow(obj: Any, subcls: type[T]) -> T:
+    """Narrow (downcast) an object with a type-safe manner.
 
-    :param obj: The object to be downcasted.
+    :param obj: The object to be casted.
     :type obj: ``Any``
     :param subcls: The type that ``obj`` is casted to.
     :type subcls: ``type[T]``

--- a/explainaboard/utils/typing_utils.py
+++ b/explainaboard/utils/typing_utils.py
@@ -58,4 +58,4 @@ def narrow(obj: Any, subcls: type[T]) -> T:
             f"{obj.__class__.__name__} is not a subclass of {subcls.__name__}"
         )
 
-    return cast(obj, subcls)
+    return cast(subcls, obj)

--- a/explainaboard/utils/typing_utils.py
+++ b/explainaboard/utils/typing_utils.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Generator, Iterable
-from typing import Any, Optional, TypeVar
+from typing import Any, cast, Optional, TypeVar
 
 T = TypeVar('T')
 
@@ -42,13 +42,18 @@ def unwrap_generator(obj: Optional[Iterable[T]]) -> Generator[T, None, None]:
         yield from obj
 
 
-NarrowType = TypeVar("NarrowType")
+def downcast(obj: Any, subcls: type[T]) -> T:
+    """Downcast the object.
 
+    :param obj: The object to be downcasted.
+    :type obj: ``Any``
+    :param subcls: The type that ``obj`` is casted to.
+    :type subcls: ``type[T]``
+    :return: ``obj`` itself
+    :rtype: ``T``
+    :raises TypeError: ``obj`` is not an object of ``T``.
+    """
+    if not isinstance(obj, subcls):
+        raise TypeError(f"{obj} is not an object of {subcls.__name__}")
 
-def narrow(obj: Any, narrow_type: type[NarrowType]) -> NarrowType:
-    """returns the object with the narrowed type or raises a TypeError
-    (obj: Any, new_type: type[T]) -> T"""
-    if isinstance(obj, narrow_type):
-        return obj
-    else:
-        raise TypeError(f"{obj} is expected to be {narrow_type}")
+    return cast(obj, subcls)

--- a/explainaboard/utils/typing_utils_test.py
+++ b/explainaboard/utils/typing_utils_test.py
@@ -8,5 +8,5 @@ from explainaboard.utils.typing_utils import narrow
 class TestTypingUtils(unittest.TestCase):
     def test_narrow(self):
         a: str | int = 's'
-        self.assertEqual(narrow(a, str), a)
-        self.assertRaises(TypeError, lambda: narrow(a, int))
+        self.assertEqual(narrow(str, a), a)
+        self.assertRaises(TypeError, lambda: narrow(int, a))


### PR DESCRIPTION
This pr introduces some small changes in `typing_utils.narrow`:

- Write a complete documentation.
- Use `__name__` in the error string rather than the `str` representation.
- Change the argument order to `narrow(type, obj)` to keep consistency with `typing.cast`