### PR TITLE
Modify analyses to be flat list

### DIFF
--- a/data/system_outputs/sst2_tabclass/sst2-tabclass-dataset.json
+++ b/data/system_outputs/sst2_tabclass/sst2-tabclass-dataset.json
@@ -8,16 +8,15 @@
         }
       }
     },
-    "custom_analyses": {
-      "example": [
-        {
-          "cls_name": "BucketAnalysis",
-          "feature": "total_words",
-          "num_buckets": 4,
-          "method": "continuous"
-        }
-      ]
-    }
+    "custom_analyses": [
+      {
+        "cls_name": "BucketAnalysis",
+        "level": "example",
+        "feature": "total_words",
+        "num_buckets": 4,
+        "method": "continuous"
+      }
+    ]
   },
   "examples": [
     {

--- a/data/system_outputs/sst2_tabreg/sst2-tabreg-dataset.json
+++ b/data/system_outputs/sst2_tabreg/sst2-tabreg-dataset.json
@@ -8,16 +8,15 @@
         }
       }
     },
-    "custom_analyses": {
-      "example": [
-        {
-          "cls_name": "BucketAnalysis",
-          "feature": "total_words",
-          "num_buckets": 4,
-          "method": "continuous"
-        }
-      ]
-    }
+    "custom_analyses": [
+      {
+        "cls_name": "BucketAnalysis",
+        "level": "example",
+        "feature": "total_words",
+        "num_buckets": 4,
+        "method": "continuous"
+      }
+    ]
   },
   "examples": [
     {

--- a/docs/example_scripts/test_kg.py
+++ b/docs/example_scripts/test_kg.py
@@ -22,10 +22,9 @@ fine_grained_res = unwrap(sys_info.results.analyses)
 overall_res = unwrap(sys_info.results.overall)
 
 # print bucket information
-for analysis_level in fine_grained_res:
-    for analysis in analysis_level:
-        if analysis is not None:
-            analysis.print()
+for analysis in fine_grained_res:
+    if analysis is not None:
+        analysis.print()
 
 # save analysis report locally
 sys_info.print_as_json(file=open("./report.json", 'w'))
@@ -48,7 +47,7 @@ for metric_info in unwrap(sys_info.results.overall)[0]:
 
 
 # get fine-grained results
-for analyses in fine_grained_res[0]:
+for analyses in fine_grained_res:
     buckets = cast(BucketAnalysisResult, analyses)
     for bucket_info in buckets.bucket_performances:
         for bucket_performance in bucket_info.performances:

--- a/explainaboard/analysis/analyses.py
+++ b/explainaboard/analysis/analyses.py
@@ -25,6 +25,7 @@ class AnalysisResult:
     """
 
     name: str
+    level: str
 
     def print(self):
         raise NotImplementedError
@@ -37,11 +38,14 @@ class AnalysisResult:
                 BucketPerformance.from_dict(v1) for v1 in dikt['bucket_performances']
             ]
             return BucketAnalysisResult(
-                name=dikt['name'], bucket_performances=bucket_performances
+                name=dikt['name'],
+                level=dikt['level'],
+                bucket_performances=bucket_performances,
             )
         elif type == 'ComboCountAnalysisResult':
             return ComboCountAnalysisResult(
                 name=dikt['name'],
+                level=dikt['level'],
                 features=dikt['features'],
                 combo_counts=dikt['combo_counts'],
             )
@@ -59,6 +63,7 @@ class Analysis:
     """
 
     description: str | None
+    level: str
 
     def perform(
         self,
@@ -86,6 +91,7 @@ class Analysis:
         if type == 'BucketAnalysis':
             return BucketAnalysis(
                 description=dikt.get('description'),
+                level=dikt['level'],
                 feature=dikt['feature'],
                 method=dikt.get('method', 'continuous'),
                 number=dikt.get('number', 4),
@@ -95,6 +101,7 @@ class Analysis:
         elif type == 'ComboCountAnalysis':
             return ComboCountAnalysis(
                 description=dikt.get('description'),
+                level=dikt['level'],
                 features=dikt['features'],
             )
 
@@ -224,7 +231,9 @@ class BucketAnalysis(Analysis):
 
             bucket_performances.append(bucket_performance)
 
-        return BucketAnalysisResult(self.feature, bucket_performances)
+        return BucketAnalysisResult(
+            name=self.feature, level=self.level, bucket_performances=bucket_performances
+        )
 
 
 @dataclass
@@ -259,6 +268,7 @@ class ComboCountAnalysis(Analysis):
     A class used to count feature combinations (e.g. for confusion matrices). It will
     return counts of each combination of values for the features named in `features`.
     Args:
+        level: the level to which this analysis should be applied
         features: the name of the features over which to perform the analysis
     """
 
@@ -292,6 +302,7 @@ class ComboCountAnalysis(Analysis):
         combo_list = list(combo_map.items())
         return ComboCountAnalysisResult(
             name='combo(' + ','.join(self.features) + ')',
+            level=self.level,
             features=self.features,
             combo_counts=combo_list,
         )
@@ -301,17 +312,14 @@ class ComboCountAnalysis(Analysis):
 class AnalysisLevel:
     name: str
     features: dict[str, FeatureType]
-    analyses: list[Analysis]
     metric_configs: list[MetricConfig]
 
     @staticmethod
     def from_dict(dikt: dict):
         features = {k: FeatureType.from_dict(v) for k, v in dikt['features'].items()}
-        analyses = [Analysis.from_dict(v) for v in dikt['analyses']]
         metric_configs = [metric_config_from_dict(v) for v in dikt['metric_configs']]
         return AnalysisLevel(
             name=dikt['name'],
             features=features,
-            analyses=analyses,
             metric_configs=metric_configs,
         )

--- a/explainaboard/analysis/result.py
+++ b/explainaboard/analysis/result.py
@@ -12,16 +12,14 @@ from explainaboard.analysis.performance import Performance
 class Result:
     overall: Optional[list[list[Performance]]] = None
     # {feature_name: {bucket_name: performance}}
-    analyses: Optional[list[list[AnalysisResult]]] = None
+    analyses: Optional[list[AnalysisResult]] = None
 
     @classmethod
     def dict_conv(cls, k: str, v: list[list[dict]] | None):
         if k == 'overall':
             return [[Performance.from_dict(v2) for v2 in v1] for v1 in v] if v else None
         elif k == 'analyses':
-            return (
-                [[AnalysisResult.from_dict(v2) for v2 in v1] for v1 in v] if v else None
-            )
+            return [AnalysisResult.from_dict(v1) for v1 in v] if v else None
         else:
             raise NotImplementedError
 

--- a/explainaboard/explainaboard_main.py
+++ b/explainaboard/explainaboard_main.py
@@ -461,10 +461,9 @@ def main():
                     )
             get_logger('report').info('')
             get_logger('report').info('--- Fine-grained Analyses')
-            for analysis_level in report.results.analyses:
-                for analysis in analysis_level:
-                    if analysis is not None:
-                        analysis.print()
+            for analysis in report.results.analyses:
+                if analysis is not None:
+                    analysis.print()
 
             if output_dir:
 

--- a/explainaboard/info.py
+++ b/explainaboard/info.py
@@ -9,7 +9,7 @@ import sys
 from typing import Callable, Optional
 
 from explainaboard import config
-from explainaboard.analysis.analyses import AnalysisLevel
+from explainaboard.analysis.analyses import Analysis, AnalysisLevel
 from explainaboard.analysis.case import AnalysisCase
 from explainaboard.analysis.result import Result
 from explainaboard.metrics.metric import MetricStats
@@ -77,6 +77,7 @@ class SysOutputInfo:
     source_tokenizer: Optional[Tokenizer] = None
     target_tokenizer: Optional[Tokenizer] = None
     analysis_levels: Optional[list[AnalysisLevel]] = None
+    analyses: Optional[list[Analysis]] = None
 
     # set later
     results: Result = field(default_factory=lambda: Result())

--- a/explainaboard/loaders/file_loader.py
+++ b/explainaboard/loaders/file_loader.py
@@ -103,7 +103,7 @@ class FileLoaderMetadata:
     supported_tasks: list[str] | None = None
     custom_features: dict[str, dict[str, FeatureType]] | None = None
     # analysis level name -> list of analyses dictionary
-    custom_analyses: dict[str, list[Analysis]] | None = None
+    custom_analyses: list[Analysis] | None = None
 
     def merge(self, other: FileLoaderMetadata) -> None:
         """
@@ -137,17 +137,14 @@ class FileLoaderMetadata:
                 )
             source_language = target_language = data.get('language')
         custom_features: dict[str, dict[str, FeatureType]] | None = None
-        custom_analyses: dict[str, list[Analysis]] | None = None
+        custom_analyses: list[Analysis] | None = None
         if 'custom_features' in data:
             custom_features = {
                 k1: {k2: FeatureType.from_dict(v2) for k2, v2 in v1.items()}
                 for k1, v1 in data['custom_features'].items()
             }
         if 'custom_analyses' in data:
-            custom_analyses = {
-                k1: [Analysis.from_dict(v2) for v2 in v1]
-                for k1, v1 in data['custom_analyses'].items()
-            }
+            custom_analyses = [Analysis.from_dict(v) for v in data['custom_analyses']]
         return FileLoaderMetadata(
             system_name=data.get('system_name'),
             dataset_name=data.get('dataset_name'),

--- a/explainaboard/meta_analyses/utils.py
+++ b/explainaboard/meta_analyses/utils.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import itertools
 from typing import Any
 
 from explainaboard.analysis.analyses import BucketAnalysisResult
@@ -18,7 +17,7 @@ def report_to_sysout(report: SysOutputInfo) -> list[dict]:
     '''
     results_fine_grained = [
         narrow(BucketAnalysisResult, x)
-        for x in itertools.chain.from_iterable(unwrap(report.results.analyses))
+        for x in unwrap(report.results.analyses)
         if isinstance(x, BucketAnalysisResult)
     ]
     meta_examples = []

--- a/explainaboard/processors/aspect_based_sentiment_classification.py
+++ b/explainaboard/processors/aspect_based_sentiment_classification.py
@@ -79,7 +79,6 @@ class AspectBasedSentimentClassificationProcessor(Processor):
 
     def default_analyses(self) -> list[Analysis]:
         features = self.default_analysis_levels()[0].features
-        continuous_features = [k for k, v in features.items() if v.dtype == 'float32']
         # Create analyses
         analyses: list[Analysis] = [
             BucketAnalysis(
@@ -95,15 +94,8 @@ class AspectBasedSentimentClassificationProcessor(Processor):
                 features=("true_label", "predicted_label"),
             ),
         ]
-        for x in continuous_features:
-            analyses.append(
-                BucketAnalysis(
-                    level="example",
-                    description=features[x].description,
-                    feature=x,
-                    method="continuous",
-                )
-            )
+        # Continuous features
+        analyses.extend(super().default_analyses())
         return analyses
 
     @classmethod

--- a/explainaboard/processors/aspect_based_sentiment_classification.py
+++ b/explainaboard/processors/aspect_based_sentiment_classification.py
@@ -95,7 +95,7 @@ class AspectBasedSentimentClassificationProcessor(Processor):
             ),
         ]
         # Continuous features
-        analyses.extend(super().default_analyses())
+        analyses.extend(self.continuous_feature_analyses())
         return analyses
 
     @classmethod

--- a/explainaboard/processors/aspect_based_sentiment_classification.py
+++ b/explainaboard/processors/aspect_based_sentiment_classification.py
@@ -15,7 +15,6 @@ from explainaboard.metrics.metric import MetricConfig
 from explainaboard.processors.processor import Processor
 from explainaboard.processors.processor_registry import register_processor
 from explainaboard.utils.spacy_loader import get_named_entities
-from explainaboard.utils.typing_utils import unwrap
 
 
 @register_processor(TaskType.aspect_based_sentiment_classification)
@@ -80,9 +79,7 @@ class AspectBasedSentimentClassificationProcessor(Processor):
 
     def default_analyses(self) -> list[Analysis]:
         features = self.default_analysis_levels()[0].features
-        continuous_features = [
-            k for k, v in features.items() if ('float' in unwrap(v.dtype))
-        ]
+        continuous_features = [k for k, v in features.items() if v.dtype == 'float32']
         # Create analyses
         analyses: list[Analysis] = [
             BucketAnalysis(

--- a/explainaboard/processors/cloze_generative.py
+++ b/explainaboard/processors/cloze_generative.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from explainaboard import TaskType
 from explainaboard.analysis import feature
-from explainaboard.analysis.analyses import Analysis, AnalysisLevel, BucketAnalysis
+from explainaboard.analysis.analyses import AnalysisLevel
 from explainaboard.analysis.feature import FeatureType
 from explainaboard.analysis.feature_funcs import (
     absolute_position,
@@ -93,20 +93,6 @@ class ClozeGenerativeProcessor(Processor):
                 metric_configs=self.default_metrics(),
             )
         ]
-
-    def default_analyses(self) -> list[Analysis]:
-        features = self.default_analysis_levels()[0].features
-        continuous_features = [k for k, v in features.items() if v.dtype == 'float32']
-        analyses: list[Analysis] = [
-            BucketAnalysis(
-                level="example",
-                description=features[x].description,
-                feature=x,
-                method="continuous",
-            )
-            for x in continuous_features
-        ]
-        return analyses
 
     @classmethod
     def default_metrics(

--- a/explainaboard/processors/cloze_generative.py
+++ b/explainaboard/processors/cloze_generative.py
@@ -7,7 +7,7 @@ import numpy as np
 
 from explainaboard import TaskType
 from explainaboard.analysis import feature
-from explainaboard.analysis.analyses import AnalysisLevel
+from explainaboard.analysis.analyses import Analysis, AnalysisLevel
 from explainaboard.analysis.feature import FeatureType
 from explainaboard.analysis.feature_funcs import (
     absolute_position,
@@ -93,6 +93,9 @@ class ClozeGenerativeProcessor(Processor):
                 metric_configs=self.default_metrics(),
             )
         ]
+
+    def default_analyses(self) -> list[Analysis]:
+        return self.continuous_feature_analyses()
 
     @classmethod
     def default_metrics(

--- a/explainaboard/processors/cloze_generative.py
+++ b/explainaboard/processors/cloze_generative.py
@@ -96,9 +96,7 @@ class ClozeGenerativeProcessor(Processor):
 
     def default_analyses(self) -> list[Analysis]:
         features = self.default_analysis_levels()[0].features
-        continuous_features = [
-            k for k, v in features.items() if ('float' in unwrap(v.dtype))
-        ]
+        continuous_features = [k for k, v in features.items() if v.dtype == 'float32']
         analyses: list[Analysis] = [
             BucketAnalysis(
                 level="example",

--- a/explainaboard/processors/cloze_multiple_choice.py
+++ b/explainaboard/processors/cloze_multiple_choice.py
@@ -6,7 +6,7 @@ from datalabs import aggregating
 
 from explainaboard import TaskType
 from explainaboard.analysis import feature
-from explainaboard.analysis.analyses import Analysis, AnalysisLevel, BucketAnalysis
+from explainaboard.analysis.analyses import AnalysisLevel
 from explainaboard.analysis.feature import FeatureType
 from explainaboard.analysis.feature_funcs import (
     absolute_position,
@@ -97,20 +97,6 @@ class ClozeMultipleChoiceProcessor(Processor):
                 metric_configs=self.default_metrics(),
             )
         ]
-
-    def default_analyses(self) -> list[Analysis]:
-        features = self.default_analysis_levels()[0].features
-        continuous_features = [k for k, v in features.items() if v.dtype == 'float32']
-        analyses: list[Analysis] = [
-            BucketAnalysis(
-                level='example',
-                description=features[x].description,
-                feature=x,
-                method="continuous",
-            )
-            for x in continuous_features
-        ]
-        return analyses
 
     @classmethod
     def default_metrics(

--- a/explainaboard/processors/cloze_multiple_choice.py
+++ b/explainaboard/processors/cloze_multiple_choice.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
-from typing import cast, List
 
 from datalabs import aggregating
 
@@ -31,7 +30,7 @@ class ClozeMultipleChoiceProcessor(Processor):
     def task_type(cls) -> TaskType:
         return TaskType.cloze_mutiple_choice
 
-    def default_analyses(self) -> list[AnalysisLevel]:
+    def default_analysis_levels(self) -> list[AnalysisLevel]:
         features: dict[str, FeatureType] = {
             "context": feature.Value("string"),
             "question_mark": feature.Value("string"),
@@ -90,24 +89,30 @@ class ClozeMultipleChoiceProcessor(Processor):
                 ),
             ),
         }
-        continuous_features = [
-            k for k, v in features.items() if ('float' in unwrap(v.dtype))
-        ]
-        analyses: list[BucketAnalysis] = [
-            BucketAnalysis(
-                description=features[x].description, feature=x, method="continuous"
-            )
-            for x in continuous_features
-        ]
 
         return [
             AnalysisLevel(
                 name='example',
                 features=features,
                 metric_configs=self.default_metrics(),
-                analyses=cast(List[Analysis], analyses),
             )
         ]
+
+    def default_analyses(self) -> list[Analysis]:
+        features = self.default_analysis_levels()[0].features
+        continuous_features = [
+            k for k, v in features.items() if ('float' in unwrap(v.dtype))
+        ]
+        analyses: list[Analysis] = [
+            BucketAnalysis(
+                level='example',
+                description=features[x].description,
+                feature=x,
+                method="continuous",
+            )
+            for x in continuous_features
+        ]
+        return analyses
 
     @classmethod
     def default_metrics(

--- a/explainaboard/processors/cloze_multiple_choice.py
+++ b/explainaboard/processors/cloze_multiple_choice.py
@@ -100,9 +100,7 @@ class ClozeMultipleChoiceProcessor(Processor):
 
     def default_analyses(self) -> list[Analysis]:
         features = self.default_analysis_levels()[0].features
-        continuous_features = [
-            k for k, v in features.items() if ('float' in unwrap(v.dtype))
-        ]
+        continuous_features = [k for k, v in features.items() if v.dtype == 'float32']
         analyses: list[Analysis] = [
             BucketAnalysis(
                 level='example',

--- a/explainaboard/processors/cloze_multiple_choice.py
+++ b/explainaboard/processors/cloze_multiple_choice.py
@@ -6,7 +6,7 @@ from datalabs import aggregating
 
 from explainaboard import TaskType
 from explainaboard.analysis import feature
-from explainaboard.analysis.analyses import AnalysisLevel
+from explainaboard.analysis.analyses import Analysis, AnalysisLevel
 from explainaboard.analysis.feature import FeatureType
 from explainaboard.analysis.feature_funcs import (
     absolute_position,
@@ -97,6 +97,9 @@ class ClozeMultipleChoiceProcessor(Processor):
                 metric_configs=self.default_metrics(),
             )
         ]
+
+    def default_analyses(self) -> list[Analysis]:
+        return self.continuous_feature_analyses()
 
     @classmethod
     def default_metrics(

--- a/explainaboard/processors/conditional_generation.py
+++ b/explainaboard/processors/conditional_generation.py
@@ -163,7 +163,7 @@ class ConditionalGenerationProcessor(Processor):
         analyses: list[Analysis] = []
         examp_features = self.default_analysis_levels()[0].features
         examp_continuous_features = [
-            k for k, v in examp_features.items() if ('float' in unwrap(v.dtype))
+            k for k, v in examp_features.items() if v.dtype == 'float32'
         ]
         analyses.extend(
             [
@@ -178,7 +178,7 @@ class ConditionalGenerationProcessor(Processor):
         )
         tok_features = self.default_analysis_levels()[1].features
         tok_continuous_features = [
-            k for k, v in tok_features.items() if ('float' in unwrap(v.dtype))
+            k for k, v in tok_features.items() if v.dtype == 'float32'
         ]
         analyses.extend(
             [

--- a/explainaboard/processors/conditional_generation.py
+++ b/explainaboard/processors/conditional_generation.py
@@ -10,7 +10,7 @@ import numpy as np
 from explainaboard import TaskType
 from explainaboard.analysis import feature
 import explainaboard.analysis.analyses
-from explainaboard.analysis.analyses import Analysis, AnalysisLevel, BucketAnalysis
+from explainaboard.analysis.analyses import AnalysisLevel
 from explainaboard.analysis.case import (
     AnalysisCase,
     AnalysisCaseMultiSpan,
@@ -158,40 +158,6 @@ class ConditionalGenerationProcessor(Processor):
                 metric_configs=self.default_metrics(level='token'),
             ),
         ]
-
-    def default_analyses(self) -> list[Analysis]:
-        analyses: list[Analysis] = []
-        examp_features = self.default_analysis_levels()[0].features
-        examp_continuous_features = [
-            k for k, v in examp_features.items() if v.dtype == 'float32'
-        ]
-        analyses.extend(
-            [
-                BucketAnalysis(
-                    level="example",
-                    description=examp_features[x].description,
-                    feature=x,
-                    method="continuous",
-                )
-                for x in examp_continuous_features
-            ]
-        )
-        tok_features = self.default_analysis_levels()[1].features
-        tok_continuous_features = [
-            k for k, v in tok_features.items() if v.dtype == 'float32'
-        ]
-        analyses.extend(
-            [
-                BucketAnalysis(
-                    level="token",
-                    description=tok_features[x].description,
-                    feature=x,
-                    method="continuous",
-                )
-                for x in tok_continuous_features
-            ]
-        )
-        return analyses
 
     @classmethod
     def _get_default_eaas_strs(cls):

--- a/explainaboard/processors/conditional_generation.py
+++ b/explainaboard/processors/conditional_generation.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections import defaultdict
 from collections.abc import Iterator
-from typing import Any, cast, List
+from typing import Any, cast
 
 from datalabs import aggregating
 import numpy as np
@@ -43,7 +43,7 @@ class ConditionalGenerationProcessor(Processor):
     def task_type(cls) -> TaskType:
         return TaskType.conditional_generation
 
-    def default_analyses(self) -> list[AnalysisLevel]:
+    def default_analysis_levels(self) -> list[AnalysisLevel]:
         examp_features: dict[str, FeatureType] = {
             "source": feature.Value("string"),
             "reference": feature.Value("string"),
@@ -102,17 +102,6 @@ class ConditionalGenerationProcessor(Processor):
                 require_training_set=True,
             ),
         }
-        examp_continuous_features = [
-            k for k, v in examp_features.items() if ('float' in unwrap(v.dtype))
-        ]
-        examp_analyses: list[BucketAnalysis] = [
-            BucketAnalysis(
-                description=examp_features[x].description,
-                feature=x,
-                method="continuous",
-            )
-            for x in examp_continuous_features
-        ]
 
         tok_features: dict[str, FeatureType] = {
             "tok_text": feature.Value(
@@ -156,30 +145,53 @@ class ConditionalGenerationProcessor(Processor):
                 ),
             ),
         }
-        tok_continuous_features = [
-            k for k, v in tok_features.items() if ('float' in unwrap(v.dtype))
-        ]
-        tok_analyses: list[BucketAnalysis] = [
-            BucketAnalysis(
-                description=tok_features[x].description, feature=x, method="continuous"
-            )
-            for x in tok_continuous_features
-        ]
 
         return [
             AnalysisLevel(
                 name='example',
                 features=examp_features,
                 metric_configs=self.default_metrics(level='example'),
-                analyses=cast(List[Analysis], examp_analyses),
             ),
             AnalysisLevel(
-                name='tok',
+                name='token',
                 features=tok_features,
-                metric_configs=self.default_metrics(level='tok'),
-                analyses=cast(List[Analysis], tok_analyses),
+                metric_configs=self.default_metrics(level='token'),
             ),
         ]
+
+    def default_analyses(self) -> list[Analysis]:
+        analyses: list[Analysis] = []
+        examp_features = self.default_analysis_levels()[0].features
+        examp_continuous_features = [
+            k for k, v in examp_features.items() if ('float' in unwrap(v.dtype))
+        ]
+        analyses.extend(
+            [
+                BucketAnalysis(
+                    level="example",
+                    description=examp_features[x].description,
+                    feature=x,
+                    method="continuous",
+                )
+                for x in examp_continuous_features
+            ]
+        )
+        tok_features = self.default_analysis_levels()[1].features
+        tok_continuous_features = [
+            k for k, v in tok_features.items() if ('float' in unwrap(v.dtype))
+        ]
+        analyses.extend(
+            [
+                BucketAnalysis(
+                    level="token",
+                    description=tok_features[x].description,
+                    feature=x,
+                    method="continuous",
+                )
+                for x in tok_continuous_features
+            ]
+        )
+        return analyses
 
     @classmethod
     def _get_default_eaas_strs(cls):
@@ -199,7 +211,7 @@ class ConditionalGenerationProcessor(Processor):
                 )
                 for x in eaas_defaults
             ],
-            'tok': [
+            'token': [
                 F1ScoreConfig(
                     name='F1',
                     source_language=source_language,
@@ -325,7 +337,7 @@ class ConditionalGenerationProcessor(Processor):
                             sys_info, output, case, statistics
                         )
                 cases.append(case)
-        elif analysis_level.name == 'tok':
+        elif analysis_level.name == 'token':
             # Calculate features
             for i, output in progress(
                 enumerate(sys_output), desc='calculating token-level features'

--- a/explainaboard/processors/conditional_generation.py
+++ b/explainaboard/processors/conditional_generation.py
@@ -10,7 +10,7 @@ import numpy as np
 from explainaboard import TaskType
 from explainaboard.analysis import feature
 import explainaboard.analysis.analyses
-from explainaboard.analysis.analyses import AnalysisLevel
+from explainaboard.analysis.analyses import Analysis, AnalysisLevel
 from explainaboard.analysis.case import (
     AnalysisCase,
     AnalysisCaseMultiSpan,
@@ -158,6 +158,9 @@ class ConditionalGenerationProcessor(Processor):
                 metric_configs=self.default_metrics(level='token'),
             ),
         ]
+
+    def default_analyses(self) -> list[Analysis]:
+        return self.continuous_feature_analyses()
 
     @classmethod
     def _get_default_eaas_strs(cls):

--- a/explainaboard/processors/extractive_qa.py
+++ b/explainaboard/processors/extractive_qa.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
-from typing import cast, List
 
 from datalabs import aggregating
 
@@ -28,7 +27,7 @@ class QAExtractiveProcessor(Processor):
     def task_type(cls) -> TaskType:
         return TaskType.qa_extractive
 
-    def default_analyses(self) -> list[AnalysisLevel]:
+    def default_analysis_levels(self) -> list[AnalysisLevel]:
         features = {
             "context": feature.Value("string"),
             "question": feature.Value("string"),
@@ -75,24 +74,30 @@ class QAExtractiveProcessor(Processor):
                 ),
             ),
         }
-        continuous_features = [
-            k for k, v in features.items() if ('float' in unwrap(v.dtype))
-        ]
-        analyses: list[BucketAnalysis] = [
-            BucketAnalysis(
-                description=features[x].description, feature=x, method="continuous"
-            )
-            for x in continuous_features
-        ]
 
         return [
             AnalysisLevel(
                 name='example',
                 features=features,
                 metric_configs=self.default_metrics(),
-                analyses=cast(List[Analysis], analyses),
             )
         ]
+
+    def default_analyses(self) -> list[Analysis]:
+        features = self.default_analysis_levels()[0].features
+        continuous_features = [
+            k for k, v in features.items() if ('float' in unwrap(v.dtype))
+        ]
+        analyses: list[Analysis] = [
+            BucketAnalysis(
+                level="example",
+                description=features[x].description,
+                feature=x,
+                method="continuous",
+            )
+            for x in continuous_features
+        ]
+        return analyses
 
     @classmethod
     def default_metrics(

--- a/explainaboard/processors/extractive_qa.py
+++ b/explainaboard/processors/extractive_qa.py
@@ -6,7 +6,7 @@ from datalabs import aggregating
 
 from explainaboard import TaskType
 from explainaboard.analysis import feature
-from explainaboard.analysis.analyses import Analysis, AnalysisLevel, BucketAnalysis
+from explainaboard.analysis.analyses import AnalysisLevel
 from explainaboard.analysis.feature_funcs import (
     accumulate_vocab_from_samples,
     count_tokens,
@@ -82,20 +82,6 @@ class QAExtractiveProcessor(Processor):
                 metric_configs=self.default_metrics(),
             )
         ]
-
-    def default_analyses(self) -> list[Analysis]:
-        features = self.default_analysis_levels()[0].features
-        continuous_features = [k for k, v in features.items() if v.dtype == 'float32']
-        analyses: list[Analysis] = [
-            BucketAnalysis(
-                level="example",
-                description=features[x].description,
-                feature=x,
-                method="continuous",
-            )
-            for x in continuous_features
-        ]
-        return analyses
 
     @classmethod
     def default_metrics(

--- a/explainaboard/processors/extractive_qa.py
+++ b/explainaboard/processors/extractive_qa.py
@@ -6,7 +6,7 @@ from datalabs import aggregating
 
 from explainaboard import TaskType
 from explainaboard.analysis import feature
-from explainaboard.analysis.analyses import AnalysisLevel
+from explainaboard.analysis.analyses import Analysis, AnalysisLevel
 from explainaboard.analysis.feature_funcs import (
     accumulate_vocab_from_samples,
     count_tokens,
@@ -82,6 +82,9 @@ class QAExtractiveProcessor(Processor):
                 metric_configs=self.default_metrics(),
             )
         ]
+
+    def default_analyses(self) -> list[Analysis]:
+        return self.continuous_feature_analyses()
 
     @classmethod
     def default_metrics(

--- a/explainaboard/processors/extractive_qa.py
+++ b/explainaboard/processors/extractive_qa.py
@@ -85,9 +85,7 @@ class QAExtractiveProcessor(Processor):
 
     def default_analyses(self) -> list[Analysis]:
         features = self.default_analysis_levels()[0].features
-        continuous_features = [
-            k for k, v in features.items() if ('float' in unwrap(v.dtype))
-        ]
+        continuous_features = [k for k, v in features.items() if v.dtype == 'float32']
         analyses: list[Analysis] = [
             BucketAnalysis(
                 level="example",

--- a/explainaboard/processors/grammatical_error_correction.py
+++ b/explainaboard/processors/grammatical_error_correction.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from explainaboard import TaskType
 from explainaboard.analysis import feature
-from explainaboard.analysis.analyses import AnalysisLevel
+from explainaboard.analysis.analyses import Analysis, AnalysisLevel
 from explainaboard.analysis.feature import FeatureType
 from explainaboard.analysis.feature_funcs import count_tokens
 from explainaboard.metrics.accuracy import SeqCorrectCountConfig
@@ -45,6 +45,9 @@ class GrammaticalErrorCorrection(Processor):
                 metric_configs=self.default_metrics(),
             )
         ]
+
+    def default_analyses(self) -> list[Analysis]:
+        return self.continuous_feature_analyses()
 
     @classmethod
     def default_metrics(

--- a/explainaboard/processors/grammatical_error_correction.py
+++ b/explainaboard/processors/grammatical_error_correction.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from explainaboard import TaskType
 from explainaboard.analysis import feature
-from explainaboard.analysis.analyses import Analysis, AnalysisLevel, BucketAnalysis
+from explainaboard.analysis.analyses import AnalysisLevel
 from explainaboard.analysis.feature import FeatureType
 from explainaboard.analysis.feature_funcs import count_tokens
 from explainaboard.metrics.accuracy import SeqCorrectCountConfig
@@ -45,20 +45,6 @@ class GrammaticalErrorCorrection(Processor):
                 metric_configs=self.default_metrics(),
             )
         ]
-
-    def default_analyses(self) -> list[Analysis]:
-        features = self.default_analysis_levels()[0].features
-        continuous_features = [k for k, v in features.items() if v.dtype == 'float32']
-        analyses: list[Analysis] = [
-            BucketAnalysis(
-                level="example",
-                description=features[x].description,
-                feature=x,
-                method="continuous",
-            )
-            for x in continuous_features
-        ]
-        return analyses
 
     @classmethod
     def default_metrics(

--- a/explainaboard/processors/grammatical_error_correction.py
+++ b/explainaboard/processors/grammatical_error_correction.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import cast, List
-
 from explainaboard import TaskType
 from explainaboard.analysis import feature
 from explainaboard.analysis.analyses import Analysis, AnalysisLevel, BucketAnalysis
@@ -20,7 +18,7 @@ class GrammaticalErrorCorrection(Processor):
     def task_type(cls) -> TaskType:
         return TaskType.grammatical_error_correction
 
-    def default_analyses(self) -> list[AnalysisLevel]:
+    def default_analysis_levels(self) -> list[AnalysisLevel]:
         features: dict[str, FeatureType] = feature.Features(
             {
                 "text": feature.Value("string"),
@@ -40,24 +38,30 @@ class GrammaticalErrorCorrection(Processor):
                 ),
             }
         )
-        continuous_features = [
-            k for k, v in features.items() if ('float' in unwrap(v.dtype))
-        ]
-        analyses: list[BucketAnalysis] = [
-            BucketAnalysis(
-                description=features[x].description, feature=x, method="continuous"
-            )
-            for x in continuous_features
-        ]
 
         return [
             AnalysisLevel(
                 name='example',
                 features=features,
                 metric_configs=self.default_metrics(),
-                analyses=cast(List[Analysis], analyses),
             )
         ]
+
+    def default_analyses(self) -> list[Analysis]:
+        features = self.default_analysis_levels()[0].features
+        continuous_features = [
+            k for k, v in features.items() if ('float' in unwrap(v.dtype))
+        ]
+        analyses: list[Analysis] = [
+            BucketAnalysis(
+                level="example",
+                description=features[x].description,
+                feature=x,
+                method="continuous",
+            )
+            for x in continuous_features
+        ]
+        return analyses
 
     @classmethod
     def default_metrics(

--- a/explainaboard/processors/grammatical_error_correction.py
+++ b/explainaboard/processors/grammatical_error_correction.py
@@ -9,7 +9,6 @@ from explainaboard.metrics.accuracy import SeqCorrectCountConfig
 from explainaboard.metrics.metric import MetricConfig
 from explainaboard.processors.processor import Processor
 from explainaboard.processors.processor_registry import register_processor
-from explainaboard.utils.typing_utils import unwrap
 
 
 @register_processor(TaskType.grammatical_error_correction)
@@ -49,9 +48,7 @@ class GrammaticalErrorCorrection(Processor):
 
     def default_analyses(self) -> list[Analysis]:
         features = self.default_analysis_levels()[0].features
-        continuous_features = [
-            k for k, v in features.items() if ('float' in unwrap(v.dtype))
-        ]
+        continuous_features = [k for k, v in features.items() if v.dtype == 'float32']
         analyses: list[Analysis] = [
             BucketAnalysis(
                 level="example",

--- a/explainaboard/processors/kg_link_tail_prediction.py
+++ b/explainaboard/processors/kg_link_tail_prediction.py
@@ -111,7 +111,7 @@ class KGLinkTailPredictionProcessor(Processor):
             )
             for k, v in discrete_features.items()
         ]
-        analyses.extend(super().default_analyses())
+        analyses.extend(self.continuous_feature_analyses())
         return analyses
 
     @classmethod

--- a/explainaboard/processors/kg_link_tail_prediction.py
+++ b/explainaboard/processors/kg_link_tail_prediction.py
@@ -98,33 +98,20 @@ class KGLinkTailPredictionProcessor(Processor):
         ]
 
     def default_analyses(self) -> list[Analysis]:
-        features = self.default_analysis_levels()[0].features
-        continuous_features = [k for k, v in features.items() if v.dtype == 'float32']
+        analysis_levels = self.default_analysis_levels()
+        features = analysis_levels[0].features
         discrete_features = {'symmetry': 2, 'entity_type_level': 8, 'true_link': 15}
-        analyses: list[Analysis] = []
-        analyses.extend(
-            [
-                BucketAnalysis(
-                    level="example",
-                    description=features[x].description,
-                    feature=x,
-                    method="continuous",
-                )
-                for x in continuous_features
-            ]
-        )
-        analyses.extend(
-            [
-                BucketAnalysis(
-                    level="example",
-                    description=features[k].description,
-                    feature=k,
-                    method="discrete",
-                    number=v,
-                )
-                for k, v in discrete_features.items()
-            ]
-        )
+        analyses: list[Analysis] = [
+            BucketAnalysis(
+                level=analysis_levels[0].name,
+                description=features[k].description,
+                feature=k,
+                method="discrete",
+                number=v,
+            )
+            for k, v in discrete_features.items()
+        ]
+        analyses.extend(super().default_analyses())
         return analyses
 
     @classmethod

--- a/explainaboard/processors/kg_link_tail_prediction.py
+++ b/explainaboard/processors/kg_link_tail_prediction.py
@@ -22,7 +22,6 @@ from explainaboard.processors.processor import Processor
 from explainaboard.processors.processor_registry import register_processor
 from explainaboard.utils import cache_api
 from explainaboard.utils.logging import progress
-from explainaboard.utils.typing_utils import unwrap
 
 
 @register_processor(TaskType.kg_link_tail_prediction)
@@ -100,9 +99,7 @@ class KGLinkTailPredictionProcessor(Processor):
 
     def default_analyses(self) -> list[Analysis]:
         features = self.default_analysis_levels()[0].features
-        continuous_features = [
-            k for k, v in features.items() if ('float' in unwrap(v.dtype))
-        ]
+        continuous_features = [k for k, v in features.items() if v.dtype == 'float32']
         discrete_features = {'symmetry': 2, 'entity_type_level': 8, 'true_link': 15}
         analyses: list[Analysis] = []
         analyses.extend(

--- a/explainaboard/processors/language_modeling.py
+++ b/explainaboard/processors/language_modeling.py
@@ -130,39 +130,18 @@ class LanguageModelingProcessor(Processor):
 
     def default_analyses(self) -> list[Analysis]:
         analyses: list[Analysis] = []
-        examp_features = self.default_analysis_levels()[0].features
-        examp_continuous_features = [
-            k for k, v in examp_features.items() if v.dtype == 'float32'
-        ]
-        analyses.extend(
-            [
-                BucketAnalysis(
-                    level="example",
-                    description=examp_features[x].description,
-                    feature=x,
-                    method="continuous",
-                )
-                for x in examp_continuous_features
-            ]
-        )
-        tok_features = self.default_analysis_levels()[1].features
-        tok_continuous_features = [
-            k
-            for k, v in tok_features.items()
-            if v.dtype == 'float32'
-            if k != 'tok_log_prob'
-        ]
-        analyses.extend(
-            [
-                BucketAnalysis(
-                    level="token",
-                    description=tok_features[x].description,
-                    feature=x,
-                    method="continuous",
-                )
-                for x in tok_continuous_features
-            ]
-        )
+        analysis_levels = self.default_analysis_levels()
+        for lev in analysis_levels:
+            for k, v in lev.features.items():
+                if v.dtype == 'float32' and k != 'tok_log_prob':
+                    analyses.append(
+                        BucketAnalysis(
+                            level=lev.name,
+                            description=lev.features[k].description,
+                            feature=k,
+                            method="continuous",
+                        )
+                    )
         return analyses
 
     def _gen_cases_and_stats(

--- a/explainaboard/processors/language_modeling.py
+++ b/explainaboard/processors/language_modeling.py
@@ -132,7 +132,7 @@ class LanguageModelingProcessor(Processor):
         analyses: list[Analysis] = []
         examp_features = self.default_analysis_levels()[0].features
         examp_continuous_features = [
-            k for k, v in examp_features.items() if ('float' in unwrap(v.dtype))
+            k for k, v in examp_features.items() if v.dtype == 'float32'
         ]
         analyses.extend(
             [
@@ -149,7 +149,7 @@ class LanguageModelingProcessor(Processor):
         tok_continuous_features = [
             k
             for k, v in tok_features.items()
-            if ('float' in unwrap(v.dtype))
+            if v.dtype == 'float32'
             if k != 'tok_log_prob'
         ]
         analyses.extend(

--- a/explainaboard/processors/language_modeling.py
+++ b/explainaboard/processors/language_modeling.py
@@ -32,7 +32,7 @@ class LanguageModelingProcessor(Processor):
     def task_type(cls) -> TaskType:
         return TaskType.language_modeling
 
-    def default_analyses(self) -> list[AnalysisLevel]:
+    def default_analysis_levels(self) -> list[AnalysisLevel]:
         examp_features: dict[str, FeatureType] = {
             "text": feature.Value("string"),
             "log_probs": feature.Value("string"),
@@ -74,17 +74,6 @@ class LanguageModelingProcessor(Processor):
                 ),
             ),
         }
-        examp_continuous_features = [
-            k for k, v in examp_features.items() if ('float' in unwrap(v.dtype))
-        ]
-        examp_analyses: list[BucketAnalysis] = [
-            BucketAnalysis(
-                description=examp_features[x].description,
-                feature=x,
-                method="continuous",
-            )
-            for x in examp_continuous_features
-        ]
 
         tok_features: dict[str, FeatureType] = {
             "tok_log_prob": feature.Value(
@@ -125,33 +114,56 @@ class LanguageModelingProcessor(Processor):
                 func=lambda info, x, c, stat: stat['vocab'].get(c.text, 0.0),
             ),
         }
-        tok_continuous_features = [
-            k
-            for k, v in tok_features.items()
-            if ('float' in unwrap(v.dtype))
-            if k != 'tok_log_prob'
-        ]
-        tok_analyses: list[BucketAnalysis] = [
-            BucketAnalysis(
-                description=tok_features[x].description, feature=x, method="continuous"
-            )
-            for x in tok_continuous_features
-        ]
 
         return [
             AnalysisLevel(
                 name='example',
                 features=examp_features,
                 metric_configs=self.default_metrics(level='example'),
-                analyses=cast(List[Analysis], examp_analyses),
             ),
             AnalysisLevel(
-                name='tok',
+                name='token',
                 features=tok_features,
-                metric_configs=self.default_metrics(level='tok'),
-                analyses=cast(List[Analysis], tok_analyses),
+                metric_configs=self.default_metrics(level='token'),
             ),
         ]
+
+    def default_analyses(self) -> list[Analysis]:
+        analyses: list[Analysis] = []
+        examp_features = self.default_analysis_levels()[0].features
+        examp_continuous_features = [
+            k for k, v in examp_features.items() if ('float' in unwrap(v.dtype))
+        ]
+        analyses.extend(
+            [
+                BucketAnalysis(
+                    level="example",
+                    description=examp_features[x].description,
+                    feature=x,
+                    method="continuous",
+                )
+                for x in examp_continuous_features
+            ]
+        )
+        tok_features = self.default_analysis_levels()[1].features
+        tok_continuous_features = [
+            k
+            for k, v in tok_features.items()
+            if ('float' in unwrap(v.dtype))
+            if k != 'tok_log_prob'
+        ]
+        analyses.extend(
+            [
+                BucketAnalysis(
+                    level="token",
+                    description=tok_features[x].description,
+                    feature=x,
+                    method="continuous",
+                )
+                for x in tok_continuous_features
+            ]
+        )
+        return analyses
 
     def _gen_cases_and_stats(
         self,
@@ -164,7 +176,7 @@ class LanguageModelingProcessor(Processor):
             return super()._gen_cases_and_stats(
                 sys_info, sys_output, statistics, analysis_level
             )
-        elif analysis_level.name != 'tok':
+        elif analysis_level.name != 'token':
             raise ValueError(f'{analysis_level.name}-level analysis not supported')
         # Do tok-level analysis
         cases: list[AnalysisCaseSpan] = []

--- a/explainaboard/processors/machine_translation.py
+++ b/explainaboard/processors/machine_translation.py
@@ -7,7 +7,7 @@ from datalabs import aggregating
 
 from explainaboard import TaskType
 from explainaboard.analysis import feature
-from explainaboard.analysis.analyses import AnalysisLevel, BucketAnalysis
+from explainaboard.analysis.analyses import Analysis, AnalysisLevel, BucketAnalysis
 from explainaboard.analysis.feature_funcs import accumulate_vocab_from_samples
 from explainaboard.info import SysOutputInfo
 from explainaboard.loaders.file_loader import FileLoader, FileLoaderField
@@ -24,8 +24,8 @@ class MachineTranslationProcessor(ConditionalGenerationProcessor):
     def task_type(cls) -> TaskType:
         return TaskType.machine_translation
 
-    def default_analyses(self) -> list[AnalysisLevel]:
-        f = super().default_analyses()
+    def default_analysis_levels(self) -> list[AnalysisLevel]:
+        f = super().default_analysis_levels()
         f = copy.deepcopy(f)
         f[0].features["attr_compression"] = feature.Value(
             dtype="float",
@@ -33,20 +33,22 @@ class MachineTranslationProcessor(ConditionalGenerationProcessor):
             func=lambda info, x, c: c.features['source_length']
             / c.features['reference_length'],
         )
-        f[0].analyses.append(
+
+        return f
+
+    def default_analyses(self) -> list[Analysis]:
+        levs = self.default_analysis_levels()
+        f = super().default_analyses()
+        f = copy.deepcopy(f)
+        f.append(
             BucketAnalysis(
-                description=f[0].features['attr_compression'].description,
+                level="example",
+                description=levs[0].features['attr_compression'].description,
                 feature='attr_compression',
                 method="continuous",
             )
         )
-
         return f
-
-    def _get_attr_compression(self, sys_info: SysOutputInfo, existing_features: dict):
-        return len(
-            unwrap(sys_info.source_tokenizer)(existing_features["source"])
-        ) / len(unwrap(sys_info.target_tokenizer)(existing_features["reference"]))
 
     @aggregating()
     def _statistics_func(self, samples: Iterator, sys_info: SysOutputInfo):

--- a/explainaboard/processors/machine_translation.py
+++ b/explainaboard/processors/machine_translation.py
@@ -7,7 +7,7 @@ from datalabs import aggregating
 
 from explainaboard import TaskType
 from explainaboard.analysis import feature
-from explainaboard.analysis.analyses import Analysis, AnalysisLevel, BucketAnalysis
+from explainaboard.analysis.analyses import AnalysisLevel
 from explainaboard.analysis.feature_funcs import accumulate_vocab_from_samples
 from explainaboard.info import SysOutputInfo
 from explainaboard.loaders.file_loader import FileLoader, FileLoaderField
@@ -34,20 +34,6 @@ class MachineTranslationProcessor(ConditionalGenerationProcessor):
             / c.features['reference_length'],
         )
 
-        return f
-
-    def default_analyses(self) -> list[Analysis]:
-        levs = self.default_analysis_levels()
-        f = super().default_analyses()
-        f = copy.deepcopy(f)
-        f.append(
-            BucketAnalysis(
-                level="example",
-                description=levs[0].features['attr_compression'].description,
-                feature='attr_compression',
-                method="continuous",
-            )
-        )
         return f
 
     @aggregating()

--- a/explainaboard/processors/nlg_meta_evaluation.py
+++ b/explainaboard/processors/nlg_meta_evaluation.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from explainaboard import TaskType
 from explainaboard.analysis import feature
-from explainaboard.analysis.analyses import AnalysisLevel
+from explainaboard.analysis.analyses import Analysis, AnalysisLevel
 from explainaboard.analysis.feature import FeatureType
 from explainaboard.analysis.feature_funcs import count_tokens
 from explainaboard.metrics.metric import MetricConfig
@@ -94,6 +94,9 @@ class NLGMetaEvaluationProcessor(Processor):
                 metric_configs=self.default_metrics(),
             )
         ]
+
+    def default_analyses(self) -> list[Analysis]:
+        return self.continuous_feature_analyses()
 
     @classmethod
     def default_metrics(

--- a/explainaboard/processors/nlg_meta_evaluation.py
+++ b/explainaboard/processors/nlg_meta_evaluation.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from explainaboard import TaskType
 from explainaboard.analysis import feature
-from explainaboard.analysis.analyses import Analysis, AnalysisLevel, BucketAnalysis
+from explainaboard.analysis.analyses import AnalysisLevel
 from explainaboard.analysis.feature import FeatureType
 from explainaboard.analysis.feature_funcs import count_tokens
 from explainaboard.metrics.metric import MetricConfig
@@ -94,22 +94,6 @@ class NLGMetaEvaluationProcessor(Processor):
                 metric_configs=self.default_metrics(),
             )
         ]
-
-    def default_analyses(self) -> list[Analysis]:
-        features = self.default_analysis_levels()[0].features
-        continuous_features = [k for k, v in features.items() if v.dtype == 'float32']
-        # Create analyses
-        analyses: list[Analysis] = []
-        for x in continuous_features:
-            analyses.append(
-                BucketAnalysis(
-                    level="example",
-                    description=features[x].description,
-                    feature=x,
-                    method="continuous",
-                )
-            )
-        return analyses
 
     @classmethod
     def default_metrics(

--- a/explainaboard/processors/nlg_meta_evaluation.py
+++ b/explainaboard/processors/nlg_meta_evaluation.py
@@ -12,7 +12,6 @@ from explainaboard.metrics.nlg_meta_evaluation import (
 )
 from explainaboard.processors.processor import Processor
 from explainaboard.processors.processor_registry import register_processor
-from explainaboard.utils.typing_utils import unwrap
 
 
 @register_processor(TaskType.nlg_meta_evaluation)
@@ -98,9 +97,7 @@ class NLGMetaEvaluationProcessor(Processor):
 
     def default_analyses(self) -> list[Analysis]:
         features = self.default_analysis_levels()[0].features
-        continuous_features = [
-            k for k, v in features.items() if ('float' in unwrap(v.dtype))
-        ]
+        continuous_features = [k for k, v in features.items() if v.dtype == 'float32']
         # Create analyses
         analyses: list[Analysis] = []
         for x in continuous_features:

--- a/explainaboard/processors/processor.py
+++ b/explainaboard/processors/processor.py
@@ -47,10 +47,13 @@ class Processor(metaclass=abc.ABCMeta):
         list would have one level for each."""
         ...
 
+    @abc.abstractmethod
     def default_analyses(self) -> list[Analysis]:
-        """Returns the analyses to be performed.
+        """Returns the analyses to be performed."""
+        ...
 
-        By default it performs analysis over
+    def continuous_feature_analyses(self) -> list[Analysis]:
+        """Return analyses over
         all continuous features specified in the analysis levels."""
         analyses: list[Analysis] = []
         analysis_levels = self.default_analysis_levels()

--- a/explainaboard/processors/processor.py
+++ b/explainaboard/processors/processor.py
@@ -12,6 +12,7 @@ from explainaboard.analysis.analyses import (
     Analysis,
     AnalysisLevel,
     AnalysisResult,
+    BucketAnalysis,
     BucketAnalysisResult,
 )
 from explainaboard.analysis.case import AnalysisCase
@@ -46,10 +47,26 @@ class Processor(metaclass=abc.ABCMeta):
         list would have one level for each."""
         ...
 
-    @abc.abstractmethod
     def default_analyses(self) -> list[Analysis]:
-        """Returns the analyses to be performed."""
-        ...
+        """Returns the analyses to be performed.
+
+        By default it performs analysis over
+        all continuous features specified in the analysis levels."""
+        analyses: list[Analysis] = []
+        analysis_levels = self.default_analysis_levels()
+        for lev in analysis_levels:
+            # Continuous features
+            for k, v in lev.features.items():
+                if v.dtype == 'float32':
+                    analyses.append(
+                        BucketAnalysis(
+                            level=lev.name,
+                            description=lev.features[k].description,
+                            feature=k,
+                            method="continuous",
+                        )
+                    )
+        return analyses
 
     @classmethod
     @abc.abstractmethod

--- a/explainaboard/processors/processor.py
+++ b/explainaboard/processors/processor.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import abc
-import itertools
 from typing import Any, cast, Optional
 
 from datalabs import aggregating, Dataset, DatasetDict, load_dataset
@@ -40,11 +39,16 @@ class Processor(metaclass=abc.ABCMeta):
         ...
 
     @abc.abstractmethod
-    def default_analyses(self) -> list[AnalysisLevel]:
+    def default_analysis_levels(self) -> list[AnalysisLevel]:
         """Returns a list of analysis levels, indicating analyses that can be
         applied to different views of the higher-level example. For instance, a task may
         perform 'example'-level analysis, and 'token'-level analysis in which case this
         list would have one level for each."""
+        ...
+
+    @abc.abstractmethod
+    def default_analyses(self) -> list[Analysis]:
+        """Returns the analyses to be performed."""
         ...
 
     @classmethod
@@ -175,8 +179,8 @@ class Processor(metaclass=abc.ABCMeta):
         self,
         sys_info: SysOutputInfo,
         custom_features: dict[str, dict[str, dict]] | None,
-        custom_analyses: dict[str, list[dict]] | None,
-    ) -> list[AnalysisLevel]:
+        custom_analyses: list[dict] | None,
+    ) -> tuple[list[AnalysisLevel], list[Analysis]]:
         """
         Customize analyses for this processor
         Args:
@@ -186,17 +190,15 @@ class Processor(metaclass=abc.ABCMeta):
         Returns:
 
         """
-        analysis_levels = self.default_analyses()
+        analysis_levels = self.default_analysis_levels()
+        analyses = self.default_analyses()
         for level in analysis_levels:
             for config in level.metric_configs:
                 config.source_language = sys_info.source_language
                 config.target_language = sys_info.target_language
         level_map = {x.name: x for x in analysis_levels}
         if custom_analyses is not None:
-            for level_name, analysis_content in custom_analyses.items():
-                level_map[level_name].analyses.extend(
-                    [Analysis.from_dict(v) for v in analysis_content]
-                )
+            analyses.extend([Analysis.from_dict(v) for v in custom_analyses])
         if custom_features is not None:
             for level_name, feature_content in custom_features.items():
                 level_map[level_name].features.update(
@@ -205,14 +207,14 @@ class Processor(metaclass=abc.ABCMeta):
                         for k, v in feature_content.items()
                     }
                 )
-        return analysis_levels
+        return analysis_levels, analyses
 
     def perform_analyses(
         self,
         sys_info: SysOutputInfo,
         analysis_cases: list[list[AnalysisCase]],
         metric_stats: list[list[MetricStats]],
-    ) -> list[list[AnalysisResult]]:
+    ) -> list[AnalysisResult]:
         """
         Perform fine-grained analyses
         :param sys_info: Information about the system output
@@ -224,23 +226,21 @@ class Processor(metaclass=abc.ABCMeta):
         """
 
         all_results = []
-        for my_level, my_cases, my_stats in zip(
-            unwrap(sys_info.analysis_levels), analysis_cases, metric_stats
-        ):
-            my_results = []
-            my_metrics = [x.to_metric() for x in my_level.metric_configs]
-            for my_analysis in progress(
-                my_level.analyses, desc=f"{my_level.name}-level analysis"
-            ):
-                my_results.append(
-                    my_analysis.perform(
-                        cases=my_cases,
-                        metrics=my_metrics,
-                        stats=my_stats,
-                        conf_value=sys_info.conf_value,
-                    )
+        level_map = {v.name: i for i, v in enumerate(unwrap(sys_info.analysis_levels))}
+        metrics = [
+            [y.to_metric() for y in x.metric_configs]
+            for x in unwrap(sys_info.analysis_levels)
+        ]
+        for my_analysis in progress(unwrap(sys_info.analyses)):
+            level_id = level_map[my_analysis.level]
+            all_results.append(
+                my_analysis.perform(
+                    cases=analysis_cases[level_id],
+                    metrics=metrics[level_id],
+                    stats=metric_stats[level_id],
+                    conf_value=sys_info.conf_value,
                 )
-            all_results.append(my_results)
+            )
 
         return all_results
 
@@ -334,7 +334,7 @@ class Processor(metaclass=abc.ABCMeta):
 
     def sort_bucket_info(
         self,
-        analysis_results: list[list[AnalysisResult]],
+        analysis_results: list[AnalysisResult],
         sort_by: str = 'value',
         sort_by_metric: str = 'first',
         sort_ascending: bool = False,
@@ -378,7 +378,7 @@ class Processor(metaclass=abc.ABCMeta):
                     return bp.value
             raise ValueError(f'could not find metric {sort_by_metric}')
 
-        for analysis_result in itertools.chain.from_iterable(analysis_results):
+        for analysis_result in analysis_results:
             if not isinstance(analysis_result, BucketAnalysisResult):
                 continue
             bucket_result = cast(
@@ -428,8 +428,8 @@ class Processor(metaclass=abc.ABCMeta):
 
         # declare customized features: _features will be updated
         custom_features: dict = metadata.get('custom_features', {})
-        custom_analyses: dict = metadata.get('custom_analyses', {})
-        sys_info.analysis_levels = self._customize_analyses(
+        custom_analyses: list = metadata.get('custom_analyses', [])
+        sys_info.analysis_levels, sys_info.analyses = self._customize_analyses(
             sys_info, custom_features, custom_analyses
         )
 

--- a/explainaboard/processors/qa_multiple_choice.py
+++ b/explainaboard/processors/qa_multiple_choice.py
@@ -6,7 +6,7 @@ from datalabs import aggregating
 
 from explainaboard import TaskType
 from explainaboard.analysis import feature
-from explainaboard.analysis.analyses import Analysis, AnalysisLevel, BucketAnalysis
+from explainaboard.analysis.analyses import AnalysisLevel
 from explainaboard.analysis.feature_funcs import (
     accumulate_vocab_from_samples,
     count_tokens,
@@ -84,20 +84,6 @@ class QAMultipleChoiceProcessor(Processor):
                 metric_configs=self.default_metrics(),
             )
         ]
-
-    def default_analyses(self) -> list[Analysis]:
-        features = self.default_analysis_levels()[0].features
-        continuous_features = [k for k, v in features.items() if v.dtype == 'float32']
-        analyses: list[Analysis] = [
-            BucketAnalysis(
-                level="example",
-                description=features[x].description,
-                feature=x,
-                method="continuous",
-            )
-            for x in continuous_features
-        ]
-        return analyses
 
     @classmethod
     def default_metrics(

--- a/explainaboard/processors/qa_multiple_choice.py
+++ b/explainaboard/processors/qa_multiple_choice.py
@@ -87,9 +87,7 @@ class QAMultipleChoiceProcessor(Processor):
 
     def default_analyses(self) -> list[Analysis]:
         features = self.default_analysis_levels()[0].features
-        continuous_features = [
-            k for k, v in features.items() if ('float' in unwrap(v.dtype))
-        ]
+        continuous_features = [k for k, v in features.items() if v.dtype == 'float32']
         analyses: list[Analysis] = [
             BucketAnalysis(
                 level="example",

--- a/explainaboard/processors/qa_multiple_choice.py
+++ b/explainaboard/processors/qa_multiple_choice.py
@@ -6,7 +6,7 @@ from datalabs import aggregating
 
 from explainaboard import TaskType
 from explainaboard.analysis import feature
-from explainaboard.analysis.analyses import AnalysisLevel
+from explainaboard.analysis.analyses import Analysis, AnalysisLevel
 from explainaboard.analysis.feature_funcs import (
     accumulate_vocab_from_samples,
     count_tokens,
@@ -84,6 +84,9 @@ class QAMultipleChoiceProcessor(Processor):
                 metric_configs=self.default_metrics(),
             )
         ]
+
+    def default_analyses(self) -> list[Analysis]:
+        return self.continuous_feature_analyses()
 
     @classmethod
     def default_metrics(

--- a/explainaboard/processors/qa_multiple_choice.py
+++ b/explainaboard/processors/qa_multiple_choice.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from collections.abc import Iterator
-from typing import cast, List
 
 from datalabs import aggregating
 
@@ -28,7 +27,7 @@ class QAMultipleChoiceProcessor(Processor):
     def task_type(cls) -> TaskType:
         return TaskType.qa_multiple_choice
 
-    def default_analyses(self) -> list[AnalysisLevel]:
+    def default_analysis_levels(self) -> list[AnalysisLevel]:
         features = {
             "context": feature.Value("string"),
             "question": feature.Value("string"),
@@ -77,24 +76,30 @@ class QAMultipleChoiceProcessor(Processor):
                 ),
             ),
         }
-        continuous_features = [
-            k for k, v in features.items() if ('float' in unwrap(v.dtype))
-        ]
-        analyses: list[BucketAnalysis] = [
-            BucketAnalysis(
-                description=features[x].description, feature=x, method="continuous"
-            )
-            for x in continuous_features
-        ]
 
         return [
             AnalysisLevel(
                 name='example',
                 features=features,
                 metric_configs=self.default_metrics(),
-                analyses=cast(List[Analysis], analyses),
             )
         ]
+
+    def default_analyses(self) -> list[Analysis]:
+        features = self.default_analysis_levels()[0].features
+        continuous_features = [
+            k for k, v in features.items() if ('float' in unwrap(v.dtype))
+        ]
+        analyses: list[Analysis] = [
+            BucketAnalysis(
+                level="example",
+                description=features[x].description,
+                feature=x,
+                method="continuous",
+            )
+            for x in continuous_features
+        ]
+        return analyses
 
     @classmethod
     def default_metrics(

--- a/explainaboard/processors/qa_open_domain.py
+++ b/explainaboard/processors/qa_open_domain.py
@@ -6,7 +6,7 @@ from datalabs import aggregating
 
 from explainaboard import TaskType
 from explainaboard.analysis import feature
-from explainaboard.analysis.analyses import AnalysisLevel
+from explainaboard.analysis.analyses import Analysis, AnalysisLevel
 from explainaboard.analysis.feature_funcs import (
     accumulate_vocab_from_samples,
     count_tokens,
@@ -76,6 +76,9 @@ class QAOpenDomainProcessor(Processor):
                 metric_configs=self.default_metrics(),
             )
         ]
+
+    def default_analyses(self) -> list[Analysis]:
+        return self.continuous_feature_analyses()
 
     @classmethod
     def default_metrics(

--- a/explainaboard/processors/qa_open_domain.py
+++ b/explainaboard/processors/qa_open_domain.py
@@ -79,9 +79,7 @@ class QAOpenDomainProcessor(Processor):
 
     def default_analyses(self) -> list[Analysis]:
         features = self.default_analysis_levels()[0].features
-        continuous_features = [
-            k for k, v in features.items() if ('float' in unwrap(v.dtype))
-        ]
+        continuous_features = [k for k, v in features.items() if v.dtype == 'float32']
         analyses: list[Analysis] = [
             BucketAnalysis(
                 level="example",

--- a/explainaboard/processors/qa_open_domain.py
+++ b/explainaboard/processors/qa_open_domain.py
@@ -6,7 +6,7 @@ from datalabs import aggregating
 
 from explainaboard import TaskType
 from explainaboard.analysis import feature
-from explainaboard.analysis.analyses import Analysis, AnalysisLevel, BucketAnalysis
+from explainaboard.analysis.analyses import AnalysisLevel
 from explainaboard.analysis.feature_funcs import (
     accumulate_vocab_from_samples,
     count_tokens,
@@ -76,20 +76,6 @@ class QAOpenDomainProcessor(Processor):
                 metric_configs=self.default_metrics(),
             )
         ]
-
-    def default_analyses(self) -> list[Analysis]:
-        features = self.default_analysis_levels()[0].features
-        continuous_features = [k for k, v in features.items() if v.dtype == 'float32']
-        analyses: list[Analysis] = [
-            BucketAnalysis(
-                level="example",
-                description=features[x].description,
-                feature=x,
-                method="continuous",
-            )
-            for x in continuous_features
-        ]
-        return analyses
 
     @classmethod
     def default_metrics(

--- a/explainaboard/processors/sequence_labeling.py
+++ b/explainaboard/processors/sequence_labeling.py
@@ -38,7 +38,7 @@ class SeqLabProcessor(Processor):
         super().__init__()
         self._span_ops: SpanOps = self.default_span_ops()
 
-    def default_analyses(self) -> list[AnalysisLevel]:
+    def default_analysis_levels(self) -> list[AnalysisLevel]:
         examp_features: dict[str, FeatureType] = {
             "tokens": feature.Sequence(feature=feature.Value("string")),
             "true_tags": feature.Sequence(feature=feature.Value("string")),
@@ -73,17 +73,6 @@ class SeqLabProcessor(Processor):
                 ),
             ),
         }
-        examp_continuous_features = [
-            k for k, v in examp_features.items() if ('float' in unwrap(v.dtype))
-        ]
-        examp_analyses: list[BucketAnalysis] = [
-            BucketAnalysis(
-                description=examp_features[x].description,
-                feature=x,
-                method="continuous",
-            )
-            for x in examp_continuous_features
-        ]
 
         span_features: dict[str, FeatureType] = {
             "span_text": feature.Value(
@@ -136,50 +125,75 @@ class SeqLabProcessor(Processor):
                 func=lambda info, x, c, stat: stat['efre_dic'].get(c.text.lower(), 0.0),
             ),
         }
-        span_continuous_features = [
-            k for k, v in span_features.items() if ('float' in unwrap(v.dtype))
-        ]
-        span_analyses: list[Analysis] = [
-            BucketAnalysis(
-                description=span_features["span_true_label"].description,
-                feature="span_true_label",
-                method="discrete",
-                number=15,
-            ),
-            ComboCountAnalysis(
-                description="confusion matrix",
-                features=("span_true_label", "span_pred_label"),
-            ),
-            BucketAnalysis(
-                description=span_features["span_capitalness"].description,
-                feature="span_capitalness",
-                method="discrete",
-                number=4,
-            ),
-        ]
-        for x in span_continuous_features:
-            span_analyses.append(
-                BucketAnalysis(
-                    description=span_features[x].description,
-                    feature=x,
-                    method="continuous",
-                )
-            )
 
         return [
             AnalysisLevel(
                 name='example',
                 features=examp_features,
                 metric_configs=self.default_metrics(level='example'),
-                analyses=cast(List[Analysis], examp_analyses),
             ),
             AnalysisLevel(
                 name='span',
                 features=span_features,
                 metric_configs=self.default_metrics(level='span'),
-                analyses=cast(List[Analysis], span_analyses),
             ),
         ]
+
+    def default_analyses(self) -> list[Analysis]:
+        analyses: list[Analysis] = []
+        default_levels = self.default_analysis_levels()
+        examp_features = default_levels[0].features
+        examp_continuous_features = [
+            k for k, v in examp_features.items() if ('float' in unwrap(v.dtype))
+        ]
+        analyses.extend(
+            [
+                BucketAnalysis(
+                    level='example',
+                    description=examp_features[x].description,
+                    feature=x,
+                    method="continuous",
+                )
+                for x in examp_continuous_features
+            ]
+        )
+        span_features = default_levels[1].features
+        span_continuous_features = [
+            k for k, v in span_features.items() if ('float' in unwrap(v.dtype))
+        ]
+        analyses.extend(
+            [
+                BucketAnalysis(
+                    level="span",
+                    description=span_features["span_true_label"].description,
+                    feature="span_true_label",
+                    method="discrete",
+                    number=15,
+                ),
+                ComboCountAnalysis(
+                    level="span",
+                    description="confusion matrix",
+                    features=("span_true_label", "span_pred_label"),
+                ),
+                BucketAnalysis(
+                    level="span",
+                    description=span_features["span_capitalness"].description,
+                    feature="span_capitalness",
+                    method="discrete",
+                    number=4,
+                ),
+            ]
+        )
+        for x in span_continuous_features:
+            analyses.append(
+                BucketAnalysis(
+                    level="span",
+                    description=span_features[x].description,
+                    feature=x,
+                    method="continuous",
+                )
+            )
+        return analyses
 
     def _get_true_label(self, data_point: dict):
         return data_point["true_tags"]

--- a/explainaboard/processors/sequence_labeling.py
+++ b/explainaboard/processors/sequence_labeling.py
@@ -140,59 +140,30 @@ class SeqLabProcessor(Processor):
         ]
 
     def default_analyses(self) -> list[Analysis]:
-        analyses: list[Analysis] = []
-        default_levels = self.default_analysis_levels()
-        examp_features = default_levels[0].features
-        examp_continuous_features = [
-            k for k, v in examp_features.items() if v.dtype == 'float32'
+        analysis_levels = self.default_analysis_levels()
+        span_features = analysis_levels[1].features
+        analyses: list[Analysis] = [
+            BucketAnalysis(
+                level="span",
+                description=span_features["span_true_label"].description,
+                feature="span_true_label",
+                method="discrete",
+                number=15,
+            ),
+            ComboCountAnalysis(
+                level="span",
+                description="confusion matrix",
+                features=("span_true_label", "span_pred_label"),
+            ),
+            BucketAnalysis(
+                level="span",
+                description=span_features["span_capitalness"].description,
+                feature="span_capitalness",
+                method="discrete",
+                number=4,
+            ),
         ]
-        analyses.extend(
-            [
-                BucketAnalysis(
-                    level='example',
-                    description=examp_features[x].description,
-                    feature=x,
-                    method="continuous",
-                )
-                for x in examp_continuous_features
-            ]
-        )
-        span_features = default_levels[1].features
-        span_continuous_features = [
-            k for k, v in span_features.items() if v.dtype == 'float32'
-        ]
-        analyses.extend(
-            [
-                BucketAnalysis(
-                    level="span",
-                    description=span_features["span_true_label"].description,
-                    feature="span_true_label",
-                    method="discrete",
-                    number=15,
-                ),
-                ComboCountAnalysis(
-                    level="span",
-                    description="confusion matrix",
-                    features=("span_true_label", "span_pred_label"),
-                ),
-                BucketAnalysis(
-                    level="span",
-                    description=span_features["span_capitalness"].description,
-                    feature="span_capitalness",
-                    method="discrete",
-                    number=4,
-                ),
-            ]
-        )
-        for x in span_continuous_features:
-            analyses.append(
-                BucketAnalysis(
-                    level="span",
-                    description=span_features[x].description,
-                    feature=x,
-                    method="continuous",
-                )
-            )
+        analyses.extend(super().default_analyses())
         return analyses
 
     def _get_true_label(self, data_point: dict):

--- a/explainaboard/processors/sequence_labeling.py
+++ b/explainaboard/processors/sequence_labeling.py
@@ -144,7 +144,7 @@ class SeqLabProcessor(Processor):
         default_levels = self.default_analysis_levels()
         examp_features = default_levels[0].features
         examp_continuous_features = [
-            k for k, v in examp_features.items() if ('float' in unwrap(v.dtype))
+            k for k, v in examp_features.items() if v.dtype == 'float32'
         ]
         analyses.extend(
             [
@@ -159,7 +159,7 @@ class SeqLabProcessor(Processor):
         )
         span_features = default_levels[1].features
         span_continuous_features = [
-            k for k, v in span_features.items() if ('float' in unwrap(v.dtype))
+            k for k, v in span_features.items() if v.dtype == 'float32'
         ]
         analyses.extend(
             [

--- a/explainaboard/processors/sequence_labeling.py
+++ b/explainaboard/processors/sequence_labeling.py
@@ -163,7 +163,7 @@ class SeqLabProcessor(Processor):
                 number=4,
             ),
         ]
-        analyses.extend(super().default_analyses())
+        analyses.extend(self.continuous_feature_analyses())
         return analyses
 
     def _get_true_label(self, data_point: dict):

--- a/explainaboard/processors/summarization.py
+++ b/explainaboard/processors/summarization.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 from collections.abc import Iterator, Sequence
+import copy
 from functools import lru_cache
-import itertools
 
 from datalabs import aggregating
 from datalabs.operations.featurize.plugins.summarization.sum_attribute import (
@@ -61,8 +61,8 @@ class SummarizationProcessor(ConditionalGenerationProcessor):
     def task_type(cls) -> TaskType:
         return TaskType.summarization
 
-    def default_analyses(self) -> list[AnalysisLevel]:
-        f = super().default_analyses()
+    def default_analysis_levels(self) -> list[AnalysisLevel]:
+        f = super().default_analysis_levels()
         new_examp_features = {
             "sum_attributes": feature.Value(
                 dtype="dict",
@@ -103,19 +103,29 @@ class SummarizationProcessor(ConditionalGenerationProcessor):
             #     func=...,
             # ),
         }
+        f[0].features.update(new_examp_features)
+        return f
+
+    def default_analyses(self) -> list[Analysis]:
+        features = self.default_analysis_levels()[0].features
         new_examp_cont_features = [
-            k for k, v in new_examp_features.items() if ('float' in unwrap(v.dtype))
+            "attr_compression",
+            "attr_copy_len",
+            "attr_coverage",
+            "attr_novelty",
         ]
         new_examp_analyses: Sequence[Analysis] = [
             BucketAnalysis(
-                description=new_examp_features[x].description,
+                level="example",
+                description=features[x].description,
                 feature=x,
                 method="continuous",
             )
             for x in new_examp_cont_features
         ]
-        f[0].features.update(new_examp_features)
-        f[0].analyses = list(itertools.chain(f[0].analyses, new_examp_analyses))
+        f = super().default_analyses()
+        f = copy.deepcopy(f)
+        f.extend(new_examp_analyses)
         return f
 
     @classmethod

--- a/explainaboard/processors/summarization.py
+++ b/explainaboard/processors/summarization.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Iterator, Sequence
-import copy
+from collections.abc import Iterator
 from functools import lru_cache
 
 from datalabs import aggregating
@@ -13,7 +12,7 @@ import numpy
 
 from explainaboard import TaskType
 from explainaboard.analysis import feature
-from explainaboard.analysis.analyses import Analysis, AnalysisLevel, BucketAnalysis
+from explainaboard.analysis.analyses import AnalysisLevel
 from explainaboard.analysis.feature_funcs import accumulate_vocab_from_samples
 from explainaboard.info import SysOutputInfo
 from explainaboard.processors.conditional_generation import (
@@ -104,28 +103,6 @@ class SummarizationProcessor(ConditionalGenerationProcessor):
             # ),
         }
         f[0].features.update(new_examp_features)
-        return f
-
-    def default_analyses(self) -> list[Analysis]:
-        features = self.default_analysis_levels()[0].features
-        new_examp_cont_features = [
-            "attr_compression",
-            "attr_copy_len",
-            "attr_coverage",
-            "attr_novelty",
-        ]
-        new_examp_analyses: Sequence[Analysis] = [
-            BucketAnalysis(
-                level="example",
-                description=features[x].description,
-                feature=x,
-                method="continuous",
-            )
-            for x in new_examp_cont_features
-        ]
-        f = super().default_analyses()
-        f = copy.deepcopy(f)
-        f.extend(new_examp_analyses)
         return f
 
     @classmethod

--- a/explainaboard/processors/tabular_classification.py
+++ b/explainaboard/processors/tabular_classification.py
@@ -58,7 +58,7 @@ class TextClassificationProcessor(Processor):
                 features=("true_label", "predicted_label"),
             ),
         ]
-        analyses.extend(super().default_analyses())
+        analyses.extend(self.continuous_feature_analyses())
         return analyses
 
     @classmethod

--- a/explainaboard/processors/tabular_classification.py
+++ b/explainaboard/processors/tabular_classification.py
@@ -13,7 +13,6 @@ from explainaboard.metrics.accuracy import AccuracyConfig
 from explainaboard.metrics.metric import MetricConfig
 from explainaboard.processors.processor import Processor
 from explainaboard.processors.processor_registry import register_processor
-from explainaboard.utils.typing_utils import unwrap
 
 
 @register_processor(TaskType.tabular_classification)
@@ -44,9 +43,7 @@ class TextClassificationProcessor(Processor):
 
     def default_analyses(self) -> list[Analysis]:
         features = self.default_analysis_levels()[0].features
-        continuous_features = [
-            k for k, v in features.items() if ('float' in unwrap(v.dtype))
-        ]
+        continuous_features = [k for k, v in features.items() if v.dtype == 'float32']
         # Create analyses
         analyses: list[Analysis] = [
             BucketAnalysis(

--- a/explainaboard/processors/tabular_classification.py
+++ b/explainaboard/processors/tabular_classification.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import cast, List
-
 from explainaboard import TaskType
 from explainaboard.analysis import feature
 from explainaboard.analysis.analyses import (
@@ -24,7 +22,7 @@ class TextClassificationProcessor(Processor):
     def task_type(cls) -> TaskType:
         return TaskType.tabular_classification
 
-    def default_analyses(self) -> list[AnalysisLevel]:
+    def default_analysis_levels(self) -> list[AnalysisLevel]:
         features: dict[str, FeatureType] = {
             "true_label": feature.Value(
                 dtype="string",
@@ -35,18 +33,31 @@ class TextClassificationProcessor(Processor):
                 description="the predicted label",
             ),
         }
+
+        return [
+            AnalysisLevel(
+                name='example',
+                features=features,
+                metric_configs=self.default_metrics(),
+            )
+        ]
+
+    def default_analyses(self) -> list[Analysis]:
+        features = self.default_analysis_levels()[0].features
         continuous_features = [
             k for k, v in features.items() if ('float' in unwrap(v.dtype))
         ]
         # Create analyses
         analyses: list[Analysis] = [
             BucketAnalysis(
+                level="example",
                 description=features["true_label"].description,
                 feature="true_label",
                 method="discrete",
                 number=15,
             ),
             ComboCountAnalysis(
+                level="example",
                 description="confusion matrix",
                 features=("true_label", "predicted_label"),
             ),
@@ -54,18 +65,13 @@ class TextClassificationProcessor(Processor):
         for x in continuous_features:
             analyses.append(
                 BucketAnalysis(
-                    description=features[x].description, feature=x, method="continuous"
+                    level="example",
+                    description=features[x].description,
+                    feature=x,
+                    method="continuous",
                 )
             )
-
-        return [
-            AnalysisLevel(
-                name='example',
-                features=features,
-                metric_configs=self.default_metrics(),
-                analyses=cast(List[Analysis], analyses),
-            )
-        ]
+        return analyses
 
     @classmethod
     def default_metrics(

--- a/explainaboard/processors/tabular_classification.py
+++ b/explainaboard/processors/tabular_classification.py
@@ -43,7 +43,6 @@ class TextClassificationProcessor(Processor):
 
     def default_analyses(self) -> list[Analysis]:
         features = self.default_analysis_levels()[0].features
-        continuous_features = [k for k, v in features.items() if v.dtype == 'float32']
         # Create analyses
         analyses: list[Analysis] = [
             BucketAnalysis(
@@ -59,15 +58,7 @@ class TextClassificationProcessor(Processor):
                 features=("true_label", "predicted_label"),
             ),
         ]
-        for x in continuous_features:
-            analyses.append(
-                BucketAnalysis(
-                    level="example",
-                    description=features[x].description,
-                    feature=x,
-                    method="continuous",
-                )
-            )
+        analyses.extend(super().default_analyses())
         return analyses
 
     @classmethod

--- a/explainaboard/processors/tabular_regression.py
+++ b/explainaboard/processors/tabular_regression.py
@@ -11,7 +11,6 @@ from explainaboard.metrics.continuous import (
 from explainaboard.metrics.metric import MetricConfig
 from explainaboard.processors.processor import Processor
 from explainaboard.processors.processor_registry import register_processor
-from explainaboard.utils.typing_utils import unwrap
 
 
 @register_processor(TaskType.tabular_regression)
@@ -42,9 +41,7 @@ class TabularRegressionProcessor(Processor):
 
     def default_analyses(self) -> list[Analysis]:
         features = self.default_analysis_levels()[0].features
-        continuous_features = [
-            k for k, v in features.items() if ('float' in unwrap(v.dtype))
-        ]
+        continuous_features = [k for k, v in features.items() if v.dtype == 'float32']
         # Create analyses
         analyses: list[Analysis] = []
         for x in continuous_features:

--- a/explainaboard/processors/tabular_regression.py
+++ b/explainaboard/processors/tabular_regression.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import cast, List
-
 from explainaboard import TaskType
 from explainaboard.analysis import feature
 from explainaboard.analysis.analyses import Analysis, AnalysisLevel, BucketAnalysis
@@ -22,7 +20,7 @@ class TabularRegressionProcessor(Processor):
     def task_type(cls) -> TaskType:
         return TaskType.tabular_regression
 
-    def default_analyses(self) -> list[AnalysisLevel]:
+    def default_analysis_levels(self) -> list[AnalysisLevel]:
         features: dict[str, FeatureType] = {
             "true_value": feature.Value(
                 dtype="float",
@@ -33,6 +31,17 @@ class TabularRegressionProcessor(Processor):
                 description="the predicted value",
             ),
         }
+
+        return [
+            AnalysisLevel(
+                name='example',
+                features=features,
+                metric_configs=self.default_metrics(),
+            )
+        ]
+
+    def default_analyses(self) -> list[Analysis]:
+        features = self.default_analysis_levels()[0].features
         continuous_features = [
             k for k, v in features.items() if ('float' in unwrap(v.dtype))
         ]
@@ -41,18 +50,13 @@ class TabularRegressionProcessor(Processor):
         for x in continuous_features:
             analyses.append(
                 BucketAnalysis(
-                    description=features[x].description, feature=x, method="continuous"
+                    level="example",
+                    description=features[x].description,
+                    feature=x,
+                    method="continuous",
                 )
             )
-
-        return [
-            AnalysisLevel(
-                name='example',
-                features=features,
-                metric_configs=self.default_metrics(),
-                analyses=cast(List[Analysis], analyses),
-            )
-        ]
+        return analyses
 
     @classmethod
     def default_metrics(

--- a/explainaboard/processors/tabular_regression.py
+++ b/explainaboard/processors/tabular_regression.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from explainaboard import TaskType
 from explainaboard.analysis import feature
-from explainaboard.analysis.analyses import AnalysisLevel
+from explainaboard.analysis.analyses import Analysis, AnalysisLevel
 from explainaboard.analysis.feature import FeatureType
 from explainaboard.metrics.continuous import (
     AbsoluteErrorConfig,
@@ -38,6 +38,9 @@ class TabularRegressionProcessor(Processor):
                 metric_configs=self.default_metrics(),
             )
         ]
+
+    def default_analyses(self) -> list[Analysis]:
+        return self.continuous_feature_analyses()
 
     @classmethod
     def default_metrics(

--- a/explainaboard/processors/tabular_regression.py
+++ b/explainaboard/processors/tabular_regression.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from explainaboard import TaskType
 from explainaboard.analysis import feature
-from explainaboard.analysis.analyses import Analysis, AnalysisLevel, BucketAnalysis
+from explainaboard.analysis.analyses import AnalysisLevel
 from explainaboard.analysis.feature import FeatureType
 from explainaboard.metrics.continuous import (
     AbsoluteErrorConfig,
@@ -38,22 +38,6 @@ class TabularRegressionProcessor(Processor):
                 metric_configs=self.default_metrics(),
             )
         ]
-
-    def default_analyses(self) -> list[Analysis]:
-        features = self.default_analysis_levels()[0].features
-        continuous_features = [k for k, v in features.items() if v.dtype == 'float32']
-        # Create analyses
-        analyses: list[Analysis] = []
-        for x in continuous_features:
-            analyses.append(
-                BucketAnalysis(
-                    level="example",
-                    description=features[x].description,
-                    feature=x,
-                    method="continuous",
-                )
-            )
-        return analyses
 
     @classmethod
     def default_metrics(

--- a/explainaboard/processors/text_classification.py
+++ b/explainaboard/processors/text_classification.py
@@ -124,7 +124,7 @@ class TextClassificationProcessor(Processor):
                 features=("true_label", "predicted_label"),
             ),
         ]
-        analyses.extend(super().default_analyses())
+        analyses.extend(self.continuous_feature_analyses())
         return analyses
 
     @classmethod

--- a/explainaboard/processors/text_classification.py
+++ b/explainaboard/processors/text_classification.py
@@ -109,7 +109,6 @@ class TextClassificationProcessor(Processor):
 
     def default_analyses(self) -> list[Analysis]:
         features = self.default_analysis_levels()[0].features
-        continuous_features = [k for k, v in features.items() if v.dtype == 'float32']
         # Create analyses
         analyses: list[Analysis] = [
             BucketAnalysis(
@@ -125,15 +124,7 @@ class TextClassificationProcessor(Processor):
                 features=("true_label", "predicted_label"),
             ),
         ]
-        for x in continuous_features:
-            analyses.append(
-                BucketAnalysis(
-                    level="example",
-                    description=features[x].description,
-                    feature=x,
-                    method="continuous",
-                )
-            )
+        analyses.extend(super().default_analyses())
         return analyses
 
     @classmethod

--- a/explainaboard/processors/text_classification.py
+++ b/explainaboard/processors/text_classification.py
@@ -109,9 +109,7 @@ class TextClassificationProcessor(Processor):
 
     def default_analyses(self) -> list[Analysis]:
         features = self.default_analysis_levels()[0].features
-        continuous_features = [
-            k for k, v in features.items() if ('float' in unwrap(v.dtype))
-        ]
+        continuous_features = [k for k, v in features.items() if v.dtype == 'float32']
         # Create analyses
         analyses: list[Analysis] = [
             BucketAnalysis(

--- a/explainaboard/processors/text_pair_classification.py
+++ b/explainaboard/processors/text_pair_classification.py
@@ -108,9 +108,7 @@ class TextPairClassificationProcessor(Processor):
 
     def default_analyses(self) -> list[Analysis]:
         features = self.default_analysis_levels()[0].features
-        continuous_features = [
-            k for k, v in features.items() if ('float' in unwrap(v.dtype))
-        ]
+        continuous_features = [k for k, v in features.items() if v.dtype == 'float32']
         # Create analyses
         analyses: list[Analysis] = [
             BucketAnalysis(

--- a/explainaboard/processors/text_pair_classification.py
+++ b/explainaboard/processors/text_pair_classification.py
@@ -108,7 +108,6 @@ class TextPairClassificationProcessor(Processor):
 
     def default_analyses(self) -> list[Analysis]:
         features = self.default_analysis_levels()[0].features
-        continuous_features = [k for k, v in features.items() if v.dtype == 'float32']
         # Create analyses
         analyses: list[Analysis] = [
             BucketAnalysis(
@@ -124,15 +123,7 @@ class TextPairClassificationProcessor(Processor):
                 features=("true_label", "predicted_label"),
             ),
         ]
-        for x in continuous_features:
-            analyses.append(
-                BucketAnalysis(
-                    level="example",
-                    description=features[x].description,
-                    feature=x,
-                    method="continuous",
-                )
-            )
+        analyses.extend(super().default_analyses())
         return analyses
 
     @classmethod

--- a/explainaboard/processors/text_pair_classification.py
+++ b/explainaboard/processors/text_pair_classification.py
@@ -123,7 +123,7 @@ class TextPairClassificationProcessor(Processor):
                 features=("true_label", "predicted_label"),
             ),
         ]
-        analyses.extend(super().default_analyses())
+        analyses.extend(self.continuous_feature_analyses())
         return analyses
 
     @classmethod

--- a/explainaboard/processors/text_pair_classification.py
+++ b/explainaboard/processors/text_pair_classification.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import cast, List
-
 from datalabs import aggregating
 
 from explainaboard import TaskType
@@ -34,7 +32,7 @@ class TextPairClassificationProcessor(Processor):
     def task_type(cls) -> TaskType:
         return TaskType.text_classification
 
-    def default_analyses(self) -> list[AnalysisLevel]:
+    def default_analysis_levels(self) -> list[AnalysisLevel]:
         features: dict[str, FeatureType] = {
             "text1": feature.Value(
                 dtype="string",
@@ -100,18 +98,30 @@ class TextPairClassificationProcessor(Processor):
             ),
         }
 
+        return [
+            AnalysisLevel(
+                name='example',
+                features=features,
+                metric_configs=self.default_metrics(),
+            )
+        ]
+
+    def default_analyses(self) -> list[Analysis]:
+        features = self.default_analysis_levels()[0].features
         continuous_features = [
             k for k, v in features.items() if ('float' in unwrap(v.dtype))
         ]
         # Create analyses
         analyses: list[Analysis] = [
             BucketAnalysis(
+                level="example",
                 description=features['true_label'].description,
                 feature="true_label",
                 method="discrete",
                 number=15,
             ),
             ComboCountAnalysis(
+                level="example",
                 description="confusion matrix",
                 features=("true_label", "predicted_label"),
             ),
@@ -119,18 +129,13 @@ class TextPairClassificationProcessor(Processor):
         for x in continuous_features:
             analyses.append(
                 BucketAnalysis(
-                    description=features[x].description, feature=x, method="continuous"
+                    level="example",
+                    description=features[x].description,
+                    feature=x,
+                    method="continuous",
                 )
             )
-
-        return [
-            AnalysisLevel(
-                name='example',
-                features=features,
-                metric_configs=self.default_metrics(),
-                analyses=cast(List[Analysis], analyses),
-            )
-        ]
+        return analyses
 
     @classmethod
     def default_metrics(

--- a/explainaboard/tests/artifacts/kg_link_tail_prediction/with_custom_feature.json
+++ b/explainaboard/tests/artifacts/kg_link_tail_prediction/with_custom_feature.json
@@ -8,16 +8,15 @@
         }
       }
     },
-    "custom_analyses": {
-      "example": [
-        {
-          "cls_name": "BucketAnalysis",
-          "feature": "rel_type",
-          "num_buckets": 2,
-          "method": "discrete"
-        }
-      ]
-    }
+    "custom_analyses": [
+      {
+        "cls_name": "BucketAnalysis",
+        "level": "example",
+        "feature": "rel_type",
+        "num_buckets": 2,
+        "method": "discrete"
+      }
+    ]
   },
   "examples": [
     {

--- a/explainaboard/tests/artifacts/machine_translation/output_with_features.json
+++ b/explainaboard/tests/artifacts/machine_translation/output_with_features.json
@@ -7,16 +7,15 @@
         }
       }
     },
-    "custom_analyses": {
-      "example": [
-        {
-          "cls_name": "BucketAnalysis",
-          "feature": "num_capital_letters",
-          "num_buckets": 4,
-          "method": "continuous"
-        }
-      ]
-    }
+    "custom_analyses": [
+      {
+        "cls_name": "BucketAnalysis",
+        "level": "example",
+        "feature": "num_capital_letters",
+        "num_buckets": 4,
+        "method": "continuous"
+      }
+    ]
   },
   "examples": [
     {

--- a/explainaboard/tests/artifacts/qa_multiple_choice/output_fig_qa_customized_features.json
+++ b/explainaboard/tests/artifacts/qa_multiple_choice/output_fig_qa_customized_features.json
@@ -8,16 +8,15 @@
         }
       }
     },
-    "custom_analyses": {
-      "example": [
-        {
-          "cls_name": "BucketAnalysis",
-          "feature": "commonsense_category",
-          "num_buckets": 8,
-          "method": "discrete"
-        }
-      ]
-    }
+    "custom_analyses": [
+      {
+        "cls_name": "BucketAnalysis",
+        "level": "example",
+        "feature": "commonsense_category",
+        "num_buckets": 8,
+        "method": "discrete"
+      }
+    ]
   },
   "examples": [
     {

--- a/explainaboard/tests/test_kg_link_tail_prediction.py
+++ b/explainaboard/tests/test_kg_link_tail_prediction.py
@@ -1,4 +1,3 @@
-import itertools
 import os
 import unittest
 
@@ -111,11 +110,7 @@ class TestKgLinkTailPrediction(unittest.TestCase):
         self.assertIsNotNone(sys_info.results.analyses)
         self.assertGreater(len(sys_info.results.overall), 0)
 
-        analysis_map = {
-            x.name: x
-            for x in itertools.chain.from_iterable(sys_info.results.analyses)
-            if x is not None
-        }
+        analysis_map = {x.name: x for x in sys_info.results.analyses if x is not None}
         symmetry_performances = analysis_map['symmetry'].bucket_performances
         if len(symmetry_performances) <= 1:  # can't sort if only 1 item
             return
@@ -150,11 +145,7 @@ class TestKgLinkTailPrediction(unittest.TestCase):
         self.assertIsNotNone(sys_info.results.analyses)
         self.assertGreater(len(sys_info.results.overall), 0)
 
-        analysis_map = {
-            x.name: x
-            for x in itertools.chain.from_iterable(sys_info.results.analyses)
-            if x is not None
-        }
+        analysis_map = {x.name: x for x in sys_info.results.analyses if x is not None}
         symmetry_performances = analysis_map['symmetry'].bucket_performances
         if len(symmetry_performances) <= 1:  # can't sort if only 1 item
             return

--- a/explainaboard/tests/test_machine_translation.py
+++ b/explainaboard/tests/test_machine_translation.py
@@ -1,5 +1,4 @@
 import dataclasses
-import itertools
 import os
 import unittest
 
@@ -66,9 +65,9 @@ class TestMachineTranslation(unittest.TestCase):
         condgen_processor = get_processor(TaskType.conditional_generation.value)
         mt_processor = get_processor(TaskType.machine_translation.value)
 
-        condgen_features_1 = condgen_processor.default_analyses()
-        mt_features = mt_processor.default_analyses()
-        condgen_features_2 = condgen_processor.default_analyses()
+        condgen_features_1 = condgen_processor.default_analysis_levels()
+        mt_features = mt_processor.default_analysis_levels()
+        condgen_features_2 = condgen_processor.default_analysis_levels()
 
         # MT features didn't change condgen features
         for cf1, cf2, mtf in zip(condgen_features_1, condgen_features_2, mt_features):
@@ -106,11 +105,7 @@ class TestMachineTranslation(unittest.TestCase):
         processor = get_processor(TaskType.machine_translation.value)
 
         sys_info = processor.process(dataclasses.asdict(data.metadata), data.samples)
-        analysis_map = {
-            x.name: x
-            for x in itertools.chain.from_iterable(sys_info.results.analyses)
-            if x is not None
-        }
+        analysis_map = {x.name: x for x in sys_info.results.analyses if x is not None}
         self.assertTrue('num_capital_letters' in analysis_map)
 
 

--- a/explainaboard/tests/test_ner.py
+++ b/explainaboard/tests/test_ner.py
@@ -49,9 +49,7 @@ class TestNER(unittest.TestCase):
 
         # test: training set dependent features should be disabled when
         # training dataset is not provided
-        activate_features = [
-            x.name for x in sys_info.results.analyses[0] if x is not None
-        ]
+        activate_features = [x.name for x in sys_info.results.analyses if x is not None]
         self.assertTrue("span_econ" not in activate_features)
         self.assertTrue("span_efre" not in activate_features)
 
@@ -83,7 +81,7 @@ class TestNER(unittest.TestCase):
         # 1. Unittest: training set dependent features shouldn't be included
         # when training dataset is not provided
         span_analysis_map = {
-            x.name: x for x in sys_info.results.analyses[1] if x is not None
+            x.name: x for x in sys_info.results.analyses if x is not None
         }
         self.assertTrue("span_econ" in span_analysis_map)
         self.assertTrue("span_efre" in span_analysis_map)
@@ -116,7 +114,9 @@ class TestNER(unittest.TestCase):
             second_bucket.performances[0].value, 0.9121588089330025, 4, "almost equal"
         )
         # 6 Unittest: test detailed bucket information: confidence interval
-        for bucket_vals in sys_info.results.analyses[0]:
+        for bucket_vals in sys_info.results.analyses:
+            if not isinstance(bucket_vals, BucketAnalysisResult):
+                continue
             for bucket in cast(BucketAnalysisResult, bucket_vals).bucket_performances:
                 for performance in bucket.performances:
                     if performance.confidence_score_low is not None:

--- a/explainaboard/tests/test_summarization.py
+++ b/explainaboard/tests/test_summarization.py
@@ -58,9 +58,9 @@ class TestSummarization(unittest.TestCase):
         condgen_processor = get_processor(TaskType.conditional_generation.value)
         sum_processor = get_processor(TaskType.summarization.value)
 
-        condgen_features_1 = condgen_processor.default_analyses()
-        sum_features = sum_processor.default_analyses()
-        condgen_features_2 = condgen_processor.default_analyses()
+        condgen_features_1 = condgen_processor.default_analysis_levels()
+        sum_features = sum_processor.default_analysis_levels()
+        condgen_features_2 = condgen_processor.default_analysis_levels()
 
         for cf1, cf2, sumf in zip(condgen_features_1, condgen_features_2, sum_features):
             lcf1 = set(cf1.features.keys())

--- a/explainaboard/visualizers/draw_hist.py
+++ b/explainaboard/visualizers/draw_hist.py
@@ -4,7 +4,7 @@ import argparse
 import json
 import os
 
-from explainaboard.analysis.analyses import BucketAnalysis, BucketAnalysisResult
+from explainaboard.analysis.analyses import BucketAnalysisResult
 from explainaboard.analysis.performance import Performance
 from explainaboard.info import SysOutputInfo
 from explainaboard.utils.logging import progress
@@ -36,25 +36,20 @@ def draw_bar_chart_from_reports(
     num_levels = len(unwrap(report_info[0].analysis_levels))
     for level_id in range(num_levels):
 
+        level_name = unwrap(report_info[0].analysis_levels)[level_id].name
+
         overall_results: list[list[Performance]] = [
             list(unwrap(x.results.overall)[level_id]) for x in report_info
-        ]
-        bucket_names: list[list[str]] = [
-            [
-                y.feature
-                for y in unwrap(x.analysis_levels)[level_id].analyses
-                if isinstance(y, BucketAnalysis)
-            ]
-            for x in report_info
         ]
         bucket_results: list[list[BucketAnalysisResult]] = [
             [
                 y
-                for y in unwrap(x.results.analyses)[level_id]
-                if isinstance(y, BucketAnalysisResult)
+                for y in unwrap(x.results.analyses)
+                if isinstance(y, BucketAnalysisResult) and y.level == level_name
             ]
             for x in report_info
         ]
+        bucket_names: list[list[str]] = [[y.name for y in x] for x in bucket_results]
         metric_names: list[list[str]] = [
             [y.metric_name for y in x] for x in overall_results
         ]

--- a/explainaboard/visualizers/performance_gap.py
+++ b/explainaboard/visualizers/performance_gap.py
@@ -1,5 +1,4 @@
 import copy
-from typing import cast
 
 from explainaboard.analysis.analyses import BucketAnalysisResult
 from explainaboard.info import SysOutputInfo
@@ -20,12 +19,13 @@ def get_pairwise_performance_gap(
             orm_met.confidence_score_high = None
 
     fgr, fgr1, fgr2 = (unwrap(x.results.analyses) for x in (sys, sys1, sys2))
-    for fgr_lev, fgr1_lev, fgr2_lev in zip(fgr, fgr1, fgr2):
-        if not isinstance(fgr_lev, BucketAnalysisResult):
+    for fgr_buks, fgr1_buks, fgr2_buks in zip(fgr, fgr1, fgr2):
+        if (
+            not isinstance(fgr_buks, BucketAnalysisResult)
+            or not isinstance(fgr1_buks, BucketAnalysisResult)
+            or not isinstance(fgr2_buks, BucketAnalysisResult)
+        ):
             continue
-        fgr_buks, fgr1_buks, fgr2_buks = (
-            cast(BucketAnalysisResult, x) for x in (fgr_lev, fgr1_lev, fgr2_lev)
-        )
         for fgr_buk, fgr1_buk, fgr2_buk in zip(
             fgr_buks.bucket_performances,
             fgr1_buks.bucket_performances,

--- a/explainaboard/visualizers/performance_gap.py
+++ b/explainaboard/visualizers/performance_gap.py
@@ -20,24 +20,23 @@ def get_pairwise_performance_gap(
             orm_met.confidence_score_high = None
 
     fgr, fgr1, fgr2 = (unwrap(x.results.analyses) for x in (sys, sys1, sys2))
-    for fgr_all, fgr1_all, fgr2_all in zip(fgr, fgr1, fgr2):
-        for fgr_lev, fgr1_lev, fgr2_lev in zip(fgr_all, fgr1_all, fgr2_all):
-            if not isinstance(fgr_lev, BucketAnalysisResult):
-                continue
-            fgr_buks, fgr1_buks, fgr2_buks = (
-                cast(BucketAnalysisResult, x) for x in (fgr_lev, fgr1_lev, fgr2_lev)
-            )
-            for fgr_buk, fgr1_buk, fgr2_buk in zip(
-                fgr_buks.bucket_performances,
-                fgr1_buks.bucket_performances,
-                fgr2_buks.bucket_performances,
+    for fgr_lev, fgr1_lev, fgr2_lev in zip(fgr, fgr1, fgr2):
+        if not isinstance(fgr_lev, BucketAnalysisResult):
+            continue
+        fgr_buks, fgr1_buks, fgr2_buks = (
+            cast(BucketAnalysisResult, x) for x in (fgr_lev, fgr1_lev, fgr2_lev)
+        )
+        for fgr_buk, fgr1_buk, fgr2_buk in zip(
+            fgr_buks.bucket_performances,
+            fgr1_buks.bucket_performances,
+            fgr2_buks.bucket_performances,
+        ):
+            for fgr_met, fgr1_met, fgr2_met in zip(
+                fgr_buk.performances, fgr1_buk.performances, fgr2_buk.performances
             ):
-                for fgr_met, fgr1_met, fgr2_met in zip(
-                    fgr_buk.performances, fgr1_buk.performances, fgr2_buk.performances
-                ):
-                    fgr_met.value = fgr1_met.value - fgr2_met.value
-                    # TODO(gneubig): these could be done via pairwise bootstraps
-                    fgr_met.confidence_score_low = None
-                    fgr_met.confidence_score_high = None
+                fgr_met.value = fgr1_met.value - fgr2_met.value
+                # TODO(gneubig): these could be done via pairwise bootstraps
+                fgr_met.confidence_score_low = None
+                fgr_met.confidence_score_high = None
 
     return sys


### PR DESCRIPTION
This modifies v0.11 so that analyses are flat lists, instead of a hierarchical list with one analysis per level. The biggest change is splitting the specification of the features and metrics for each analysis level, and the analyses themselves into different functions:

```
    @abc.abstractmethod
    def default_analysis_levels(self) -> list[AnalysisLevel]:
        """Returns a list of analysis levels, indicating analyses that can be
        applied to different views of the higher-level example. For instance, a task may
        perform 'example'-level analysis, and 'token'-level analysis in which case this
        list would have one level for each."""
        ...

    @abc.abstractmethod
    def default_analyses(self) -> list[Analysis]:
        """Returns the analyses to be performed."""
        ...
```