### PR TITLE
Refactoring MetricStats

### DIFF
--- a/explainaboard/metrics/accuracy.py
+++ b/explainaboard/metrics/accuracy.py
@@ -5,7 +5,12 @@ from typing import Optional
 
 import numpy as np
 
-from explainaboard.metrics.metric import Metric, MetricConfig, MetricStats
+from explainaboard.metrics.metric import (
+    Metric,
+    MetricConfig,
+    MetricStats,
+    SimpleMetricStats,
+)
 from explainaboard.metrics.registry import register_metric_config
 
 
@@ -25,7 +30,7 @@ class Accuracy(Metric):
     def calc_stats_from_data(
         self, true_data: list, pred_data: list, config: Optional[MetricConfig] = None
     ) -> MetricStats:
-        return MetricStats(
+        return SimpleMetricStats(
             np.array(
                 [
                     (1.0 if y == x or isinstance(x, list) and y in x else 0.0)
@@ -54,7 +59,7 @@ class CorrectCount(Accuracy):
         self, true_data: list, pred_data: list, config: Optional[MetricConfig] = None
     ) -> MetricStats:
 
-        return MetricStats(
+        return SimpleMetricStats(
             np.array(
                 [
                     (1.0 if y == x or isinstance(x, list) and y in x else 0.0)
@@ -69,7 +74,7 @@ class CorrectCount(Accuracy):
         :param stats: stats for every example
         :return: aggregated stats
         """
-        data = stats.get_data()
+        data = stats.get_batch_data() if stats.is_batched() else stats.get_data()
         if data.size == 0:
             return np.array(0.0)
         else:
@@ -117,4 +122,4 @@ class SeqCorrectCount(CorrectCount):
                     recall.append(1.0)
                 else:
                     recall.append(0.0)
-        return MetricStats(np.array(recall))
+        return SimpleMetricStats(np.array(recall))

--- a/explainaboard/metrics/continuous.py
+++ b/explainaboard/metrics/continuous.py
@@ -5,7 +5,12 @@ from typing import Optional
 
 import numpy as np
 
-from explainaboard.metrics.metric import Metric, MetricConfig, MetricStats
+from explainaboard.metrics.metric import (
+    Metric,
+    MetricConfig,
+    MetricStats,
+    SimpleMetricStats,
+)
 from explainaboard.metrics.registry import register_metric_config
 
 
@@ -26,7 +31,7 @@ class RootMeanSquaredError(Metric):
     ) -> MetricStats:
         error = np.array([(x - y) for x, y in zip(true_data, pred_data)])
         squared_error = error * error
-        return MetricStats(squared_error)
+        return SimpleMetricStats(squared_error)
 
     def is_simple_average(self, stats: MetricStats):
         return False
@@ -53,4 +58,4 @@ class AbsoluteError(Metric):
         self, true_data: list, pred_data: list, config: Optional[MetricConfig] = None
     ) -> MetricStats:
         error = np.array([abs(x - y) for x, y in zip(true_data, pred_data)])
-        return MetricStats(error)
+        return SimpleMetricStats(error)

--- a/explainaboard/metrics/eaas.py
+++ b/explainaboard/metrics/eaas.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import copy
 from dataclasses import dataclass
-from typing import Optional, Union
+from typing import cast, final, Optional
 
 from eaas.async_client import AsyncClient, AsyncRequest
 from eaas.config import Config
@@ -10,7 +10,6 @@ import numpy as np
 import sacrebleu
 
 from explainaboard.metrics.metric import Metric, MetricConfig, MetricStats
-from explainaboard.utils.typing_utils import unwrap
 
 _eaas_config = None
 _eaas_client = None
@@ -24,45 +23,58 @@ def get_eaas_client():
     return _eaas_client
 
 
+@final
 class EaaSMetricStats(MetricStats):
+    """MetricStats with EaaS invocations.
+
+    Obtaining the data from EaaS is deferred until it is wanted.
     """
-    Stats from EaaS for calculation of any of the metrics. These are calculated lazily,
-    so that a request is dispatched to the EaaS server and the results are retrieved
-    when they're needed.
-    """
 
-    def __init__(self, name: str, pos: int, eaas_request: AsyncRequest):
-        super().__init__(data=None)
-        self.name = name
-        self.pos = pos
-        self.eaas_request = eaas_request
-        self._data: Optional[np.ndarray] = None
+    def __init__(self, name: str, pos: int, eaas_request: AsyncRequest) -> None:
+        """Initializes the EaaSMetricStats.
 
-    def __len__(self):
-        return len(self.get_data())
+        Args:
+            name: Name of this metric.
+            pos: Position of the statistics in the returned array.
+            eaas_request: Request object to the EaaS service.
+        """
+        self._name = name  # TODO(odashi): Remove this member.
+        self._pos = pos
+        self._eaas_request = eaas_request
+        self._data: np.ndarray | None = None
 
-    def _fetch_results(self):
+    def _fetch_results(self) -> None:
+        """Obtains the data from the EaaS service."""
         if self._data is None:
-            result = self.eaas_request.get_result()
+            result = self._eaas_request.get_result()
             self._data = np.array(
                 [
                     x if isinstance(x, list) else [x]
-                    for x in result['scores'][self.pos]['stats']
+                    for x in result['scores'][self._pos]['stats']
                 ]
             )
 
-    def get_data(self) -> np.ndarray:
-        self._fetch_results()
-        return unwrap(self._data)
+    def __len__(self) -> int:
+        """See MetricStats.__len__."""
+        return len(self.get_data())
 
-    def filter(self, indices: Union[list[int], np.ndarray]) -> MetricStats:
-        """
-        Return a view of these stats filtered down to the indicated indices
-        """
-        sdata: np.ndarray = self.get_data()
-        if not isinstance(indices, np.ndarray):
-            indices = np.array(indices)
-        return MetricStats(sdata[indices])
+    def is_batched(self) -> bool:
+        """See MetricStats.is_batched."""
+        return False
+
+    def num_statistics(self) -> int:
+        """See MetricStats.num_statistics."""
+        return self.get_data().shape[-1]
+
+    def get_data(self) -> np.ndarray:
+        """See MetricStats.get_data."""
+        self._fetch_results()
+        # self._data must have the data at this point.
+        return cast(np.ndarray, self._data)
+
+    def get_batch_data(self) -> np.ndarray:
+        """See MetricStats.get_batch_data."""
+        raise NotImplementedError
 
 
 # NOTE(odashi): Not register this config to the registry.
@@ -113,10 +125,11 @@ class EaaSMetric(Metric):
         :param stats: stats for every example
         :return: aggregated stats
         """
+        data = stats.get_batch_data() if stats.is_batched() else stats.get_data()
         if self.config.name in {'bleu', 'chrf'}:
-            return np.sum(stats.get_data(), axis=-2)
+            return np.sum(data, axis=-2)
         else:
-            return np.mean(stats.get_data(), axis=-2)
+            return np.mean(data, axis=-2)
 
     def calc_stats_from_data(
         self, true_data: list, pred_data: list, config: Optional[MetricConfig] = None

--- a/explainaboard/metrics/eaas.py
+++ b/explainaboard/metrics/eaas.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import copy
 from dataclasses import dataclass
-from typing import cast, final, Optional
+from typing import Any, cast, final, Optional
 
 from eaas.async_client import AsyncClient, AsyncRequest
 from eaas.config import Config
@@ -66,13 +66,13 @@ class EaaSMetricStats(MetricStats):
         """See MetricStats.num_statistics."""
         return self.get_data().shape[-1]
 
-    def get_data(self) -> np.ndarray:
+    def get_data(self) -> np.ndarray[tuple[int, int], Any]:
         """See MetricStats.get_data."""
         self._fetch_results()
         # self._data must have the data at this point.
         return cast(np.ndarray, self._data)
 
-    def get_batch_data(self) -> np.ndarray:
+    def get_batch_data(self) -> np.ndarray[tuple[int, int, int], Any]:
         """See MetricStats.get_batch_data."""
         raise NotImplementedError
 

--- a/explainaboard/metrics/extractive_qa.py
+++ b/explainaboard/metrics/extractive_qa.py
@@ -7,7 +7,12 @@ from typing import Optional, Union
 
 import numpy as np
 
-from explainaboard.metrics.metric import Metric, MetricConfig, MetricStats
+from explainaboard.metrics.metric import (
+    Metric,
+    MetricConfig,
+    MetricStats,
+    SimpleMetricStats,
+)
 from explainaboard.metrics.registry import register_metric_config
 from explainaboard.utils.preprocessor import ExtractiveQAPreprocessor, Preprocessor
 from explainaboard.utils.typing_utils import unwrap_or
@@ -29,7 +34,7 @@ class ExtractiveQAMetric(Metric):
         true_data = [[x] if isinstance(x, str) else x for x in true_data]
         config = unwrap_or(config, self.config)
         preprocessor = ExtractiveQAPreprocessor(language=config.source_language)
-        return MetricStats(
+        return SimpleMetricStats(
             np.array(
                 [
                     max([self.sample_level_metric(t, p, preprocessor) for t in ts])

--- a/explainaboard/metrics/f1_score.py
+++ b/explainaboard/metrics/f1_score.py
@@ -6,7 +6,12 @@ from typing import cast, Optional
 
 import numpy as np
 
-from explainaboard.metrics.metric import Metric, MetricConfig, MetricStats
+from explainaboard.metrics.metric import (
+    Metric,
+    MetricConfig,
+    MetricStats,
+    SimpleMetricStats,
+)
 from explainaboard.metrics.registry import register_metric_config
 from explainaboard.utils.span_utils import BIOSpanOps, BMESSpanOps, SpanOps
 from explainaboard.utils.typing_utils import unwrap_or
@@ -73,7 +78,7 @@ class F1Score(Metric):
                     stats[i, tid * stat_mult + 2] += 1
                     if config.separate_match:
                         stats[i, tid * stat_mult + 3] += 1
-        return MetricStats(stats)
+        return SimpleMetricStats(stats)
 
     def calc_metric_from_aggregate(
         self, agg_stats: np.ndarray, config: Optional[MetricConfig] = None
@@ -185,4 +190,4 @@ class SeqF1Score(F1Score):
                 for span in spans:
                     c = tag_ids[span[0]]
                     stats[i, c * stat_mult + offset] += 1
-        return MetricStats(stats)
+        return SimpleMetricStats(stats)

--- a/explainaboard/metrics/log_prob.py
+++ b/explainaboard/metrics/log_prob.py
@@ -5,7 +5,12 @@ from typing import cast, Optional
 
 import numpy as np
 
-from explainaboard.metrics.metric import Metric, MetricConfig, MetricStats
+from explainaboard.metrics.metric import (
+    Metric,
+    MetricConfig,
+    MetricStats,
+    SimpleMetricStats,
+)
 from explainaboard.metrics.registry import register_metric_config
 from explainaboard.utils.typing_utils import unwrap_or
 
@@ -26,8 +31,7 @@ class LogProb(Metric):
     """
 
     def is_simple_average(self, stats: MetricStats):
-        stats_data = stats.get_data()
-        return stats_data.ndim == 1 or stats_data.shape[-1] == 1
+        return stats.num_statistics() == 1
 
     def calc_stats_from_data(
         self, true_data: list, pred_data: list, config: Optional[MetricConfig] = None
@@ -37,9 +41,9 @@ class LogProb(Metric):
         level) and either one float for each or float+length rows
         """
         if len(pred_data) == 0 or isinstance(pred_data[0], float):
-            return MetricStats(np.array(pred_data))
+            return SimpleMetricStats(np.array(pred_data))
         elif isinstance(pred_data[0], list):
-            return MetricStats(np.array([[sum(x), len(x)] for x in pred_data]))
+            return SimpleMetricStats(np.array([[sum(x), len(x)] for x in pred_data]))
         else:
             t = type(pred_data[0])
             raise ValueError(f'Invalid type of pred_data for calc_stats_from_data {t}')

--- a/explainaboard/metrics/metric.py
+++ b/explainaboard/metrics/metric.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import abc
 from dataclasses import dataclass
-from typing import final, Optional
+from typing import Any, final, Optional
 
 import numpy as np
 from scipy.stats import t as stats_t
@@ -109,7 +109,7 @@ class MetricStats(metaclass=abc.ABCMeta):
         ...
 
     @abc.abstractmethod
-    def get_data(self) -> np.ndarray:
+    def get_data(self) -> np.ndarray[tuple[int, int], Any]:
         """Get the sufficient statistics in ndarray format.
 
         This function must always return a 2-dimensional ndarray.
@@ -123,7 +123,7 @@ class MetricStats(metaclass=abc.ABCMeta):
         ...
 
     @abc.abstractmethod
-    def get_batch_data(self) -> np.ndarray:
+    def get_batch_data(self) -> np.ndarray[tuple[int, int, int], Any]:
         """Getthe sufficient statistics in ndarray format.
 
         This function must always return a 3-dimensional ndarray.
@@ -217,7 +217,7 @@ class SimpleMetricStats(MetricStats):
         """See MetricStats.num_statistics."""
         return self._data.shape[-1]
 
-    def get_data(self) -> np.ndarray:
+    def get_data(self) -> np.ndarray[tuple[int, int], Any]:
         """See MetricStats.get_data."""
         if self.is_batched():
             raise RuntimeError(
@@ -225,7 +225,7 @@ class SimpleMetricStats(MetricStats):
             )
         return self._data
 
-    def get_batch_data(self) -> np.ndarray:
+    def get_batch_data(self) -> np.ndarray[tuple[int, int, int], Any]:
         """See MetricStats.get_batch_data."""
         if not self.is_batched():
             raise RuntimeError(

--- a/explainaboard/metrics/metric.py
+++ b/explainaboard/metrics/metric.py
@@ -87,7 +87,7 @@ class MetricStats(metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def is_batched(self) -> bool:
-        """Retruns whether this statistics is batched or not.
+        """Returns whether this statistics object is batched or not.
 
         If this function returns True, `get_batch_data()` must return a corresponding
         value.

--- a/explainaboard/metrics/metric.py
+++ b/explainaboard/metrics/metric.py
@@ -124,7 +124,7 @@ class MetricStats(metaclass=abc.ABCMeta):
 
     @abc.abstractmethod
     def get_batch_data(self) -> np.ndarray[tuple[int, int, int], Any]:
-        """Getthe sufficient statistics in ndarray format.
+        """Get the sufficient statistics in ndarray format.
 
         This function must always return a 3-dimensional ndarray.
         This function may return a shallow copy of the underlying object. Changing the

--- a/explainaboard/metrics/nlg_meta_evaluation.py
+++ b/explainaboard/metrics/nlg_meta_evaluation.py
@@ -6,7 +6,12 @@ from typing import Optional, Union
 import numpy as np
 from scipy.stats import pearsonr
 
-from explainaboard.metrics.metric import Metric, MetricConfig, MetricStats
+from explainaboard.metrics.metric import (
+    Metric,
+    MetricConfig,
+    MetricStats,
+    SimpleMetricStats,
+)
 from explainaboard.metrics.registry import register_metric_config
 from explainaboard.utils.typing_utils import narrow, unwrap_or
 
@@ -50,7 +55,7 @@ class CorrelationMetric(Metric):
     ) -> MetricStats:
         config = narrow(CorrelationConfig, unwrap_or(config, self.config))
 
-        return MetricStats(
+        return SimpleMetricStats(
             np.array(
                 [
                     (true[0], true[1], true[3 if config.use_z_score else 2], pred)
@@ -100,9 +105,7 @@ class CorrelationMetric(Metric):
         :param stats: stats for every example
         :return: aggregated stats
         """
-
-        data = stats.get_data()
-        return data
+        return stats.get_batch_data() if stats.is_batched() else stats.get_data()
 
     def calc_metric_from_aggregate(
         self, agg_stats: np.ndarray, config: Optional[MetricConfig] = None

--- a/explainaboard/metrics/ranking.py
+++ b/explainaboard/metrics/ranking.py
@@ -5,7 +5,12 @@ from typing import Any, cast, Optional
 
 import numpy as np
 
-from explainaboard.metrics.metric import Metric, MetricConfig, MetricStats
+from explainaboard.metrics.metric import (
+    Metric,
+    MetricConfig,
+    MetricStats,
+    SimpleMetricStats,
+)
 from explainaboard.metrics.registry import register_metric_config
 from explainaboard.utils.typing_utils import unwrap_or
 
@@ -29,7 +34,7 @@ class Hits(Metric):
         self, true_data: list, pred_data: list, config: Optional[MetricConfig] = None
     ) -> MetricStats:  # TODO(Pengfei): why do we need the 3rd argument?
         config = cast(HitsConfig, unwrap_or(config, self.config))
-        return MetricStats(
+        return SimpleMetricStats(
             np.array(
                 [
                     (1.0 if t in p[: config.hits_k] else 0.0)
@@ -42,7 +47,7 @@ class Hits(Metric):
         self, rank_data: list, config: Optional[MetricConfig] = None
     ) -> MetricStats:  # TODO(Pengfei): why do we need the 3rd argument?
         config = cast(HitsConfig, unwrap_or(config, self.config))
-        return MetricStats(
+        return SimpleMetricStats(
             np.array([(1.0 if rank <= config.hits_k else 0.0) for rank in rank_data])
         )
 
@@ -74,7 +79,7 @@ class MeanReciprocalRank(Metric):
     def calc_stats_from_data(
         self, true_data: list, pred_data: list, config: Optional[MetricConfig] = None
     ) -> MetricStats:
-        return MetricStats(
+        return SimpleMetricStats(
             np.array([self.mrr_val(t, p) for t, p in zip(true_data, pred_data)])
         )
 
@@ -83,7 +88,7 @@ class MeanReciprocalRank(Metric):
     ) -> MetricStats:
         if any([rank is None for rank in rank_data]):
             raise ValueError('cannot calculate statistics when rank is none')
-        return MetricStats(np.array([1.0 / rank for rank in rank_data]))
+        return SimpleMetricStats(np.array([1.0 / rank for rank in rank_data]))
 
 
 @dataclass
@@ -109,11 +114,13 @@ class MeanRank(Metric):
     def calc_stats_from_data(
         self, true_data: list, pred_data: list, config: Optional[MetricConfig] = None
     ) -> MetricStats:
-        return MetricStats(
+        return SimpleMetricStats(
             np.array([self.mr_val(t, p) for t, p in zip(true_data, pred_data)])
         )
 
     def calc_stats_from_rank(
         self, rank_data: list, config: Optional[MetricConfig] = None
     ) -> MetricStats:
-        return MetricStats(np.array([rank for rank in rank_data if rank is not None]))
+        return SimpleMetricStats(
+            np.array([rank for rank in rank_data if rank is not None])
+        )

--- a/explainaboard/processors/conditional_generation.py
+++ b/explainaboard/processors/conditional_generation.py
@@ -9,7 +9,6 @@ import numpy as np
 
 from explainaboard import TaskType
 from explainaboard.analysis import feature
-import explainaboard.analysis.analyses
 from explainaboard.analysis.analyses import Analysis, AnalysisLevel
 from explainaboard.analysis.case import (
     AnalysisCase,
@@ -17,7 +16,6 @@ from explainaboard.analysis.case import (
     AnalysisCaseSpan,
 )
 from explainaboard.analysis.feature import FeatureType
-import explainaboard.analysis.feature_funcs
 from explainaboard.analysis.feature_funcs import (
     accumulate_vocab_from_samples,
     cap_feature,
@@ -26,12 +24,14 @@ from explainaboard.analysis.feature_funcs import (
     feat_num_oov,
 )
 from explainaboard.info import SysOutputInfo
-import explainaboard.metrics.eaas
-from explainaboard.metrics.eaas import EaaSMetricConfig, get_eaas_client
+from explainaboard.metrics.eaas import (
+    EaaSMetricConfig,
+    EaaSMetricStats,
+    get_eaas_client,
+)
 from explainaboard.metrics.external_eval import ExternalEvalConfig
 from explainaboard.metrics.f1_score import F1ScoreConfig
-import explainaboard.metrics.metric
-from explainaboard.metrics.metric import MetricConfig, MetricStats
+from explainaboard.metrics.metric import MetricConfig, MetricStats, SimpleMetricStats
 from explainaboard.processors.processor import Processor
 from explainaboard.processors.processor_registry import register_processor
 from explainaboard.utils.logging import progress
@@ -300,9 +300,7 @@ class ConditionalGenerationProcessor(Processor):
                 calculate=['corpus', 'stats'],
             )
             metric_stats: list[MetricStats] = [
-                explainaboard.metrics.eaas.EaaSMetricStats(
-                    name=name, pos=i, eaas_request=async_request
-                )
+                EaaSMetricStats(name=name, pos=i, eaas_request=async_request)
                 for i, name in enumerate(metric_names)
             ]
             # Calculate features
@@ -393,7 +391,7 @@ class ConditionalGenerationProcessor(Processor):
                     stats_list.append([1.0, 0.0, 0.0])
                 else:
                     stats_list.append([0.0, 1.0, 0.0])
-            metric_stats = [MetricStats(np.array(stats_list))]
+            metric_stats = [SimpleMetricStats(np.array(stats_list))]
         else:
             raise ValueError(f'{analysis_level.name}-level analysis not supported')
 

--- a/explainaboard/processors/language_modeling.py
+++ b/explainaboard/processors/language_modeling.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, cast, List
+from typing import Any
 
 from datalabs import aggregating
 import numpy as np
@@ -19,7 +19,7 @@ from explainaboard.analysis.feature_funcs import (
 )
 from explainaboard.info import SysOutputInfo
 from explainaboard.metrics.log_prob import LogProbConfig
-from explainaboard.metrics.metric import MetricConfig, MetricStats
+from explainaboard.metrics.metric import MetricConfig, MetricStats, SimpleMetricStats
 from explainaboard.processors.processor import Processor
 from explainaboard.processors.processor_registry import register_processor
 from explainaboard.utils.logging import progress
@@ -158,7 +158,7 @@ class LanguageModelingProcessor(Processor):
         elif analysis_level.name != 'token':
             raise ValueError(f'{analysis_level.name}-level analysis not supported')
         # Do tok-level analysis
-        cases: list[AnalysisCaseSpan] = []
+        cases: list[AnalysisCase] = []
         # Calculate features
         for i, output in progress(
             enumerate(sys_output), desc='calculating tok-level features'
@@ -191,10 +191,10 @@ class LanguageModelingProcessor(Processor):
                             sys_info, output, case, statistics
                         )
                 cases.append(case)
-        metric_stats = [
-            MetricStats(np.array([x.features['tok_log_prob'] for x in cases]))
+        metric_stats: list[MetricStats] = [
+            SimpleMetricStats(np.array([x.features['tok_log_prob'] for x in cases]))
         ]
-        return cast(List[AnalysisCase], cases), metric_stats
+        return cases, metric_stats
 
     @classmethod
     def default_metrics(


### PR DESCRIPTION
This change refactors implementations around `MetricStats`:

- Make `MetricStats` an interface: only abstract functions can be overridden. The existing `MetricStats` is implemented as `SimpleMetricStats`
- Separate `get_data` function into `get_data` (2-dims) and `get_batch_data` (3-dims) and add `is_batched` to check if `get_batch_data` is available.