### PR TITLE
Reduce outputs of tests CI step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
           python -m spacy download en_core_web_sm
           python -m nltk.downloader punkt
       - name: unittest
-        run: python -m unittest
+        run: EXPLAINABOARD_HIDE_PROGRESS=1 python -m unittest -v
   format:
     runs-on: ubuntu-latest
     steps:

--- a/explainaboard/tests/test_cli.py
+++ b/explainaboard/tests/test_cli.py
@@ -1,3 +1,4 @@
+import logging
 from pathlib import Path
 import unittest
 from unittest import TestCase
@@ -6,12 +7,17 @@ from unittest.mock import patch
 import explainaboard.explainaboard_main
 from explainaboard.tests.utils import OPTIONAL_TEST_SUITES, test_output_path, top_path
 from explainaboard.utils.cache_api import cache_online_file
+from explainaboard.utils.logging import get_logger
 import explainaboard.visualizers.draw_charts
 
 
 class TestCLI(TestCase):
     """TODO: these tests only tests if they run. After the main script
     has been refactored, we can make these tests more useful"""
+
+    def setUp(self):
+        # To disable non-critical logging.
+        get_logger("report").setLevel(logging.WARNING)
 
     def test_textclass_datalab(self):
         args = [


### PR DESCRIPTION
Currently, `unittest` step shows lots of output, which prevents developers from quickly identifying test failures if some test fails. This PR reduces the output so that they can easily figure out which test passed and failed. Here's a list of changes:
- Suppress messages with level INFO. The messages are not needed in unit tests because they're not critical by definition
- Suppress progress messages in unit tests which are supposed to run very quickly. If some operations that take in the order of minutes and the operations are tested in unit tests, which indicates we're doing something wrong. If those slow tests are really important, the tests need to be run separately as integration tests, not as unit tests.
- Adds `-v` option to `unittest.main` to show passed tests.