### PR TITLE
Move supported_file_types to Loader

### DIFF
--- a/explainaboard/loaders/loader.py
+++ b/explainaboard/loaders/loader.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import final, Literal, Optional
 
 from explainaboard.constants import FileType, Source
@@ -10,6 +10,14 @@ from explainaboard.loaders.file_loader import (
     FileLoaderReturn,
     TextFileLoader,
 )
+
+
+@dataclass
+class SupportedFileTypes:
+    """List of dataset/output file types supported by the loader."""
+
+    custom_dataset: list[FileType] = field(default_factory=list)
+    system_output: list[FileType] = field(default_factory=list)
 
 
 class Loader:
@@ -42,6 +50,13 @@ class Loader:
     @classmethod
     def default_output_file_loaders(cls) -> dict[FileType, FileLoader]:
         return {FileType.text: TextFileLoader()}
+
+    @classmethod
+    def supported_file_types(cls) -> SupportedFileTypes:
+        return SupportedFileTypes(
+            list(cls.default_dataset_file_loaders().keys()),
+            list(cls.default_output_file_loaders().keys()),
+        )
 
     def __init__(
         self,

--- a/explainaboard/loaders/loader_registry.py
+++ b/explainaboard/loaders/loader_registry.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field
 from typing import Optional
 
 from explainaboard import TaskType
@@ -10,6 +9,18 @@ from explainaboard.loaders.loader import Loader
 
 # loader_registry is a global variable, storing all basic loading functions
 _loader_registry: dict[TaskType, type[Loader]] = {}
+
+
+def get_loader_class(task: TaskType | str) -> type[Loader]:
+    """Obtains the loader class for the specified task type.
+
+    Args:
+        task: Task type or task name.
+
+    Returns:
+        The Loader class associated to `task`.
+    """
+    return _loader_registry[TaskType(task)]
 
 
 def get_custom_dataset_loader(
@@ -68,17 +79,3 @@ def register_loader(task_type: TaskType):
         return cls
 
     return register_loader_fn
-
-
-@dataclass
-class SupportedFileFormats:
-    custom_dataset: list[FileType] = field(default_factory=list)
-    system_output: list[FileType] = field(default_factory=list)
-
-
-def get_supported_file_types_for_loader(task: TaskType) -> SupportedFileFormats:
-    loader_class = _loader_registry[task]
-    return SupportedFileFormats(
-        list(loader_class.default_dataset_file_loaders().keys()),
-        list(loader_class.default_output_file_loaders().keys()),
-    )

--- a/explainaboard/tests/test_get_tasks.py
+++ b/explainaboard/tests/test_get_tasks.py
@@ -1,7 +1,7 @@
 import unittest
 
 from explainaboard import get_task_categories
-from explainaboard.loaders.loader_registry import get_supported_file_types_for_loader
+from explainaboard.loaders.loader_registry import get_loader_class
 from explainaboard.processors.processor_registry import get_metric_list_for_processor
 
 
@@ -20,7 +20,7 @@ class TestTasks(unittest.TestCase):
             self.assertIsNotNone(task_category.name)
             for task in task_category.tasks:
                 supported_metrics = get_metric_list_for_processor(task.name)
-                supported_formats = get_supported_file_types_for_loader(task.name)
+                supported_formats = get_loader_class(task.name).supported_file_types()
                 self.assertEqual(
                     len(supported_metrics),
                     len(set([x.name for x in supported_metrics])),


### PR DESCRIPTION
This pr adds `Loader.supported_file_types` and removes the same implementation in `loader_registry` since this functionality should belong to `Loader`.

This also adds `loader_registry.get_loader_class` to obtain the Loader class which is required to use the Loader's class methods without initialization.

I guess `loader_registry.get_custom_dataset_loader` is also not needed: it can be replaced by simply initializing the class returned by `get_loader_class`. I will propose another pr to fix this.