### PR TITLE
Refactor selecting the dataset/output file loaders.

### DIFF
--- a/explainaboard/loaders/loader.py
+++ b/explainaboard/loaders/loader.py
@@ -107,7 +107,7 @@ class Loader:
         if not output_file_type:
             output_file_type = self.default_output_file_type()
 
-        # determine file loaders1
+        # determine file loaders
         try:
             self._dataset_file_loader = unwrap_or_else(
                 dataset_file_loader,

--- a/explainaboard/loaders/loader.py
+++ b/explainaboard/loaders/loader.py
@@ -107,16 +107,27 @@ class Loader:
         if not output_file_type:
             output_file_type = self.default_output_file_type()
 
-        # determine file loaders
-        # Propagates KeyError to outside if unsupported file type is specified.
-        self._dataset_file_loader = unwrap_or_else(
-            dataset_file_loader,
-            lambda: self.default_dataset_file_loaders()[unwrap(dataset_file_type)],
-        )
-        self._output_file_loader = unwrap_or_else(
-            output_file_loader,
-            lambda: self.default_output_file_loaders()[unwrap(output_file_type)],
-        )
+        # determine file loaders1
+        try:
+            self._dataset_file_loader = unwrap_or_else(
+                dataset_file_loader,
+                lambda: self.default_dataset_file_loaders()[unwrap(dataset_file_type)],
+            )
+        except KeyError:
+            raise ValueError(
+                f"{dataset_file_type} is not a supported dataset file type of "
+                f"{self.__class__.__name__}."
+            )
+        try:
+            self._output_file_loader = unwrap_or_else(
+                output_file_loader,
+                lambda: self.default_output_file_loaders()[unwrap(output_file_type)],
+            )
+        except KeyError:
+            raise ValueError(
+                f"{output_file_type} is not a supported output file type of "
+                f"{self.__class__.__name__}."
+            )
 
         self._dataset_data = dataset_data  # base64, filepath or datalab options
         self._output_data = output_data

--- a/explainaboard/loaders/loader.py
+++ b/explainaboard/loaders/loader.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import final, Literal, Optional
 
 from explainaboard.constants import FileType, Source
 from explainaboard.loaders.file_loader import (
@@ -10,6 +9,7 @@ from explainaboard.loaders.file_loader import (
     FileLoaderReturn,
     TextFileLoader,
 )
+from explainaboard.utils.typing_utils import unwrap, unwrap_or_else
 
 
 @dataclass
@@ -84,40 +84,18 @@ class Loader:
             output_file_type = self.default_output_file_type()
 
         # determine file loaders
-        self._dataset_file_loader = self.select_file_loader(
-            "dataset", dataset_file_type, dataset_file_loader
+        # Propagates KeyError to outside if unsupported file type is specified.
+        self._dataset_file_loader = unwrap_or_else(
+            dataset_file_loader,
+            lambda: self.default_dataset_file_loaders()[unwrap(dataset_file_type)],
         )
-        self._output_file_loader = self.select_file_loader(
-            "output", output_file_type, output_file_loader
+        self._output_file_loader = unwrap_or_else(
+            output_file_loader,
+            lambda: self.default_output_file_loaders()[unwrap(output_file_type)],
         )
 
         self._dataset_data = dataset_data  # base64, filepath or datalab options
         self._output_data = output_data
-
-    @classmethod
-    @final
-    def select_file_loader(
-        cls,
-        split: Literal["dataset", "output"],
-        file_type: FileType,
-        custom_loader: Optional[FileLoader],
-    ) -> FileLoader:
-        if custom_loader:
-            return custom_loader
-        else:
-            if split == "dataset":
-                default_file_loaders = cls.default_dataset_file_loaders()
-            elif split == "output":
-                default_file_loaders = cls.default_output_file_loaders()
-            else:
-                raise ValueError("split must be one of [dataset, output]")
-            if file_type not in default_file_loaders:
-                raise ValueError(
-                    f"A file loader for {file_type} is not provided. "
-                    "please pass it in as an argument."
-                )
-            else:
-                return default_file_loaders[file_type]
 
     def load(self) -> FileLoaderReturn:
         dataset_loaded_data = self._dataset_file_loader.load(

--- a/explainaboard/loaders/loader.py
+++ b/explainaboard/loaders/loader.py
@@ -36,8 +36,8 @@ class Loader:
         cls,
         dataset: DatalabLoaderOption,
         output_data: str,
-        output_source: Optional[Source] = None,
-        output_file_type: Optional[FileType] = None,
+        output_source: Source | None = None,
+        output_file_type: FileType | None = None,
         field_mapping: dict[str, str] | None = None,
     ) -> Loader:
         """Convenient method to initializes a loader for a dataset from datalab.

--- a/explainaboard/utils/typing_utils.py
+++ b/explainaboard/utils/typing_utils.py
@@ -2,20 +2,20 @@
 
 from __future__ import annotations
 
-from collections.abc import Generator, Iterable
-from typing import Any, Optional, TypeVar
+from collections.abc import Callable, Generator, Iterable
+from typing import Any, TypeVar
 
 T = TypeVar('T')
 
 
-def unwrap(obj: Optional[T]) -> T:
+def unwrap(obj: T | None) -> T:
     '''Unwrap the ``Optional`` type hint.
 
     This function takes an object wrapped with the ``Optional``, and returns itself
     if the object is not ``None``. Otherwise this funciton raises ValueError.
 
     :param obj: The object to unwrap.
-    :type obj: ``Optional[T]``
+    :type obj: ``T | None``
     :return: ``obj`` itself.
     :rtype: The underlying type ``T``.
     :raises ValueError: ``obj`` is None.
@@ -25,14 +25,14 @@ def unwrap(obj: Optional[T]) -> T:
     return obj
 
 
-def unwrap_or(obj: Optional[T], default: T) -> T:
+def unwrap_or(obj: T | None, default: T) -> T:
     '''Unwrap the ``Optional`` type hint, or return the default value.
 
     This function takes an object wrapped with the ``Optional``, and returns itself
     if the object is not ``None``. Otherwise this function returns ``default``.
 
     :param obj: The object to unwrap.
-    :type obj: ``Optional[T]``
+    :type obj: ``T | None``
     :param default: The default value.
     :type default: ``T``
     :return: ``obj`` or ``default`` according to the value of ``obj``.
@@ -41,7 +41,25 @@ def unwrap_or(obj: Optional[T], default: T) -> T:
     return obj if obj is not None else default
 
 
-def unwrap_generator(obj: Optional[Iterable[T]]) -> Generator[T, None, None]:
+def unwrap_or_else(obj: T | None, default: Callable[[], T]) -> T:
+    '''Unwrap the ``Optional`` type hint, or return the default value.
+
+    This function takes an object wrapped with the ``Optional``, and returns itself
+    if the object is not ``None``. Otherwise this function returns the return value of
+    ``default``. This means that obtaining the default value is deferred until it is
+    required.
+
+    :param obj: The object to unwrap.
+    :type obj: ``T | None``
+    :param default: The function to return the default value.
+    :type default: ``Callable[[], T]``
+    :return: ``obj`` or ``default()`` according to the value of ``obj``.
+    :rtype: The underlying type ``T``.
+    '''
+    return obj if obj is not None else default()
+
+
+def unwrap_generator(obj: Iterable[T] | None) -> Generator[T, None, None]:
     '''Unwrap the ``Optional`` ``Iterable``s and provides its generator.
 
     This function takes an ``Iterable`` object wrapped by the ``Optional``, and provides
@@ -50,7 +68,7 @@ def unwrap_generator(obj: Optional[Iterable[T]]) -> Generator[T, None, None]:
     If raising ``ValueError`` when ``None`` is perferred, use ``unwrap()`` instead.
 
     :param obj: The object to unwrap.
-    :type obj: ``Optional[Iterable[T]]``
+    :type obj: ``Iterable[T] | None``
     :return: A generator over the underlying object.
     :rtype: ``Generator[T, None, None]``
     '''


### PR DESCRIPTION
This pr does following things:

- Introduce `typing_utils.unwrap_or_else(obj, fn)`: provides a similar semantics to the Rust's `Option.unwrap_or_else`.
- Remove `Loader.select_file_loader` and implement the same logic using `unwrap` and `unwrap_or_else`.