### PR TITLE
Add text_writer context manager

### DIFF
--- a/explainaboard/explainaboard_main.py
+++ b/explainaboard/explainaboard_main.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import argparse
 import json
 import os
-import sys
 
 from explainaboard import get_loader_class, get_processor, TaskType
 from explainaboard.analyzers import get_pairwise_performance_gap
@@ -16,6 +15,7 @@ from explainaboard.loaders.file_loader import (
     FileLoaderMetadata,
 )
 from explainaboard.metrics.registry import metric_name_to_config
+from explainaboard.utils.io_utils import text_writer
 from explainaboard.utils.logging import get_logger
 from explainaboard.utils.tensor_analysis import (
     aggregate_score_tensor,
@@ -474,17 +474,12 @@ def main():
                     f"{output_dir_figures}/{x_file_name}",
                 )
 
-        if args.report_json is not None:
-            report_file = open(args.report_json, 'w')
-        else:
-            report_file = sys.stdout
-        if len(system_outputs) == 1:  # individual system analysis
-            reports[0].print_as_json(file=report_file)
-        elif len(system_outputs) == 2:  # pairwise analysis
-            compare_analysis = get_pairwise_performance_gap(reports[0], reports[1])
-            compare_analysis.print_as_json(file=report_file)
-        if args.report_json is not None:
-            report_file.close()
+        with text_writer(args.report_json) as report_file:
+            if len(system_outputs) == 1:  # individual system analysis
+                reports[0].print_as_json(file=report_file)
+            elif len(system_outputs) == 2:  # pairwise analysis
+                compare_analysis = get_pairwise_performance_gap(reports[0], reports[1])
+                compare_analysis.print_as_json(file=report_file)
 
 
 if __name__ == '__main__':

--- a/explainaboard/utils/io_utils.py
+++ b/explainaboard/utils/io_utils.py
@@ -1,0 +1,25 @@
+"""Utility functions to manipulate IO."""
+
+from __future__ import annotations
+
+from collections.abc import Generator
+import contextlib
+import sys
+from typing import TextIO
+
+
+@contextlib.contextmanager
+def text_writer(filename: str | None = None) -> Generator[TextIO, None, None]:
+    """Prepare a text file to output, or assign STDOUT.
+
+    Args:
+        filename: Path to the file, or None to use STDOUT.
+
+    Yields:
+        A text file object assigned to the context.
+    """
+    if filename is None:
+        yield sys.stdout
+    else:
+        with open(filename, 'w') as fp:
+            yield fp

--- a/explainaboard/utils/io_utils_test.py
+++ b/explainaboard/utils/io_utils_test.py
@@ -1,0 +1,20 @@
+"""Tests for io_utils."""
+
+import os
+import sys
+import tempfile
+import unittest
+
+from explainaboard.utils import io_utils
+
+
+class TestIOUtils(unittest.TestCase):
+    def test_text_writer_file(self):
+        with tempfile.TemporaryDirectory as dirname:
+            with io_utils.text_writer(os.path.join(dirname, "test.txt")) as fp:
+                fp.write("foobar")
+            self.assertEqual(open(dirname, "test.txt").read(), "foobar")
+
+    def test_text_writer_stdout(self):
+        with io_utils.text_writer() as fp:
+            self.assertIs(fp, sys.stdout)


### PR DESCRIPTION
This pr adds `utils.io_utils.text_writer(file)` context manager, and replace the behavior to make reports in the main module to this functionality. Unlike the current implemenation, this function correctly close the file when some exception raised during generating the report file.