### PR TITLE
Add SerializableDataclass

### DIFF
--- a/explainaboard/serialization/test_types.py
+++ b/explainaboard/serialization/test_types.py
@@ -14,14 +14,28 @@ class MyData(SerializableDataclass):
     bar: str
 
 
+class WithoutDecorator(SerializableDataclass):
+    """SerializableDataclass without decorator."""
+
+    pass
+
+
 class TestSerializableDataclass(unittest.TestCase):
     def test_serialize(self) -> None:
         self.assertEqual(MyData(111, "222").serialize(), {"foo": 111, "bar": "222"})
+
+    def test_serialize_without_decorator(self) -> None:
+        with self.assertRaisesRegex(TypeError, r"is not a dataclass"):
+            WithoutDecorator().serialize()
 
     def test_deserialize(self) -> None:
         self.assertEqual(
             MyData.deserialize({"foo": 333, "bar": "444"}), MyData(333, "444")
         )
+
+    def test_deserialize_without_decorator(self) -> None:
+        with self.assertRaisesRegex(TypeError, r"is not a dataclass"):
+            WithoutDecorator.deserialize({})
 
     def test_deserialize_excessive(self) -> None:
         # Unrecognized members are ignored.

--- a/explainaboard/serialization/test_types.py
+++ b/explainaboard/serialization/test_types.py
@@ -1,0 +1,35 @@
+"""Tests for explainaboard.serialization.types."""
+
+import dataclasses
+import unittest
+
+from explainaboard.serialization.types import SerializableDataclass
+
+
+@dataclasses.dataclass
+class MyData(SerializableDataclass):
+    """SerializableDataclass for this test."""
+
+    foo: int
+    bar: str
+
+
+class TestSerializableDataclass(unittest.TestCase):
+    def test_serialize(self) -> None:
+        self.assertEqual(MyData(111, "222").serialize(), {"foo": 111, "bar": "222"})
+
+    def test_deserialize(self) -> None:
+        self.assertEqual(
+            MyData.deserialize({"foo": 333, "bar": "444"}), MyData(333, "444")
+        )
+
+    def test_deserialize_excessive(self) -> None:
+        # Unrecognized members are ignored.
+        self.assertEqual(
+            MyData.deserialize({"foo": 555, "bar": "666", "baz": 777}),
+            MyData(555, "666"),
+        )
+
+    def test_deserialize_deficient(self) -> None:
+        with self.assertRaisesRegex(TypeError, r"positional argument: 'bar'"):
+            MyData.deserialize({"foo": 888})

--- a/explainaboard/serialization/types.py
+++ b/explainaboard/serialization/types.py
@@ -95,12 +95,17 @@ class SerializableDataclass(Serializable):
     @final
     def serialize(self) -> dict[str, SerializableData]:
         """See Serializable.serialize."""
+        if not dataclasses.is_dataclass(self):
+            raise TypeError(f"{self.__class__.__name__} is not a dataclass.")
         return dataclasses.asdict(self)
 
     @final
     @classmethod
     def deserialize(cls, data: dict[str, SerializableData]) -> Serializable:
         """See Serializable.deserialize."""
+        if not dataclasses.is_dataclass(cls):
+            raise TypeError(f"{cls.__name__} is not a dataclass.")
+
         # This function does not process runtime type checking for now.
         field_names = set(field.name for field in dataclasses.fields(cls))
         return cls(**{k: v for k, v in data.items() if k in field_names})

--- a/explainaboard/serialization/types.py
+++ b/explainaboard/serialization/types.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import abc
-from typing import Dict, List, Tuple, Union
+import dataclasses
+from typing import Dict, final, List, Tuple, Union
 
 # TODO(odashi):
 # Recursive type is supported by only the head of mypy:
@@ -71,3 +72,35 @@ class Serializable(metaclass=abc.ABCMeta):
             Reconstructed object.
         """
         ...
+
+
+class SerializableDataclass(Serializable):
+    """Mix-in class of serializable dataclass.
+
+    This class provides a common implementation to serialize/deserialize dataclass.
+
+    Example:
+        @dataclass
+        MyData(SerializableDataclass):
+            foo: int
+            bar: str
+
+        >>> MyData(111, "222").serialize()
+        {"foo": 111, "bar": "222"}
+
+        >>> MyData.deserialize({"foo": 333, "bar": "444"})
+        MyData(foo=333, bar="444")
+    """
+
+    @final
+    def serialize(self) -> dict[str, SerializableData]:
+        """See Serializable.serialize."""
+        return dataclasses.asdict(self)
+
+    @final
+    @classmethod
+    def deserialize(cls, data: dict[str, SerializableData]) -> Serializable:
+        """See Serializable.deserialize."""
+        # This function does not process runtime type checking for now.
+        field_names = set(field.name for field in dataclasses.fields(cls))
+        return cls(**{k: v for k, v in data.items() if k in field_names})

--- a/explainaboard/serialization/types.py
+++ b/explainaboard/serialization/types.py
@@ -80,10 +80,10 @@ class SerializableDataclass(Serializable):
     This class provides a common implementation to serialize/deserialize dataclass.
 
     Example:
-        @dataclass
-        MyData(SerializableDataclass):
-            foo: int
-            bar: str
+        >>> @dataclass
+        >>> MyData(SerializableDataclass):
+        >>>     foo: int
+        >>>     bar: str
 
         >>> MyData(111, "222").serialize()
         {"foo": 111, "bar": "222"}


### PR DESCRIPTION
This pr adds `SerializableDataclass` mix-in, which provides a common interface to serialize/deserialize dataclasses.

For now `serialize()` and `deserialize()` functions are protected by `@final` to let the derived classes follow the common behavior.