### PR TITLE
Common implementation of type registry and serializer.

### DIFF
--- a/explainaboard/serialization/registry.py
+++ b/explainaboard/serialization/registry.py
@@ -1,5 +1,7 @@
 """Definition of TypeRegistry."""
 
+from __future__ import annotations
+
 from collections.abc import Callable
 from typing import Generic, TypeVar
 

--- a/explainaboard/serialization/registry.py
+++ b/explainaboard/serialization/registry.py
@@ -1,0 +1,110 @@
+"""Definition of TypeRegistry."""
+
+from collections.abc import Callable
+from typing import Generic, TypeVar
+
+T = TypeVar("T")
+
+
+class TypeRegistry(Generic[T]):
+    """Registry to store serializable classes.
+
+    This class defines a set of type information used in a serialization format.
+    Serializers defined on this registry can store type information to the serialized
+    data, while deserializers can in turn restore the type information from the data.
+
+    Specifically, this registry represents a bidirectional mapping between types and
+    corresponding strings. Each class can be mapped to only one string.
+
+    Example:
+        registry = TypeRegistry[object]()
+
+        # Register existing types
+        registry.register("myint")(int)
+
+        # Register a class with decorator
+        @registry.register("foo")
+        class Foo:
+            ...
+
+        # Obtain types
+        assert registry.get_type("myint") is int
+        assert registry.get_type("foo") is Foo
+
+        # Obtain names
+        assert registry.get_name(int) == "myint"
+        assert registry.get_name(Foo) == "foo"
+    """
+
+    def __init__(self) -> None:
+        """Initializes the registry."""
+        self._str_to_cls: dict[str, type] = {}
+        self._cls_to_str: dict[type, str] = {}
+
+    def register(self, name: str) -> Callable[[type[T]], type[T]]:
+        """Makes a decorator to register a type with the given name.
+
+        Args:
+            name: Name of the type in this registry.
+
+        Returns:
+            A decorator to register a type.
+        """
+
+        def wrapper(cls: type[T]) -> type[T]:
+            """Decorator to register a type with the bound name.
+
+            Args:
+                cls: Type to be registered.
+
+            Returns:
+                `cls` itself.
+
+            Raises:
+                ValueError: Either:
+                    * `name` is already used in the registry.
+                    * `cls` is already registered.
+            """
+            if name in self._str_to_cls:
+                raise ValueError(f"Name \"{name}\" is already used in the registry.")
+            if cls in self._cls_to_str:
+                raise ValueError(f"Type \"{cls.__name__}\" is already registered.")
+            self._str_to_cls[name] = cls
+            self._cls_to_str[cls] = name
+            return cls
+
+        return wrapper
+
+    def get_type(self, name: str) -> type[T]:
+        """Obtains the corresponding type of the given name.
+
+        Args:
+            name: Name to lookup in this registry.
+
+        Returns:
+            The type associated to `name`.
+
+        Raises:
+            ValueError: No type associated to `name`.
+        """
+        cls = self._str_to_cls.get(name)
+        if cls is None:
+            raise ValueError(f"No type associated to the name \"{name}\".")
+        return cls
+
+    def get_name(self, cls: type[T]) -> str:
+        """Obtains the associated name of the given type in this registry.
+
+        Args:
+            cls: Type to lookup in this registry.
+
+        Returns:
+            The name associated to `cls`.
+
+        Raises:
+            ValueError: No name associated to `cls`.
+        """
+        name = self._cls_to_str.get(cls)
+        if name is None:
+            raise ValueError(f"No name associated to the type \"{cls.__name__}\".")
+        return name

--- a/explainaboard/serialization/serializers.py
+++ b/explainaboard/serialization/serializers.py
@@ -1,0 +1,111 @@
+"""Definition of DictSerializer"""
+
+from __future__ import annotations
+
+from explainaboard.serialization.registry import TypeRegistry
+from explainaboard.serialization.types import (
+    PrimitiveData,
+    Serializable,
+    SerializableData,
+)
+
+
+class PrimitiveSerializer:
+    """Serialization from/to primitive types.
+
+    This serializer converts given object to possibly nested objects with only the
+    builtin types.
+
+    Serializable objects are converted to a dict with special member "cls_name" to store
+    its registered type name. This means that the object should not have an attribute
+    with name "cls_name".
+    """
+
+    def __init__(self, registry: TypeRegistry[Serializable]) -> None:
+        """Initializes DictSerializer.
+
+        Args:
+            registry: TypeRegistry to lookup type information.
+        """
+        self._registry = registry
+
+    def serialize(self, data: SerializableData) -> PrimitiveData:
+        """Serialize given data to a primitive object.
+
+        Args:
+            data: data to be converted.
+
+        Returns:
+            Converted data.
+
+        Raises:
+            ValueError: Some portion in `data` is not convertible.
+        """
+        if data is None:
+            return data
+
+        if isinstance(data, (bool, int, float, str)):
+            return data
+
+        if isinstance(data, (list, tuple)):
+            return type(data)(self.serialize(x) for x in data)
+
+        if isinstance(data, dict):
+            if "cls_name" in data:
+                raise ValueError("dict can not contain the key \"cls_name\".")
+            return {k: self.serialize(v) for k, v in data.items()}
+
+        if isinstance(data, Serializable):
+            cls_name = self._registry.get_name(type(data))
+            attributes = data.serialize()
+            if "cls_name" in attributes:
+                raise ValueError("Serializable can not contain the key \"cls_name\".")
+            attributes["cls_name"] = cls_name
+            return {k: self.serialize(v) for k, v in attributes.items()}
+
+        raise ValueError(f"Not a serializable data: {type(data).__name__}")
+
+    def deserialize(self, data: PrimitiveData) -> SerializableData:
+        """Deserialize given data to the original serializable data.
+
+        Args:
+            data: data to be converted.
+
+        Returns:
+            Restored data.
+
+        Raises:
+            ValueError: Some portion in `data` is not convertible.
+        """
+        if data is None:
+            return data
+
+        if isinstance(data, (bool, int, float, str)):
+            return data
+
+        if isinstance(data, (list, tuple)):
+            return type(data)(self.deserialize(x) for x in data)
+
+        if isinstance(data, dict):
+            # NOTE(odashi):
+            # Check the existence of the key without using get() since we couldn't
+            # distinguish whether the returned None is the default or the real value.
+            if "cls_name" not in data:
+                # Restore dict.
+                return {k: self.deserialize(v) for k, v in data.items()}
+
+            cls_name = data["cls_name"]
+
+            if isinstance(cls_name, str):
+                # Restore Serializable.
+                cls = self._registry.get_type(cls_name)
+                attributes = {
+                    k: self.deserialize(v) for k, v in data.items() if k != "cls_name"
+                }
+                return cls.deserialize(attributes)
+
+            raise ValueError(
+                f"Value of \"cls_name\" must be str, but got {type(cls_name).__name__}"
+            )
+
+        raise ValueError(f"Not a serialized data: {type(data).__name__}")

--- a/explainaboard/serialization/test_registry.py
+++ b/explainaboard/serialization/test_registry.py
@@ -1,0 +1,44 @@
+"""Tests for explainaboard.serialization.registry"""
+
+import unittest
+
+from explainaboard.serialization.registry import TypeRegistry
+
+
+class TypeRegistryTest(unittest.TestCase):
+    def test_register_decorator(self) -> None:
+        registry = TypeRegistry[object]()
+
+        @registry.register("foo")
+        class Bar:
+            pass
+
+        self.assertIs(registry.get_type("foo"), Bar)
+        self.assertEqual(registry.get_name(Bar), "foo")
+
+    def test_register_function(self) -> None:
+        registry = TypeRegistry[object]()
+
+        class Qux:
+            pass
+
+        registry.register("baz")(Qux)
+
+        self.assertIs(registry.get_type("baz"), Qux)
+        self.assertEqual(registry.get_name(Qux), "baz")
+
+    def test_register_builtin(self) -> None:
+        registry = TypeRegistry[object]()
+        registry.register("number")(int)
+        self.assertIs(registry.get_type("number"), int)
+        self.assertEqual(registry.get_name(int), "number")
+
+    def test_invalid_type(self) -> None:
+        registry = TypeRegistry[object]()
+        with self.assertRaisesRegex(ValueError, r"^No name associated"):
+            registry.get_name(int)
+
+    def test_invalid_name(self) -> None:
+        registry = TypeRegistry[object]()
+        with self.assertRaisesRegex(ValueError, r"^No type associated"):
+            registry.get_type("fail")

--- a/explainaboard/serialization/test_registry.py
+++ b/explainaboard/serialization/test_registry.py
@@ -1,5 +1,7 @@
 """Tests for explainaboard.serialization.registry"""
 
+from __future__ import annotations
+
 import unittest
 
 from explainaboard.serialization.registry import TypeRegistry

--- a/explainaboard/serialization/test_registry.py
+++ b/explainaboard/serialization/test_registry.py
@@ -9,25 +9,25 @@ from explainaboard.serialization.registry import TypeRegistry
 
 class TypeRegistryTest(unittest.TestCase):
     def test_register_decorator(self) -> None:
-        registry = TypeRegistry[object]()
+        test_registry = TypeRegistry[object]()
 
-        @registry.register("foo")
+        @test_registry.register("foo")
         class Bar:
             pass
 
-        self.assertIs(registry.get_type("foo"), Bar)
-        self.assertEqual(registry.get_name(Bar), "foo")
+        self.assertIs(test_registry.get_type("foo"), Bar)
+        self.assertEqual(test_registry.get_name(Bar), "foo")
 
     def test_register_function(self) -> None:
-        registry = TypeRegistry[object]()
+        test_registry = TypeRegistry[object]()
 
         class Qux:
             pass
 
-        registry.register("baz")(Qux)
+        test_registry.register("baz")(Qux)
 
-        self.assertIs(registry.get_type("baz"), Qux)
-        self.assertEqual(registry.get_name(Qux), "baz")
+        self.assertIs(test_registry.get_type("baz"), Qux)
+        self.assertEqual(test_registry.get_name(Qux), "baz")
 
     def test_register_builtin(self) -> None:
         registry = TypeRegistry[object]()

--- a/explainaboard/serialization/test_serializers.py
+++ b/explainaboard/serialization/test_serializers.py
@@ -1,0 +1,220 @@
+"""Tests for explainaboard.serialization.serializers"""
+
+from dataclasses import dataclass
+import unittest
+
+from explainaboard.serialization.registry import TypeRegistry
+from explainaboard.serialization.serializers import PrimitiveSerializer
+from explainaboard.serialization.types import Serializable, SerializableData
+from explainaboard.utils.typing_utils import narrow
+
+registry = TypeRegistry[Serializable]()
+
+
+@registry.register("Foo")
+class Foo(Serializable):
+    """Serializable class."""
+
+    def __init__(self, a: int, b: str) -> None:
+        self._a = a
+        self._b = b
+
+    def __eq__(self, other: object) -> bool:
+        return isinstance(other, Foo) and self._a == other._a and self._b == other._b
+
+    def serialize(self) -> dict[str, SerializableData]:
+        return {"a": self._a, "b": self._b}
+
+    @classmethod
+    def deserialize(cls, data: dict[str, SerializableData]) -> Serializable:
+        return cls(narrow(int, data["a"]), narrow(str, data["b"]))
+
+
+@registry.register("Bar")
+@dataclass(frozen=True)
+class Bar(Serializable):
+    """Serializable dataclass."""
+
+    x: int
+    y: str
+
+    def serialize(self) -> dict[str, SerializableData]:
+        return {"x": self.x, "y": self.y}
+
+    @classmethod
+    def deserialize(cls, data: dict[str, SerializableData]) -> Serializable:
+        return cls(narrow(int, data["x"]), narrow(str, data["y"]))
+
+
+@registry.register("Nested")
+@dataclass(frozen=True)
+class Nested(Serializable):
+    """Nested serializable class."""
+
+    foo: Foo
+    bar: Bar
+
+    def serialize(self) -> dict[str, SerializableData]:
+        return {"foo": self.foo, "bar": self.bar}
+
+    @classmethod
+    def deserialize(cls, data: dict[str, SerializableData]) -> Serializable:
+        return cls(narrow(Foo, data["foo"]), narrow(Bar, data["bar"]))
+
+
+class Unregistered(Serializable):
+    """Unregistered serializable class."""
+
+    def serialize(self) -> dict[str, SerializableData]:
+        raise NotImplementedError
+
+    @classmethod
+    def deserialize(cls, data: dict[str, SerializableData]) -> Serializable:
+        raise NotImplementedError
+
+
+class Unserializable:
+    """Unserializable class."""
+
+    pass
+
+
+@registry.register("WithClsName")
+class WithClsName(Serializable):
+    """Class with "cls_name" attribute."""
+
+    def serialize(self) -> dict[str, SerializableData]:
+        return {"cls_name": None}
+
+    @classmethod
+    def deserialize(cls, data: dict[str, SerializableData]) -> Serializable:
+        return cls()
+
+
+class PrimitiveSerializerTest(unittest.TestCase):
+    def test_serialize_primitives(self) -> None:
+        s = PrimitiveSerializer(registry)
+
+        self.assertIs(s.serialize(None), None)
+        self.assertIs(s.serialize(True), True)
+        self.assertIs(s.serialize(False), False)
+
+        self.assertIsInstance(s.serialize(12345), int)
+        self.assertIsInstance(s.serialize(123.5), float)
+        self.assertIsInstance(s.serialize("12345"), str)
+        self.assertIsInstance(s.serialize([1, 2, 3]), list)
+        self.assertIsInstance(s.serialize((1, 2, 3)), tuple)
+        self.assertIsInstance(s.serialize({"1": 10, "2": 20}), dict)
+
+        self.assertEqual(s.serialize(12345), 12345)
+        self.assertEqual(s.serialize(123.5), 123.5)
+        self.assertEqual(s.serialize("12345"), "12345")
+        self.assertEqual(s.serialize([1, 2, 3]), [1, 2, 3])
+        self.assertEqual(s.serialize((1, 2, 3)), (1, 2, 3))
+        self.assertEqual(s.serialize({"1": 10, "2": 20}), {"1": 10, "2": 20})
+
+    def test_serialize_serializables(self) -> None:
+        s = PrimitiveSerializer(registry)
+
+        foo = Foo(111, "222")
+        bar = Bar(333, "444")
+        nested = Nested(foo, bar)
+
+        foo_dict = {"cls_name": "Foo", "a": 111, "b": "222"}
+        bar_dict = {"cls_name": "Bar", "x": 333, "y": "444"}
+        nested_dict = {"cls_name": "Nested", "foo": foo_dict, "bar": bar_dict}
+
+        self.assertIsInstance(s.serialize(foo), dict)
+        self.assertIsInstance(s.serialize(bar), dict)
+        self.assertIsInstance(s.serialize(nested), dict)
+        self.assertIsInstance(s.serialize([foo, bar]), list)
+        self.assertIsInstance(s.serialize((foo, bar)), tuple)
+        self.assertIsInstance(s.serialize({"foo": foo, "bar": bar}), dict)
+
+        self.assertEqual(s.serialize(foo), foo_dict)
+        self.assertEqual(s.serialize(bar), bar_dict)
+        self.assertEqual(s.serialize(nested), nested_dict)
+        self.assertEqual(s.serialize([foo, bar]), [foo_dict, bar_dict])
+        self.assertEqual(s.serialize((foo, bar)), (foo_dict, bar_dict))
+        self.assertEqual(
+            s.serialize({"foo": foo, "bar": bar}), {"foo": foo_dict, "bar": bar_dict}
+        )
+
+    def test_serialize_invalid(self) -> None:
+        s = PrimitiveSerializer(registry)
+
+        with self.assertRaisesRegex(ValueError, r"^No name associated"):
+            s.serialize(Unregistered())
+
+        with self.assertRaisesRegex(ValueError, r"^Not a serializable data"):
+            s.serialize(Unserializable())  # type: ignore
+
+        with self.assertRaisesRegex(ValueError, r"^Serializable can not contain"):
+            s.serialize(WithClsName())
+
+        with self.assertRaisesRegex(ValueError, r"^dict can not contain"):
+            s.serialize({"cls_name": None})
+
+    def test_deserialize_primitives(self) -> None:
+        s = PrimitiveSerializer(registry)
+
+        self.assertIs(s.deserialize(None), None)
+        self.assertIs(s.deserialize(True), True)
+        self.assertIs(s.deserialize(False), False)
+
+        self.assertIsInstance(s.deserialize(12345), int)
+        self.assertIsInstance(s.deserialize(123.5), float)
+        self.assertIsInstance(s.deserialize("12345"), str)
+        self.assertIsInstance(s.deserialize([1, 2, 3]), list)
+        self.assertIsInstance(s.deserialize((1, 2, 3)), tuple)
+        self.assertIsInstance(s.deserialize({"1": 10, "2": 20}), dict)
+
+        self.assertEqual(s.deserialize(12345), 12345)
+        self.assertEqual(s.deserialize(123.5), 123.5)
+        self.assertEqual(s.deserialize("12345"), "12345")
+        self.assertEqual(s.deserialize([1, 2, 3]), [1, 2, 3])
+        self.assertEqual(s.deserialize((1, 2, 3)), (1, 2, 3))
+        self.assertEqual(s.deserialize({"1": 10, "2": 20}), {"1": 10, "2": 20})
+
+    def test_deserialize_serializables(self) -> None:
+        s = PrimitiveSerializer(registry)
+
+        foo = Foo(111, "222")
+        bar = Bar(333, "444")
+        nested = Nested(foo, bar)
+
+        foo_dict = {"cls_name": "Foo", "a": 111, "b": "222"}
+        bar_dict = {"cls_name": "Bar", "x": 333, "y": "444"}
+        nested_dict = {"cls_name": "Nested", "foo": foo_dict, "bar": bar_dict}
+
+        self.assertIsInstance(s.deserialize(foo_dict), Foo)
+        self.assertIsInstance(s.deserialize(bar_dict), Bar)
+        self.assertIsInstance(s.deserialize(nested_dict), Nested)
+        self.assertIsInstance(s.deserialize([foo_dict, bar_dict]), list)
+        self.assertIsInstance(s.deserialize((foo_dict, bar_dict)), tuple)
+        self.assertIsInstance(s.deserialize({"foo": foo_dict, "bar": bar_dict}), dict)
+
+        self.assertEqual(s.deserialize(foo_dict), foo)
+        self.assertEqual(s.deserialize(bar_dict), bar)
+        self.assertEqual(s.deserialize(nested_dict), nested)
+        self.assertEqual(s.deserialize([foo_dict, bar_dict]), [foo, bar])
+        self.assertEqual(s.deserialize((foo_dict, bar_dict)), (foo, bar))
+        self.assertEqual(
+            s.deserialize({"foo": foo_dict, "bar": bar_dict}), {"foo": foo, "bar": bar}
+        )
+
+    def test_deserialize_invalid(self) -> None:
+        s = PrimitiveSerializer(registry)
+
+        with self.assertRaisesRegex(ValueError, r"^Value of \"cls_name\" must be str"):
+            # Ensure that this case should be prevented.
+            s.deserialize({"cls_name": None})
+
+        with self.assertRaisesRegex(ValueError, r"^Value of \"cls_name\" must be str"):
+            s.deserialize({"cls_name": 123})
+
+        with self.assertRaisesRegex(ValueError, r"^No type associated"):
+            s.deserialize({"cls_name": "Unknown"})
+
+        with self.assertRaisesRegex(ValueError, r"^Not a serialized data"):
+            s.deserialize(Foo(111, "222"))  # type: ignore

--- a/explainaboard/serialization/test_serializers.py
+++ b/explainaboard/serialization/test_serializers.py
@@ -1,5 +1,7 @@
 """Tests for explainaboard.serialization.serializers"""
 
+from __future__ import annotations
+
 from dataclasses import dataclass
 import unittest
 

--- a/explainaboard/serialization/test_serializers.py
+++ b/explainaboard/serialization/test_serializers.py
@@ -87,7 +87,7 @@ class WithClsName(Serializable):
         return {"cls_name": None}
 
     @classmethod
-    def deserialize(cls, data: dict[str, SerializableData]) -> Serializable:
+    def deserialize(cls, _data: dict[str, SerializableData]) -> Serializable:
         return cls()
 
 

--- a/explainaboard/serialization/test_serializers.py
+++ b/explainaboard/serialization/test_serializers.py
@@ -10,10 +10,10 @@ from explainaboard.serialization.serializers import PrimitiveSerializer
 from explainaboard.serialization.types import Serializable, SerializableData
 from explainaboard.utils.typing_utils import narrow
 
-registry = TypeRegistry[Serializable]()
+test_registry = TypeRegistry[Serializable]()
 
 
-@registry.register("Foo")
+@test_registry.register("Foo")
 class Foo(Serializable):
     """Serializable class."""
 
@@ -32,7 +32,7 @@ class Foo(Serializable):
         return cls(narrow(int, data["a"]), narrow(str, data["b"]))
 
 
-@registry.register("Bar")
+@test_registry.register("Bar")
 @dataclass(frozen=True)
 class Bar(Serializable):
     """Serializable dataclass."""
@@ -48,7 +48,7 @@ class Bar(Serializable):
         return cls(narrow(int, data["x"]), narrow(str, data["y"]))
 
 
-@registry.register("Nested")
+@test_registry.register("Nested")
 @dataclass(frozen=True)
 class Nested(Serializable):
     """Nested serializable class."""
@@ -81,7 +81,7 @@ class Unserializable:
     pass
 
 
-@registry.register("WithClsName")
+@test_registry.register("WithClsName")
 class WithClsName(Serializable):
     """Class with "cls_name" attribute."""
 
@@ -95,7 +95,7 @@ class WithClsName(Serializable):
 
 class PrimitiveSerializerTest(unittest.TestCase):
     def test_serialize_primitives(self) -> None:
-        s = PrimitiveSerializer(registry)
+        s = PrimitiveSerializer(test_registry)
 
         self.assertIs(s.serialize(None), None)
         self.assertIs(s.serialize(True), True)
@@ -116,7 +116,7 @@ class PrimitiveSerializerTest(unittest.TestCase):
         self.assertEqual(s.serialize({"1": 10, "2": 20}), {"1": 10, "2": 20})
 
     def test_serialize_serializables(self) -> None:
-        s = PrimitiveSerializer(registry)
+        s = PrimitiveSerializer(test_registry)
 
         foo = Foo(111, "222")
         bar = Bar(333, "444")
@@ -143,7 +143,7 @@ class PrimitiveSerializerTest(unittest.TestCase):
         )
 
     def test_serialize_invalid(self) -> None:
-        s = PrimitiveSerializer(registry)
+        s = PrimitiveSerializer(test_registry)
 
         with self.assertRaisesRegex(ValueError, r"^No name associated"):
             s.serialize(Unregistered())
@@ -158,7 +158,7 @@ class PrimitiveSerializerTest(unittest.TestCase):
             s.serialize({"cls_name": None})
 
     def test_deserialize_primitives(self) -> None:
-        s = PrimitiveSerializer(registry)
+        s = PrimitiveSerializer(test_registry)
 
         self.assertIs(s.deserialize(None), None)
         self.assertIs(s.deserialize(True), True)
@@ -179,7 +179,7 @@ class PrimitiveSerializerTest(unittest.TestCase):
         self.assertEqual(s.deserialize({"1": 10, "2": 20}), {"1": 10, "2": 20})
 
     def test_deserialize_serializables(self) -> None:
-        s = PrimitiveSerializer(registry)
+        s = PrimitiveSerializer(test_registry)
 
         foo = Foo(111, "222")
         bar = Bar(333, "444")
@@ -206,7 +206,7 @@ class PrimitiveSerializerTest(unittest.TestCase):
         )
 
     def test_deserialize_invalid(self) -> None:
-        s = PrimitiveSerializer(registry)
+        s = PrimitiveSerializer(test_registry)
 
         with self.assertRaisesRegex(ValueError, r"^Value of \"cls_name\" must be str"):
             # Ensure that this case should be prevented.

--- a/explainaboard/serialization/types.py
+++ b/explainaboard/serialization/types.py
@@ -1,0 +1,73 @@
+"""Type definitions for serialization."""
+
+from __future__ import annotations
+
+import abc
+from typing import Union
+
+# TODO(odashi):
+# Recursive type is supported by only the head of mypy:
+# https://github.com/python/mypy/issues/731
+# Remove following type-ignore annotations when we got an official release.
+
+# Type of primitive data.
+PrimitiveData = Union[  # type: ignore
+    None,
+    bool,
+    int,
+    float,
+    str,
+    list["PrimitiveData"],  # type: ignore
+    tuple["PrimitiveData", ...],  # type: ignore
+    dict[str, "PrimitiveData"],  # type: ignore
+]
+
+# Type of elements in Serializable objects.
+SerializableData = Union[  # type: ignore
+    None,
+    bool,
+    int,
+    float,
+    str,
+    list["SerializableData"],  # type: ignore
+    tuple["SerializableData", ...],  # type: ignore
+    dict[str, "SerializableData"],  # type: ignore
+    "Serializable",
+]
+
+
+class Serializable(metaclass=abc.ABCMeta):
+    """Interface to represent serializable classes."""
+
+    @abc.abstractmethod
+    def serialize(self) -> dict[str, SerializableData]:
+        """Returns the dict of inner elements.
+
+        This function must return a dict of shallow references (or copies) to inner
+        objects. Any manual expansion should not be applied by itself so that external
+        serializers can treat all elements with their manner.
+
+        Returns:
+            dict containing the data of self.
+        """
+        ...
+
+    @classmethod
+    @abc.abstractmethod
+    def deserialize(cls, data: dict[str, SerializableData]) -> Serializable:
+        """Constructs the object corresponding to the given data.
+
+        Args:
+            data: dict of elements to reconstruct the object.
+                At the point of calling this function, all elements in this argument
+                are already reconstructed by the external deserializer.
+                Since the deserializer does not have ways to validate member types, this
+                function need to check if the given elements have correct types.
+                Note that this argument may give elements with wrong types even when the
+                serialized data has no errors. For example, several serialization
+                formats do not distinguish the difference between list and tuple.
+
+        Returns:
+            Reconstructed object.
+        """
+        ...

--- a/explainaboard/serialization/types.py
+++ b/explainaboard/serialization/types.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import abc
-from typing import Union
+from typing import Dict, List, Tuple, Union
 
 # TODO(odashi):
 # Recursive type is supported by only the head of mypy:
@@ -17,9 +17,9 @@ PrimitiveData = Union[  # type: ignore
     int,
     float,
     str,
-    list["PrimitiveData"],  # type: ignore
-    tuple["PrimitiveData", ...],  # type: ignore
-    dict[str, "PrimitiveData"],  # type: ignore
+    List["PrimitiveData"],  # type: ignore
+    Tuple["PrimitiveData", ...],  # type: ignore
+    Dict[str, "PrimitiveData"],  # type: ignore
 ]
 
 # Type of elements in Serializable objects.
@@ -29,9 +29,9 @@ SerializableData = Union[  # type: ignore
     int,
     float,
     str,
-    list["SerializableData"],  # type: ignore
-    tuple["SerializableData", ...],  # type: ignore
-    dict[str, "SerializableData"],  # type: ignore
+    List["SerializableData"],  # type: ignore
+    Tuple["SerializableData", ...],  # type: ignore
+    Dict[str, "SerializableData"],  # type: ignore
     "Serializable",
 ]
 


### PR DESCRIPTION
This pr attempts to introduce a common implementation of the type registry and the serializer pattern.

The `TypeRegistry` class remembers any `str <-> type` mapping. It also provides a type parameter that restricts the acceptable types (checked by the static type checker).

The `Serializable` interface provides a common way to serialize/deserialize objects.

The `PrimitiveSerializer` convertes nested `Serializable` objects into a data with only builtin types, which can be passed to other string serializer, e.g., `json.dumps()`.