### PR TITLE
Remove EaaS related codeblock from MetricConfig registry

### DIFF
--- a/explainaboard/explainaboard_main.py
+++ b/explainaboard/explainaboard_main.py
@@ -303,7 +303,7 @@ def create_parser():
 
 
 def get_metric_config_or_eaas(name: str) -> type[MetricConfig]:
-    """Obtains MetricConfig class frin registry or corresponding EaaS binding.
+    """Obtains MetricConfig class from registry or corresponding EaaS binding.
 
     Args:
         name: Name of the metric.

--- a/explainaboard/explainaboard_main.py
+++ b/explainaboard/explainaboard_main.py
@@ -4,6 +4,8 @@ import argparse
 import json
 import os
 
+import eaas.endpoint
+
 from explainaboard import get_loader_class, get_processor, TaskType
 from explainaboard.analyzers import get_pairwise_performance_gap
 from explainaboard.analyzers.draw_hist import draw_bar_chart_from_reports
@@ -14,6 +16,8 @@ from explainaboard.loaders.file_loader import (
     FileLoaderField,
     FileLoaderMetadata,
 )
+from explainaboard.metrics.eaas import EaaSMetricConfig
+from explainaboard.metrics.metric import MetricConfig
 from explainaboard.metrics.registry import get_metric_config_class
 from explainaboard.utils.io_utils import text_writer
 from explainaboard.utils.logging import get_logger
@@ -298,6 +302,29 @@ def create_parser():
     return parser
 
 
+def get_metric_config_or_eaas(name: str) -> type[MetricConfig]:
+    """Obtains MetricConfig class frin registry or corresponding EaaS binding.
+
+    Args:
+        name: Name of the metric.
+
+    Returns:
+        A MetricConfig class associated to either a registered Metric or EaaS.
+
+    Raises:
+        ValueError: `name` is not registered in neither the registry nor EaaS.
+    """
+    try:
+        return get_metric_config_class(name)
+    except ValueError:
+        if name in eaas.endpoint.EndpointConfig().valid_metrics:
+            return EaaSMetricConfig
+
+    raise ValueError(
+        f"Metric name {name} is not registered in neither the registry nor EaaS."
+    )
+
+
 # TODO(Pengfei): The overall implementation of this script should be deduplicated
 def main():
     args = create_parser().parse_args()
@@ -429,7 +456,7 @@ def main():
             if 'metric_configs' in metadata:
                 raise ValueError('Cannot specify both metric names and metric configs')
             metric_configs = [
-                get_metric_config_class(name)(name, source_language, target_language)
+                get_metric_config_or_eaas(name)(name, source_language, target_language)
                 for name in metric_names
             ]
             metadata["metric_configs"] = metric_configs

--- a/explainaboard/metrics/registry.py
+++ b/explainaboard/metrics/registry.py
@@ -1,32 +1,42 @@
 from __future__ import annotations
 
-from eaas.endpoint import EndpointConfig
+from typing import TypeVar
 
-from explainaboard.metrics.eaas import EaaSMetricConfig
 from explainaboard.metrics.metric import MetricConfig
+
+MetricConfigT = TypeVar("MetricConfigT", bound=MetricConfig)
 
 _metric_config_registry: dict[str, type[MetricConfig]] = {}
 
 
-def register_metric_config(cls):
-    """
-    a register for task specific processors.
-    example usage: `@register_processor()`
-    """
+def register_metric_config(cls: type[MetricConfigT]) -> type[MetricConfigT]:
+    """Decorator function to register a MetricConfig class to the registry.
 
+    Args:
+        cls: A MetricConfig subclass.
+
+    Returns:
+        `cls` itself. The type information is preserved.
+    """
     _metric_config_registry[cls.__name__] = cls
     if cls.__name__.endswith('Config'):
         _metric_config_registry[cls.__name__[:-6]] = cls
     return cls
 
 
-def get_metric_config_class(name) -> type[MetricConfig]:
+def get_metric_config_class(name: str) -> type[MetricConfig]:
+    """Obtains a MetricConfig class associated to the given name.
+
+    Args:
+        name: MetricConfig name.
+
+    Returns:
+        MetricConfig subclass associated to `name`.
+
+    Raises:
+        ValueError: `name` is not associated.
+    """
     config_cls = _metric_config_registry.get(name)
-    if config_cls is not None:
-        return config_cls
-
-    # TODO(odashi): Avoid EaaS completely from this module.
-    if name in EndpointConfig().valid_metrics:
-        return EaaSMetricConfig
-
-    raise ValueError(f'Invalid Metric {name}')
+    if config_cls is None:
+        raise ValueError(f'Invalid Metric {name}')
+    return config_cls


### PR DESCRIPTION
This pr attempts to separate EaaS-related things from the MetricConfig registry.
The original code may accidentally instantiate the EaaS-based metric even when the users don't want to use any external stuff. This pr introduces a wrapper function in the main module to instantiate the EaaS metrics separately from the registry.