### PR TITLE
Avoid showing the first line of test method's docstring in tests

### DIFF
--- a/explainaboard/tests/test_loaders.py
+++ b/explainaboard/tests/test_loaders.py
@@ -90,8 +90,9 @@ class BaseLoaderTests(TestCase):
         spaces_pred = loader_pred.load(spaces_path, Source.local_filesystem)
         self.assertEqual(tabs_pred, spaces_pred)
 
-    def test_missing_loader(self):
-        """raises ValueError because a tsv file loader is not provided by default"""
+    def test_raise_value_error_for_missing_tsv_file_loader(self):
+        # Given a tsv file type, should raise ValueError because the loader is
+        # not provided by default.
         self.assertRaises(
             ValueError,
             lambda: Loader(

--- a/explainaboard/tests/test_preprocessor.py
+++ b/explainaboard/tests/test_preprocessor.py
@@ -9,10 +9,6 @@ class TestExampleCode(unittest.TestCase):
     """
 
     def test_mlqa_preprocessor(self):
-        """
-        This tests the MLQAPreprocess
-        """
-
         en_preprocessor = ExtractiveQAPreprocessor(language='en')
         text = "This is a boring movie."
         text_processed = en_preprocessor(text)


### PR DESCRIPTION
Currently, running `test_missing_loader` method shows the following "unusual" output as if there is code to print out messages using `print`:
<img width="685" alt="Screen Shot 2022-08-24 at 22 12 24" src="https://user-images.githubusercontent.com/1183444/186427619-465ff85b-674b-41c4-bdb8-54f7dd483de1.png">

Python's unittest module has a behavior that [the test runner prints the first line of test method's docstring in tests](https://github.com/python/cpython/blob/203b598e5113f3662bfbaf3474dd62a258b8b6ce/Lib/unittest/runner.py#L44-L54). It seems better to rename the test name to more informative for now because all tests except this test and `test_mlqa_preprocessor` (this docstring isn't informative) don't use this feature. Whether to use this feature or not can be discussed in separate places if necessary.
