### PR TITLE
add get_metric_config_class

### DIFF
--- a/explainaboard/explainaboard_main.py
+++ b/explainaboard/explainaboard_main.py
@@ -14,7 +14,7 @@ from explainaboard.loaders.file_loader import (
     FileLoaderField,
     FileLoaderMetadata,
 )
-from explainaboard.metrics.registry import metric_name_to_config
+from explainaboard.metrics.registry import get_metric_config_class
 from explainaboard.utils.io_utils import text_writer
 from explainaboard.utils.logging import get_logger
 from explainaboard.utils.tensor_analysis import (
@@ -429,7 +429,7 @@ def main():
             if 'metric_configs' in metadata:
                 raise ValueError('Cannot specify both metric names and metric configs')
             metric_configs = [
-                metric_name_to_config(name, source_language, target_language)
+                get_metric_config_class(name)(name, source_language, target_language)
                 for name in metric_names
             ]
             metadata["metric_configs"] = metric_configs

--- a/explainaboard/metrics/eaas.py
+++ b/explainaboard/metrics/eaas.py
@@ -8,7 +8,6 @@ import numpy as np
 import sacrebleu
 
 from explainaboard.metrics.metric import Metric, MetricConfig, MetricStats
-from explainaboard.metrics.registry import register_metric_config
 from explainaboard.utils.typing_utils import unwrap
 
 
@@ -64,8 +63,9 @@ class EaaSMetricStats(MetricStats):
         return MetricStats(sdata[indices])
 
 
+# NOTE(odashi): Not register this config to the registry.
+# This metric class has different usage than other metrics.
 @dataclass
-@register_metric_config
 class EaaSMetricConfig(MetricConfig):
     def to_metric(self):
         return EaaSMetric(self)

--- a/explainaboard/metrics/registry.py
+++ b/explainaboard/metrics/registry.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 from eaas.endpoint import EndpointConfig
 
+from explainaboard.metrics.eaas import EaaSMetricConfig
 from explainaboard.metrics.metric import MetricConfig
 
-_metric_config_registry = {}
+_metric_config_registry: dict[str, type[MetricConfig]] = {}
 
 
 def register_metric_config(cls):
@@ -19,22 +20,13 @@ def register_metric_config(cls):
     return cls
 
 
-def metric_name_to_config_class(name):
-    return _metric_config_registry[name]
+def get_metric_config_class(name) -> type[MetricConfig]:
+    config_cls = _metric_config_registry.get(name)
+    if config_cls is not None:
+        return config_cls
 
+    # TODO(odashi): Avoid EaaS completely from this module.
+    if name in EndpointConfig().valid_metrics:
+        return EaaSMetricConfig
 
-def metric_name_to_config(
-    name: str, source_language: str, target_language: str
-) -> MetricConfig:
-    if name in _metric_config_registry:
-        return _metric_config_registry[name](
-            name=name, source_language=source_language, target_language=target_language
-        )
-    elif name in EndpointConfig().valid_metrics:
-        return _metric_config_registry['EaaSMetricConfig'](
-            name=name,
-            source_language=source_language,
-            target_language=target_language,
-        )
-    else:
-        raise ValueError(f'Invalid metric {name}')
+    raise ValueError(f'Invalid Metric {name}')


### PR DESCRIPTION
This pr adds `get_metric_config_class` to simplify the behavior of the registry. The function returns the `MetricConfig` class associated to the given name. 