### PR TITLE
Suppress INFO level message in tests

### DIFF
--- a/explainaboard/tests/test_cli.py
+++ b/explainaboard/tests/test_cli.py
@@ -17,7 +17,8 @@ class TestCLI(TestCase):
 
     def setUp(self):
         # To disable non-critical logging.
-        get_logger("report").setLevel(logging.WARNING)
+        for name in [None, "report"]:
+            get_logger(name).setLevel(logging.WARNING)
 
     def test_textclass_datalab(self):
         args = [


### PR DESCRIPTION
This is a follow-up change of #395 to suppress remaining INFO level messages in tests.