### PR TITLE
Follow GNU convention about CLI arguments

### DIFF
--- a/docs/cli_interface.md
+++ b/docs/cli_interface.md
@@ -50,12 +50,12 @@ Sentiment Treebank, a set of sentiment tags over English reviews.
 
 The below example loads the `sst2` dataset from DataLab:
 ```shell
-explainaboard --task text-classification --dataset sst2 --system_outputs ./data/system_outputs/sst2/sst2-lstm-output.txt
+explainaboard --task text-classification --dataset sst2 --system-outputs ./data/system_outputs/sst2/sst2-lstm-output.txt
 ```
 
 The below example loads a dataset from an existing file:
 ```shell
-explainaboard --task text-classification --custom_dataset_paths ./data/system_outputs/sst2/sst2-dataset.tsv --system_outputs ./data/system_outputs/sst2/sst2-lstm-output.txt
+explainaboard --task text-classification --custom-dataset-paths ./data/system_outputs/sst2/sst2-dataset.tsv --system-outputs ./data/system_outputs/sst2/sst2-lstm-output.txt
 ```
 
 
@@ -70,12 +70,12 @@ Stanford Natural Language Inference dataset.
 
 The below example loads the `snli` dataset from DataLab:
 ```shell
-explainaboard --task text-pair-classification --dataset snli --system_outputs ./data/system_outputs/snli/snli-roberta-output.txt
+explainaboard --task text-pair-classification --dataset snli --system-outputs ./data/system_outputs/snli/snli-roberta-output.txt
 ```
 
 The below example loads a dataset from an existing file:
 ```shell
-explainaboard --task text-pair-classification --custom_dataset_paths ./data/system_outputs/snli/snli-dataset.tsv --system_outputs ./data/system_outputs/snli/snli-roberta-output.txt
+explainaboard --task text-pair-classification --custom-dataset-paths ./data/system_outputs/snli/snli-dataset.tsv --system-outputs ./data/system_outputs/snli/snli-roberta-output.txt
 ```
 
 
@@ -89,7 +89,7 @@ a summarization system on the CNN-daily mail dataset.
 
 The below example loads a miniature version of the CNN-daily mail dataset (100 lines only) from an existing file:
 ```shell
-explainaboard --task summarization --custom_dataset_paths ./data/system_outputs/cnndm/cnndm_mini-dataset.tsv --system_outputs ./data/system_outputs/cnndm/cnndm_mini-bart-output.txt --metrics rouge2 bart_score_en_ref
+explainaboard --task summarization --custom-dataset-paths ./data/system_outputs/cnndm/cnndm_mini-dataset.tsv --system-outputs ./data/system_outputs/cnndm/cnndm_mini-bart-output.txt --metrics rouge2 bart_score_en_ref
 ```
 Note that this uses two different metrics separated by a space.
 
@@ -101,7 +101,7 @@ wget -P ./data/system_outputs/cnndm/ http://www.phontron.com/download/cnndm-bart
 
 Then run the below command and it should work:
 ```shell
-explainaboard --task summarization --dataset cnn_dailymail --system_outputs ./data/system_outputs/cnndm/cnndm-bart-output.txt --metrics rouge2
+explainaboard --task summarization --dataset cnn_dailymail --system-outputs ./data/system_outputs/cnndm/cnndm-bart-output.txt --metrics rouge2
 ```
 
 ## Language Modeling
@@ -114,7 +114,7 @@ probability for each space-separated word. Here is an example:
 
 The below example analyzes the wikitext corpus:
 ```shell
-explainaboard --task language-modeling --custom_dataset_paths ./data/system_outputs/wikitext/wikitext-dataset.txt --system_outputs ./data/system_outputs/wikitext-sys1-output.txt
+explainaboard --task language-modeling --custom-dataset-paths ./data/system_outputs/wikitext/wikitext-dataset.txt --system-outputs ./data/system_outputs/wikitext-sys1-output.txt
 ```
 
 ## Named Entity Recognition
@@ -126,12 +126,12 @@ The below examples demonstrate how you can perform such analysis on the CoNLL 20
 
 The below example loads the `conll2003` NER dataset from DataLab:
 ```shell
-explainaboard --task named-entity-recognition --dataset conll2003 --sub_dataset ner --system_outputs ./data/system_outputs/conll2003/conll2003-elmo-output.conll
+explainaboard --task named-entity-recognition --dataset conll2003 --sub-dataset ner --system-outputs ./data/system_outputs/conll2003/conll2003-elmo-output.conll
 ```
 
 Alternatively, you can reference a dataset file directly.
 ```shell
-explainaboard --task named-entity-recognition --custom_dataset_paths ./data/system_outputs/conll2003/conll2003-dataset.conll --system_outputs ./data/system_outputs/conll2003/conll2003-elmo-output.conll 
+explainaboard --task named-entity-recognition --custom-dataset-paths ./data/system_outputs/conll2003/conll2003-dataset.conll --system-outputs ./data/system_outputs/conll2003/conll2003-elmo-output.conll 
 ```
 
 
@@ -142,13 +142,13 @@ Word segmentation aims to segment texts without spaces between words.
 
 The below example loads the `msr` dataset from DataLab:
 ```shell
-explainaboard --task word-segmentation --dataset msr --system_outputs ./data/system_outputs/cws/test-msr-predictions.tsv
+explainaboard --task word-segmentation --dataset msr --system-outputs ./data/system_outputs/cws/test-msr-predictions.tsv
 ```
 Note that the file `test-msr-predictions.tsv` can be downloaded [here](https://datalab-hub.s3.amazonaws.com/predictions/test-msr-predictions.tsv)
 
 Alternatively, you can reference a dataset file directly.
 ```
-explainaboard --task word-segmentation --custom_dataset_paths ./data/system_outputs/cws/test.tsv --system_outputs ./data/system_outputs/cws/prediction.tsv
+explainaboard --task word-segmentation --custom-dataset-paths ./data/system_outputs/cws/test.tsv --system-outputs ./data/system_outputs/cws/prediction.tsv
 ```
 
 
@@ -159,12 +159,12 @@ Dividing text into syntactically related non-overlapping groups of words.
 
 The below example loads the `conll00_chunk` dataset from DataLab:
 ```shell
-explainaboard --task chunking --dataset conll00_chunk --system_outputs ./data/system_outputs/chunking/test-conll00-predictions.tsv
+explainaboard --task chunking --dataset conll00_chunk --system-outputs ./data/system_outputs/chunking/test-conll00-predictions.tsv
 ```
 
 Alternatively, you can reference a dataset file directly.
 ```
-explainaboard --task chunking --custom_dataset_paths ./data/system_outputs/chunking/dataset-test-conll00.tsv --system_outputs ./data/system_outputs/chunking/test-conll00-predictions.tsv
+explainaboard --task chunking --custom-dataset-paths ./data/system_outputs/chunking/dataset-test-conll00.tsv --system-outputs ./data/system_outputs/chunking/test-conll00-predictions.tsv
 ```
 
 
@@ -178,12 +178,12 @@ The below example performs this extraction on the dataset SQuAD.
 
 Below is an example of referencing the dataset directly.
 ```shell
-explainaboard --task qa-extractive --custom_dataset_paths ./data/system_outputs/squad/squad_mini-dataset.json --system_outputs ./data/system_outputs/squad/squad_mini-example-output.json > report.json
+explainaboard --task qa-extractive --custom-dataset-paths ./data/system_outputs/squad/squad_mini-dataset.json --system-outputs ./data/system_outputs/squad/squad_mini-example-output.json > report.json
 ```
 
 The below example loads the `squad` dataset from DataLab. There is an [open issue](https://github.com/neulab/ExplainaBoard/issues/239) that prevents the specification of a dataset split, so this will not work at the moment. But we are working on it.
 ```shell
-explainaboard --task qa-extractive --dataset squad --system_outputs MY_FILE > report.json
+explainaboard --task qa-extractive --dataset squad --system-outputs MY_FILE > report.json
 ```
 
 
@@ -198,7 +198,7 @@ ExplainaBoard CLI.
 
 Using Build-in datasets from DataLab:
 ```shell
-explainaboard --task qa-open-domain --dataset natural_questions_comp_gen   --system_outputs ./data/system_outputs/test.dpr.nq.txt  > report.json
+explainaboard --task qa-open-domain --dataset natural_questions_comp_gen   --system-outputs ./data/system_outputs/test.dpr.nq.txt  > report.json
 ```
 
 
@@ -212,12 +212,12 @@ The following example demonstrates this on the metaphor QA dataset.
 
 The below example loads the `fig_qa` dataset from DataLab.
 ```shell
-explainaboard --task qa-multiple-choice --dataset fig_qa --system_outputs ./data/system_outputs/fig_qa/fig_qa-gptneo-output.json > report.json
+explainaboard --task qa-multiple-choice --dataset fig_qa --system-outputs ./data/system_outputs/fig_qa/fig_qa-gptneo-output.json > report.json
 ```
 
 And this is what it looks like with a custom dataset.
 ```shell
-explainaboard --task qa-multiple-choice --custom_dataset_paths ./data/system_outputs/fig_qa/fig_qa-dataset.json --system_outputs ./data/system_outputs/fig_qa/fig_qa-gptneo-output.json > report.json
+explainaboard --task qa-multiple-choice --custom-dataset-paths ./data/system_outputs/fig_qa/fig_qa-dataset.json --system-outputs ./data/system_outputs/fig_qa/fig_qa-gptneo-output.json > report.json
 ```
 
 
@@ -230,11 +230,11 @@ Predicting the tail entity of missing links in knowledge graphs
 The below example loads the `fb15k_237` dataset from DataLab.
 ```shell
     wget https://datalab-hub.s3.amazonaws.com/predictions/test_distmult.json
-    explainaboard --task kg-link-tail-prediction --dataset fb15k_237 --sub_dataset origin --system_outputs test_distmult.json > log.res
+    explainaboard --task kg-link-tail-prediction --dataset fb15k_237 --sub-dataset origin --system-outputs test_distmult.json > log.res
 ```
 
 ```shell
-    explainaboard --task kg-link-tail-prediction --custom_dataset_paths ./data/system_outputs/fb15k-237/data_mini.json --system_outputs ./data/system_outputs/fb15k-237/test-kg-prediction-no-user-defined-new.json > report.json
+    explainaboard --task kg-link-tail-prediction --custom-dataset-paths ./data/system_outputs/fb15k-237/data_mini.json --system-outputs ./data/system_outputs/fb15k-237/test-kg-prediction-no-user-defined-new.json > report.json
 ```
  
 
@@ -246,7 +246,7 @@ Predict the sentiment of a text based on a specific aspect.
 
 This is an example with a custom dataset.
 ```shell
-explainaboard --task aspect-based-sentiment-classification --custom_dataset_paths ./data/system_outputs/absa/absa-dataset.txt --system_outputs ./data/system_outputs/absa/absa-example-output.tsv > report.json
+explainaboard --task aspect-based-sentiment-classification --custom-dataset-paths ./data/system_outputs/absa/absa-dataset.txt --system-outputs ./data/system_outputs/absa/absa-example-output.tsv > report.json
 ```
 
 ## [Multiple-choice Cloze]
@@ -255,7 +255,7 @@ Fill in a blank based on multiple provided options
 **CLI Example**
 This is an example using the dataset from `DataLab`
 ```shell
-explainaboard --task cloze-multiple-choice --dataset gaokao2018_np1 --sub_dataset cloze-multiple-choice --metrics CorrectScore --system_outputs ./integration_tests/artifacts/gaokao/rst_2018_quanguojuan1_cloze_choice.json > report.json
+explainaboard --task cloze-multiple-choice --dataset gaokao2018_np1 --sub-dataset cloze-multiple-choice --metrics CorrectScore --system-outputs ./integration_tests/artifacts/gaokao/rst_2018_quanguojuan1_cloze_choice.json > report.json
 ```
 
 
@@ -265,7 +265,7 @@ Fill in a blank based on hint
 **CLI Example**
 This is an example using the dataset from `DataLab`
 ```shell
-explainaboard --task cloze-generative --dataset gaokao2018_np1 --sub_dataset cloze-hint --metrics CorrectScore --system_outputs ./integration_tests/artifacts/gaokao/rst_2018_quanguojuan1_cloze_hint.json > report.json
+explainaboard --task cloze-generative --dataset gaokao2018_np1 --sub-dataset cloze-hint --metrics CorrectScore --system-outputs ./integration_tests/artifacts/gaokao/rst_2018_quanguojuan1_cloze_hint.json > report.json
 ```
 
 
@@ -275,7 +275,7 @@ Correct errors in a text
 **CLI Example**
 This is an example using the dataset from `DataLab`
 ```shell
-explainaboard --task grammatical-error-correction --dataset gaokao2018_np1 --sub_dataset writing-grammar --metrics SeqCorrectScore --system_outputs ./integration_tests/artifacts/gaokao/rst_2018_quanguojuan1_gec.json > report.json
+explainaboard --task grammatical-error-correction --dataset gaokao2018_np1 --sub-dataset writing-grammar --metrics SeqCorrectScore --system-outputs ./integration_tests/artifacts/gaokao/rst_2018_quanguojuan1_gec.json > report.json
 ```
 
 ## Tabular Classification
@@ -291,7 +291,7 @@ dataset `json` file, as is done in `sst2-tabclass-dataset.json` below.
 
 The below example loads a dataset from an existing file:
 ```shell
-explainaboard --task tabular-classification --custom_dataset_paths ./data/system_outputs/sst2_tabclass/sst2-tabclass-dataset.json --system_outputs ./data/system_outputs/sst2/sst2-lstm-output.txt
+explainaboard --task tabular-classification --custom-dataset-paths ./data/system_outputs/sst2_tabclass/sst2-tabclass-dataset.json --system-outputs ./data/system_outputs/sst2/sst2-lstm-output.txt
 ```
 ## Tabular Regression
 
@@ -302,5 +302,5 @@ the predicted outputs are continuous numbers instead of classes.
 
 The below example loads a dataset from an existing file:
 ```shell
-explainaboard --task tabular-regression --custom_dataset_paths ./data/system_outputs/sst2_tabreg/sst2-tabclass-dataset.json --system_outputs ./data/system_outputs/sst2_tabreg/sst2-tabreg-lstm-output.txt
+explainaboard --task tabular-regression --custom-dataset-paths ./data/system_outputs/sst2_tabreg/sst2-tabclass-dataset.json --system-outputs ./data/system_outputs/sst2_tabreg/sst2-tabreg-lstm-output.txt
 ```

--- a/docs/multilingual_multitask_evaluation.md
+++ b/docs/multilingual_multitask_evaluation.md
@@ -38,7 +38,7 @@ Once the system outputs are ready, evaluation can be conducted through following
 
 
 ```
-explainaboard --system_outputs ./data/system_outputs/multilingual/json/mt5base/xnli/*
+explainaboard --system-outputs ./data/system_outputs/multilingual/json/mt5base/xnli/*
 ```
 
 
@@ -68,28 +68,28 @@ For example,
 
 * Differant languages on `marc` dataset (text classification task) using `mt5base (a.k.a CL-mt5base)` system
 ```shell
-explainaboard --system_outputs ./data/system_outputs/multilingual/json/mt5base/marc/*
+explainaboard --system-outputs ./data/system_outputs/multilingual/json/mt5base/marc/*
 ```
 
 * Differant languages on `xquad` dataset (text classification task) using `mt5base` system
 ```shell
-explainaboard --system_outputs ./data/system_outputs/multilingual/json/mt5base/xquad/*
+explainaboard --system-outputs ./data/system_outputs/multilingual/json/mt5base/xquad/*
 ```
 
 * Differant languages on `xnli` dataset (natural language inference task) using `mlpp (a.k.a CL-mlpp15out1sum)` system
 ```shell
-explainaboard --system_outputs ./data/system_outputs/multilingual/json/mlpp/xnli/*
+explainaboard --system-outputs ./data/system_outputs/multilingual/json/mlpp/xnli/*
 ```
 
 * Differant languages on `marc` dataset (text classification task) using `mlpp` system
 ```shell
-explainaboard --system_outputs ./data/system_outputs/multilingual/json/mlpp/marc/*
+explainaboard --system-outputs ./data/system_outputs/multilingual/json/mlpp/marc/*
 ```
 
 
 * Differant languages on `xquad` dataset (extractive question answwering) using `mlpp` system
 ```shell
-explainaboard --system_outputs ./data/system_outputs/multilingual/json/mlpp/xquad/*
+explainaboard --system-outputs ./data/system_outputs/multilingual/json/mlpp/xquad/*
 ```
 
 
@@ -188,7 +188,7 @@ know the average performance ove all languages for each dataset,
 
 
 ```
-explainaboard --reports ./output/reports/* --languages_aggregation average
+explainaboard --reports ./output/reports/* --languages-aggregation average
 ```
 Then following results will be printed:
 
@@ -234,7 +234,7 @@ For example, the following command represent: the performance gap between two sy
 from `mar` and `xnli` datasets.
 
 ```
-explainaboard --reports ./output/reports/* --datasets marc xnli --systems_aggregation minus
+explainaboard --reports ./output/reports/* --datasets marc xnli --systems-aggregation minus
 ```
 
 Then following results will be printed:

--- a/docs/task_aspect_based_sentiment_classification.md
+++ b/docs/task_aspect_based_sentiment_classification.md
@@ -31,11 +31,11 @@ aspect \t sentence \t true_label
 In order to perform your basic analysis, we can run the following command:
 
 ```shell
-explainaboard --task aspect-based-sentiment-classification --custom_dataset_paths ./data/system_outputs/absa/absa-dataset.txt --system_outputs ./data/system_outputs/absa/absa-example-output.tsv > report.json
+explainaboard --task aspect-based-sentiment-classification --custom-dataset-paths ./data/system_outputs/absa/absa-dataset.txt --system-outputs ./data/system_outputs/absa/absa-example-output.tsv > report.json
 ```
 where
 * `--task`: denotes the task name, you can find all supported task names [here](https://github.com/neulab/ExplainaBoard/blob/main/docs/supported_tasks.md)
-* `--system_outputs`: denote the path of system outputs. Multiple one should be 
+* `--system-outputs`: denote the path of system outputs. Multiple one should be 
   separated by space, for example, system1 system2
 * `report.json`: the generated analysis file with json format. You can find the file [here](https://github.com/neulab/ExplainaBoard/blob/main/data/reports/report_absa.json). Tips: use a json viewer
                   like [this one](http://jsonviewer.stack.hu/) for better interpretation.

--- a/docs/task_conditional_generation.md
+++ b/docs/task_conditional_generation.md
@@ -43,11 +43,11 @@ wget -P ./data/system_outputs/cnndm/ http://www.phontron.com/download/cnndm-bart
 
 Then run the below command and it should work:
 ```shell
-explainaboard --task summarization --dataset cnn_dailymail --system_outputs ./data/system_outputs/cnndm/cnndm-bart-output.txt --metrics rouge2
+explainaboard --task summarization --dataset cnn_dailymail --system-outputs ./data/system_outputs/cnndm/cnndm-bart-output.txt --metrics rouge2
 ```
 
 * `--task`: denotes the task name.
-* `--system_outputs`: denote the path of system outputs. Multiple one should be
+* `--system-outputs`: denote the path of system outputs. Multiple one should be
   separated by space, for example, system1 system2
 * `--dataset`: optional, denotes the dataset name
 * `--metrics`: optional, different metrics should be separated by space. See [more supported metrics](https://github.com/neulab/ExplainaBoard/blob/main/docs/supported_tasks.md#summarization)
@@ -62,7 +62,7 @@ source_sentence \t target_sentence
 
 In this case, we can directly use the miniature dataset distributed with the repo:
 ```shell
-explainaboard --task summarization --custom_dataset_paths ./data/system_outputs/cnndm/cnndm_mini-dataset.tsv --system_outputs ./data/system_outputs/cnndm/cnndm_mini-bart-output.txt --metrics rouge2 bart_score_en_ref
+explainaboard --task summarization --custom-dataset-paths ./data/system_outputs/cnndm/cnndm_mini-dataset.tsv --system-outputs ./data/system_outputs/cnndm/cnndm_mini-bart-output.txt --metrics rouge2 bart_score_en_ref
 ```
 
 ## Other Task Examples
@@ -71,19 +71,19 @@ explainaboard --task summarization --custom_dataset_paths ./data/system_outputs/
 
 Try it out for translation as below. The examples use a custom dataset that is not included in DataLab at the moment.
 ```shell
-explainaboard --task machine-translation --custom_dataset_paths ./data/system_outputs/ted_multi/ted_multi_slk_eng-dataset.tsv --system_outputs ./data/system_outputs/ted_multi/ted_multi_slk_eng-nmt-output.txt --metrics bleu comet
+explainaboard --task machine-translation --custom-dataset-paths ./data/system_outputs/ted_multi/ted_multi_slk_eng-dataset.tsv --system-outputs ./data/system_outputs/ted_multi/ted_multi_slk_eng-nmt-output.txt --metrics bleu comet
 ```
 
 ### Code Generation
 
 You can try out evaluation of code generation on the CoNaLa dataset in DataLab as below:
 ```shell
-explainaboard --task machine-translation --dataset conala --output_file_type json --system_outputs ./data/system_outputs/conala/conala-baseline-output.json --report_json report.json
+explainaboard --task machine-translation --dataset conala --output-file-type json --system-outputs ./data/system_outputs/conala/conala-baseline-output.json --report-json report.json
 ```
 
 You can also use a custom code generation dataset:
 ```shell
-explainaboard --task machine-translation --custom_dataset_file_type json --custom_dataset_paths data/system_outputs/conala/conala-dataset.json --output_file_type json --system_outputs ./data/system_outputs/conala/conala-baseline-output.json --report_json report.json
+explainaboard --task machine-translation --custom-dataset-file-type json --custom-dataset-paths data/system_outputs/conala/conala-dataset.json --output-file-type json --system-outputs ./data/system_outputs/conala/conala-baseline-output.json --report-json report.json
 ```
 
 ## Notes

--- a/docs/task_extractive_qa.md
+++ b/docs/task_extractive_qa.md
@@ -27,10 +27,10 @@ An example system output file is here:
 
 The below example loads the `squad` dataset from DataLab. There is an [open issue](https://github.com/neulab/ExplainaBoard/issues/239) that prevents the specification of a dataset split, so this will not work at the moment. But we are working on it.
 ```shell
-explainaboard --task qa-extractive --dataset squad --system_outputs MY_FILE > report.json
+explainaboard --task qa-extractive --dataset squad --system-outputs MY_FILE > report.json
 ```
 * `--task`: denotes the task name.
-* `--system_outputs`: denote the path of system outputs. Multiple one should be
+* `--system-outputs`: denote the path of system outputs. Multiple one should be
   separated by space, for example, system1 system2
 * `--dataset`:optional, denotes the dataset name
 * `report.json`: the generated analysis file with json format. . Tips: use a json viewer
@@ -38,7 +38,7 @@ explainaboard --task qa-extractive --dataset squad --system_outputs MY_FILE > re
 
 You can use a custom dataset directly:
 ```shell
-explainaboard --task qa-extractive --custom_dataset_paths ./data/system_outputs/squad/squad_mini-dataset.json --system_outputs ./data/system_outputs/squad/squad_mini-example-output.json > report.json
+explainaboard --task qa-extractive --custom-dataset-paths ./data/system_outputs/squad/squad_mini-dataset.json --system-outputs ./data/system_outputs/squad/squad_mini-example-output.json > report.json
 ```
 
 The dataset can be in the following format:

--- a/docs/task_grammatical_error_correction.md
+++ b/docs/task_grammatical_error_correction.md
@@ -50,12 +50,12 @@ Let's say we have one system output file:
 
 The below example loads the `gaokao2018_np1` dataset (with the subdataset name of `writing-grammar`) from DataLab:
 ```shell
-explainaboard --task grammatical-error-correction --dataset gaokao2018_np1 --sub_dataset writing-grammar --metrics SeqCorrectScore --system_outputs ./integration_tests/artifacts/gaokao/rst_2018_quanguojuan1_gec.json > report.json
+explainaboard --task grammatical-error-correction --dataset gaokao2018_np1 --sub-dataset writing-grammar --metrics SeqCorrectScore --system-outputs ./integration_tests/artifacts/gaokao/rst_2018_quanguojuan1_gec.json > report.json
 ```
 
 where
 * `--task`: denotes the task name, you can find all supported task names [here](https://github.com/neulab/ExplainaBoard/blob/main/docs/cli_interface.md)
-* `--system_outputs`: denote the path of system outputs. Multiple one should be
+* `--system-outputs`: denote the path of system outputs. Multiple one should be
   separated by space, for example, system1 system2
 * `--dataset`: denotes the dataset name
 * `--dataset`: denotes the subdataset name
@@ -64,4 +64,4 @@ where
   like [this one](http://jsonviewer.stack.hu/) for better interpretation.
 
 Alternatively, you can load the dataset from an existing file using the
-`--custom_dataset_paths` option
+`--custom-dataset-paths` option

--- a/docs/task_kg_link_tail_prediction.md
+++ b/docs/task_kg_link_tail_prediction.md
@@ -76,13 +76,13 @@ Let's say we have one system output file:
 In order to perform your basic analysis, we can run the following command:
 
 ```shell
-explainaboard --task kg-link-tail-prediction --custom_dataset_paths ./data/system_outputs/fb15k-237/test-kg-prediction-no-user-defined.json --system_outputs ./data/system_outputs/fb15k-237/test-kg-prediction-no-user-defined.json > report.json
+explainaboard --task kg-link-tail-prediction --custom-dataset-paths ./data/system_outputs/fb15k-237/test-kg-prediction-no-user-defined.json --system-outputs ./data/system_outputs/fb15k-237/test-kg-prediction-no-user-defined.json > report.json
 
 ```
 where
 * `--task`: denotes the task name. 
-* `--custom_dataset_paths`: the path of test samples
-* `--system_outputs`: denote the path of system outputs. Multiple one should be 
+* `--custom-dataset-paths`: the path of test samples
+* `--system-outputs`: denote the path of system outputs. Multiple one should be 
   separated by space, for example, system1 system2
 * `--dataset`:optional, denotes the dataset name
 * `report.json`: the generated analysis file with json format. Tips: use a json viewer like [`this one`](http://jsonviewer.stack.hu/) for better interpretation.
@@ -91,7 +91,7 @@ If the dataset has been supported by [`DataLab`](https://github.com/ExpressAI/Da
 you could also run (the advantage is that more bucketing features will be supported):
 
 ```shell
-    explainaboard --task kg-link-tail-prediction --dataset fb15k_237 --sub_dataset origin --system_outputs test_distmult.json > log.res
+    explainaboard --task kg-link-tail-prediction --dataset fb15k_237 --sub-dataset origin --system-outputs test_distmult.json > log.res
 ```
 where 
 * `test_distmult.json` represents the system output file, for example, you can download
@@ -180,7 +180,7 @@ Note that you must provide the rank of the true entity in the predictions, for a
 An example system output is [provided](https://github.com/neulab/ExplainaBoard/blob/main/integration_tests/artifacts/test-kg-prediction-user-defined.json), and you can test it using the following command:
 
 ```shell
-explainaboard --task kg-link-tail-prediction --custom_dataset_paths ./data/system_outputs/fb15k-237/data_mini.json --system_outputs ./data/system_outputs/fb15k-237/test-kg-prediction-no-user-defined-new.json > report.json
+explainaboard --task kg-link-tail-prediction --custom-dataset-paths ./data/system_outputs/fb15k-237/data_mini.json --system-outputs ./data/system_outputs/fb15k-237/test-kg-prediction-no-user-defined-new.json > report.json
 ```
 
 

--- a/docs/task_meta_evaluation.md
+++ b/docs/task_meta_evaluation.md
@@ -37,10 +37,18 @@ We have an example system outputs file:
 
 ## Performing Basic Analysis
 You can load the dataset from an existing file using the
-`--custom_dataset_paths` option
+`--custom-dataset-paths` option
 
 ```shell
-explainaboard   --task nlg-meta-evaluation --custom_dataset_paths ./data/system_outputs/nlg_meta_evaluation/wmt20-DA/cs-en/data.tsv --system_outputs ./data/system_outputs/nlg_meta_evaluation/wmt20-DA/cs-en/score.txt --output_file_type text --output_dir output/cs-en --source_language en --target_language en --metrics SysPearsonCorr SegKtauCorr RootMeanSquareError
+explainaboard \
+    --task nlg-meta-evaluation \
+    --custom-dataset-paths ./data/system_outputs/nlg_meta_evaluation/wmt20-DA/cs-en/data.tsv \
+    --system-outputs ./data/system_outputs/nlg_meta_evaluation/wmt20-DA/cs-en/score.txt \
+    --output-file-type text \
+    --output-dir output/cs-en \
+    --source-language en \
+    --target-language en \
+    --metrics SysPearsonCorr SegKtauCorr RootMeanSquareError
 ```
 
 

--- a/docs/task_qa_multiple_choice.md
+++ b/docs/task_qa_multiple_choice.md
@@ -53,11 +53,11 @@ etc. from different systems.
 In order to perform your basic analysis, we can run the following command:
 
 ```shell
-    explainaboard --task qa-multiple-choice --system_outputs ./data/system_outputs/fig_qa/gpt2.json > report.json
+    explainaboard --task qa-multiple-choice --system-outputs ./data/system_outputs/fig_qa/gpt2.json > report.json
 ```
 where
 * `--task`: denotes the task name, you can find all supported task names [here](https://github.com/neulab/ExplainaBoard/blob/main/docs/supported_tasks.md)
-* `--system_outputs`: denote the path of system outputs. Multiple one should be 
+* `--system-outputs`: denote the path of system outputs. Multiple one should be 
   separated by space, for example, system1 system2
 * `--dataset`:optional, denotes the dataset name
 * `report.json`: the generated analysis file with json format. You can find the file [here](https://github.com/ExpressAI/ExplainaBoard/blob/main/data/reports/report.json). Tips: use a json viewer
@@ -75,7 +75,7 @@ TODO: add insights
 
 One also can perform pair-wise analysis:
 ```shell
-explainaboard --task qa-multiple-choice --system_outputs model_1 model_2 > report.json
+explainaboard --task qa-multiple-choice --system-outputs model_1 model_2 > report.json
 ```
 where two system outputs are fed separated by space.
 * `report.json`: the generated analysis file with json format, whose schema is similar to the above one with single system evaluation except that

--- a/docs/task_qa_open_domain.md
+++ b/docs/task_qa_open_domain.md
@@ -30,11 +30,11 @@ etc. from different systems.
 In order to perform your basic analysis, we can run the following command:
 
 ```shell
-explainaboard --task qa-open-domain --dataset natural_questions_comp_gen   --system_outputs ./data/system_outputs/qa_open_domain/test.dpr.nq.txt  > report.json
+explainaboard --task qa-open-domain --dataset natural_questions_comp_gen   --system-outputs ./data/system_outputs/qa_open_domain/test.dpr.nq.txt  > report.json
 ```
 where
 * `--task`: denotes the task name, you can find all supported task names [here](https://github.com/neulab/ExplainaBoard/blob/main/docs/supported_tasks.md)
-* `--system_outputs`: denote the path of system outputs. Multiple one should be 
+* `--system-outputs`: denote the path of system outputs. Multiple one should be 
   separated by space, for example, system1 system2
 * `--dataset`:denotes the dataset name
 * `report.json`: the generated analysis file with json format. You can find the file [here](https://github.com/ExpressAI/ExplainaBoard/blob/main/data/reports/report.json). Tips: use a json viewer

--- a/docs/task_text_classification.md
+++ b/docs/task_text_classification.md
@@ -24,22 +24,22 @@ etc. from different systems.
 
 The below example loads the `sst2` dataset from DataLab:
 ```shell
-explainaboard --task text-classification --dataset sst2 --system_outputs ./data/system_outputs/sst2/sst2-lstm-output.txt
+explainaboard --task text-classification --dataset sst2 --system-outputs ./data/system_outputs/sst2/sst2-lstm-output.txt
 ```
 
 where
 * `--task`: denotes the task name, you can find all supported task names [here](https://github.com/neulab/ExplainaBoard/blob/main/docs/cli_interface.md)
-* `--system_outputs`: denote the path of system outputs. Multiple one should be
+* `--system-outputs`: denote the path of system outputs. Multiple one should be
   separated by space, for example, system1 system2
 * `--dataset`: denotes the dataset name
 * `report.json`: the generated analysis file with json format. Tips: use a json viewer
   like [this one](http://jsonviewer.stack.hu/) for better interpretation.
 
 Alternatively, you can load the dataset from an existing file using the
-`--custom_dataset_paths` option
+`--custom-dataset-paths` option
 
 ```shell
-explainaboard --task text-classification --custom_dataset_paths ./data/system_outputs/sst2/sst2-dataset.tsv --system_outputs ./data/system_outputs/sst2/sst2-lstm-output.txt
+explainaboard --task text-classification --custom-dataset-paths ./data/system_outputs/sst2/sst2-dataset.tsv --system-outputs ./data/system_outputs/sst2/sst2-lstm-output.txt
 ```
 
 in which case the file format of this file is TSV
@@ -51,7 +51,7 @@ text \t true_label
 
 One also can perform pair-wise analysis:
 ```shell
-explainaboard --task text-classification --dataset sst2 --system_outputs ./data/system_outputs/sst2/sst2-lstm-output.txt ./data/system_outputs/sst2/sst2-cnn-output.txt > report.json
+explainaboard --task text-classification --dataset sst2 --system-outputs ./data/system_outputs/sst2/sst2-lstm-output.txt ./data/system_outputs/sst2/sst2-cnn-output.txt > report.json
 ```
 where two system outputs are fed separated by space.
 * `report.json`: the generated analysis file with json format, whose schema is similar 

--- a/docs/task_text_pair_classification.md
+++ b/docs/task_text_pair_classification.md
@@ -24,22 +24,22 @@ Let's say we have one system output file from a RoBERTa model.
 
 The below example loads the `snli` dataset from DataLab:
 ```shell
-explainaboard --task text-pair-classification --dataset snli --system_outputs ./data/system_outputs/snli/snli-roberta-output.txt
+explainaboard --task text-pair-classification --dataset snli --system-outputs ./data/system_outputs/snli/snli-roberta-output.txt
 ```
 
 where
 * `--task`: denotes the task name, you can find all supported task names [here](https://github.com/neulab/ExplainaBoard/blob/main/docs/cli_interface.md)
-* `--system_outputs`: denote the path of system outputs. Multiple one should be
+* `--system-outputs`: denote the path of system outputs. Multiple one should be
   separated by space, for example, system1 system2
 * `--dataset`: denotes the dataset name
 * `report.json`: the generated analysis file with json format. Tips: use a json viewer
   like [this one](http://jsonviewer.stack.hu/) for better interpretation.
 
 Alternatively, you can load the dataset from an existing file using the
-`--custom_dataset_paths` option
+`--custom-dataset-paths` option
 
 ```shell
-explainaboard --task text-pair-classification --custom_dataset_paths ./data/system_outputs/snli/snli-dataset.tsv --system_outputs ./data/system_outputs/snli/snli-roberta-output.txt
+explainaboard --task text-pair-classification --custom-dataset-paths ./data/system_outputs/snli/snli-dataset.tsv --system-outputs ./data/system_outputs/snli/snli-roberta-output.txt
 ```
 
 in which case the file format of the custom dataset file (`snli-dataset.tsv`) is TSV

--- a/explainaboard/explainaboard_main.py
+++ b/explainaboard/explainaboard_main.py
@@ -363,7 +363,7 @@ def main():
         if output_dir_reports and not os.path.exists(output_dir_reports):
             os.makedirs(output_dir_reports)
 
-        # check for benchmark submission: explainaboard  --system_outputs ./data/
+        # check for benchmark submission: explainaboard  --system-outputs ./data/
         # system_outputs/sst2/user_specified_metadata.json
         num_systems = len(system_outputs)
         dataset_file_types: list[str | None] = [dataset_file_type] * num_systems

--- a/explainaboard/explainaboard_main.py
+++ b/explainaboard/explainaboard_main.py
@@ -125,7 +125,7 @@ def create_parser():
     parser = argparse.ArgumentParser(description='Explainable Leaderboards for NLP')
     parser.add_argument('--task', type=str, required=False, help="the task name")
     parser.add_argument(
-        '--system_outputs',
+        '--system-outputs',
         type=str,
         required=True,
         nargs="+",
@@ -169,21 +169,21 @@ def create_parser():
     )
 
     parser.add_argument(
-        '--systems_aggregation',
+        '--systems-aggregation',
         type=str,
         required=False,
         help="None|minus|combination",
     )
 
     parser.add_argument(
-        '--datasets_aggregation',
+        '--datasets-aggregation',
         type=str,
         required=False,
         help="None|average|",
     )
 
     parser.add_argument(
-        '--languages_aggregation',
+        '--languages-aggregation',
         type=str,
         required=False,
         help="None|average|",
@@ -198,7 +198,7 @@ def create_parser():
     )
 
     parser.add_argument(
-        '--sub_dataset',
+        '--sub-dataset',
         type=str,
         required=False,
         default=None,
@@ -215,7 +215,7 @@ def create_parser():
 
     parser.add_argument(
         '--language',
-        '--target_language',
+        '--target-language',
         dest='target_language',
         type=str,
         required=False,
@@ -225,7 +225,7 @@ def create_parser():
     )
 
     parser.add_argument(
-        '--source_language',
+        '--source-language',
         type=str,
         required=False,
         default=None,
@@ -233,7 +233,7 @@ def create_parser():
     )
 
     parser.add_argument(
-        '--reload_stat',
+        '--reload-stat',
         type=str,
         required=False,
         default=None,
@@ -249,7 +249,7 @@ def create_parser():
     )
 
     parser.add_argument(
-        '--output_file_type',
+        '--output-file-type',
         type=str,
         required=False,
         default=None,
@@ -257,7 +257,7 @@ def create_parser():
     )
 
     parser.add_argument(
-        '--conf_value',
+        '--conf-value',
         type=float,
         required=False,
         default=0.05,
@@ -265,7 +265,7 @@ def create_parser():
     )
 
     parser.add_argument(
-        '--output_dir',
+        '--output-dir',
         type=str,
         required=False,
         default=None,
@@ -273,7 +273,7 @@ def create_parser():
     )
 
     parser.add_argument(
-        '--report_json',
+        '--report-json',
         type=str,
         required=False,
         default=None,
@@ -281,21 +281,21 @@ def create_parser():
     )
 
     parser.add_argument(
-        '--system_details',
+        '--system-details',
         type=str,
         required=False,
         help="a json file to store detailed information for a system",
     )
 
     parser.add_argument(
-        '--custom_dataset_paths',
+        '--custom-dataset-paths',
         type=str,
         nargs="*",
         help="path to custom dataset",
     )
 
     parser.add_argument(
-        '--custom_dataset_file_type',
+        '--custom-dataset-file-type',
         type=str,
         help="file types for custom datasets",
     )

--- a/explainaboard/visualizers/draw_charts.py
+++ b/explainaboard/visualizers/draw_charts.py
@@ -257,7 +257,7 @@ def main():
     )
 
     parser.add_argument(
-        '--sys_names',
+        '--sys-names',
         type=str,
         required=False,
         nargs="+",
@@ -266,7 +266,7 @@ def main():
     )
 
     parser.add_argument(
-        '--output_dir',
+        '--output-dir',
         type=str,
         required=False,
         default="figures",

--- a/explainaboard/visualizers/draw_charts.py
+++ b/explainaboard/visualizers/draw_charts.py
@@ -6,11 +6,11 @@ summaries of the included analyses.
 
 Here is an example of usage:
 > explainaboard --task text-classification --dataset sst2 \
-                --system_outputs ./data/system_outputs/sst2/sst2-lstm-output.txt \
-                --report_json report-lstm.json
+                --system-outputs ./data/system_outputs/sst2/sst2-lstm-output.txt \
+                --report-json report-lstm.json
 > explainaboard --task text-classification --dataset sst2 \
-                --system_outputs ./data/system_outputs/sst2/sst2-cnn-output.txt \
-                --report_json report-cnn.json
+                --system-outputs ./data/system_outputs/sst2/sst2-cnn-output.txt \
+                --report-json report-cnn.json
 > python -m explainaboard.visualizers.draw_charts \
                 --reports report-lstm.json report-cnn.json
 

--- a/integration_tests/cli_test.py
+++ b/integration_tests/cli_test.py
@@ -29,11 +29,11 @@ class CLITest(TestCase):
             'explainaboard.explainaboard_main',
             '--task',
             'text-classification',
-            '--system_outputs',
+            '--system-outputs',
             f'{top_path}/data/system_outputs/sst2/sst2-lstm-output.txt',
             '--dataset',
             'sst2',
-            '--report_json',
+            '--report-json',
             '/dev/null',
         ]
         with patch('sys.argv', args):
@@ -44,12 +44,12 @@ class CLITest(TestCase):
             'explainaboard.explainaboard_main',
             '--task',
             'text-classification',
-            '--system_outputs',
+            '--system-outputs',
             f'{top_path}/data/system_outputs/sst2/sst2-lstm-output.txt',
             f'{top_path}/data/system_outputs/sst2/sst2-cnn-output.txt',
             '--dataset',
             'sst2',
-            '--report_json',
+            '--report-json',
             '/dev/null',
         ]
         with patch('sys.argv', args):
@@ -63,11 +63,11 @@ class CLITest(TestCase):
                 'explainaboard.explainaboard_main',
                 '--task',
                 'text-classification',
-                '--system_outputs',
+                '--system-outputs',
                 f'{top_path}/data/system_outputs/sst2/sst2-{sysname}-output.txt',
                 '--dataset',
                 'sst2',
-                '--report_json',
+                '--report-json',
                 f'{test_output_path}/reports/sst2-{sysname}-output.json',  # noqa
             ]
             with patch('sys.argv', args):
@@ -77,7 +77,7 @@ class CLITest(TestCase):
             '--reports',
             f'{test_output_path}/reports/sst2-lstm-output.json',
             f'{test_output_path}/reports/sst2-cnn-output.json',
-            '--output_dir',
+            '--output-dir',
             f'{test_output_path}/figures/',
         ]
         with patch('sys.argv', args):
@@ -88,11 +88,11 @@ class CLITest(TestCase):
             'explainaboard.explainaboard_main',
             '--task',
             'text-classification',
-            '--system_outputs',
+            '--system-outputs',
             f'{top_path}/data/system_outputs/sst2/sst2-lstm-output.txt',
-            '--custom_dataset_paths',
+            '--custom-dataset-paths',
             f'{top_path}/data/system_outputs/sst2/sst2-dataset.tsv',
-            '--report_json',
+            '--report-json',
             '/dev/null',
         ]
         with patch('sys.argv', args):
@@ -103,11 +103,11 @@ class CLITest(TestCase):
             'explainaboard.explainaboard_main',
             '--task',
             'tabular-regression',
-            '--system_outputs',
+            '--system-outputs',
             f'{top_path}/data/system_outputs/sst2_tabreg/sst2-tabreg-lstm-output.txt',
-            '--custom_dataset_paths',
+            '--custom-dataset-paths',
             f'{top_path}/data/system_outputs/sst2_tabreg/sst2-tabreg-dataset.json',
-            '--report_json',
+            '--report-json',
             '/dev/null',
         ]
         with patch('sys.argv', args):
@@ -118,11 +118,11 @@ class CLITest(TestCase):
             'explainaboard.explainaboard_main',
             '--task',
             'tabular-classification',
-            '--system_outputs',
+            '--system-outputs',
             f'{top_path}/data/system_outputs/sst2/sst2-lstm-output.txt',
-            '--custom_dataset_paths',
+            '--custom-dataset-paths',
             f'{top_path}/data/system_outputs/sst2_tabclass/sst2-tabclass-dataset.json',
-            '--report_json',
+            '--report-json',
             '/dev/null',
         ]
         with patch('sys.argv', args):
@@ -134,11 +134,11 @@ class CLITest(TestCase):
             'explainaboard.explainaboard_main',
             '--task',
             'text-pair-classification',
-            '--system_outputs',
+            '--system-outputs',
             f'{top_path}/data/system_outputs/snli/snli-roberta-output.txt',
             '--dataset',
             'snli',
-            '--report_json',
+            '--report-json',
             '/dev/null',
         ]
         with patch('sys.argv', args):
@@ -149,11 +149,11 @@ class CLITest(TestCase):
             'explainaboard.explainaboard_main',
             '--task',
             'text-pair-classification',
-            '--system_outputs',
+            '--system-outputs',
             f'{top_path}/data/system_outputs/snli/snli-roberta-output.txt',
-            '--custom_dataset_paths',
+            '--custom-dataset-paths',
             f'{top_path}/data/system_outputs/snli/snli-dataset.tsv',
-            '--report_json',
+            '--report-json',
             '/dev/null',
         ]
         with patch('sys.argv', args):
@@ -164,14 +164,14 @@ class CLITest(TestCase):
             'explainaboard.explainaboard_main',
             '--task',
             'summarization',
-            '--custom_dataset_paths',
+            '--custom-dataset-paths',
             f'{top_path}/data/system_outputs/cnndm/cnndm_mini-dataset.tsv',
-            '--system_outputs',
+            '--system-outputs',
             f'{top_path}/data/system_outputs/cnndm/cnndm_mini-bart-output.txt',
             '--metrics',
             'rouge2',
             'chrf',
-            '--report_json',
+            '--report-json',
             '/dev/null',
         ]
         with patch('sys.argv', args):
@@ -189,11 +189,11 @@ class CLITest(TestCase):
             'summarization',
             '--dataset',
             'cnn_dailymail',
-            '--system_outputs',
+            '--system-outputs',
             filename,
             '--metrics',
             'rouge2',
-            '--report_json',
+            '--report-json',
             '/dev/null',
         ]
         with patch('sys.argv', args):
@@ -204,13 +204,13 @@ class CLITest(TestCase):
             'explainaboard.explainaboard_main',
             '--task',
             'machine-translation',
-            '--custom_dataset_paths',
+            '--custom-dataset-paths',
             f'{top_path}/data/system_outputs/ted_multi/ted_multi_slk_eng-dataset.tsv',
-            '--system_outputs',
+            '--system-outputs',
             f'{top_path}/data/system_outputs/ted_multi/ted_multi_slk_eng-nmt-output.txt',  # noqa
             '--metrics',
             'bleu',
-            '--report_json',
+            '--report-json',
             '/dev/null',
         ]
         with patch('sys.argv', args):
@@ -221,15 +221,15 @@ class CLITest(TestCase):
             'explainaboard.explainaboard_main',
             "--task",
             "machine-translation",
-            "--custom_dataset_file_type",
+            "--custom-dataset-file-type",
             "json",
-            "--custom_dataset_paths",
+            "--custom-dataset-paths",
             f"{top_path}/data/system_outputs/conala/conala-dataset.json",
-            "--output_file_type",
+            "--output-file-type",
             "json",
-            "--system_outputs",
+            "--system-outputs",
             f"{top_path}/data/system_outputs/conala/conala-baseline-output.json",
-            "--report_json",
+            "--report-json",
             "report.json",
         ]
         with patch('sys.argv', args):
@@ -242,11 +242,11 @@ class CLITest(TestCase):
             "machine-translation",
             "--dataset",
             "conala",
-            "--output_file_type",
+            "--output-file-type",
             "json",
-            "--system_outputs",
+            "--system-outputs",
             f"{top_path}/data/system_outputs/conala/conala-baseline-output.json",
-            "--report_json",
+            "--report-json",
             "report.json",
         ]
         with patch('sys.argv', args):
@@ -257,11 +257,11 @@ class CLITest(TestCase):
             'explainaboard.explainaboard_main',
             '--task',
             'language-modeling',
-            '--custom_dataset_paths',
+            '--custom-dataset-paths',
             f'{top_path}/data/system_outputs/wikitext/wikitext-dataset.txt',
-            '--system_outputs',
+            '--system-outputs',
             f'{top_path}/data/system_outputs/wikitext/wikitext-sys1-output.txt',
-            '--report_json',
+            '--report-json',
             '/dev/null',
         ]
         with patch('sys.argv', args):
@@ -274,11 +274,11 @@ class CLITest(TestCase):
             'named-entity-recognition',
             '--dataset',
             'conll2003',
-            '--sub_dataset',
+            '--sub-dataset',
             'ner',
-            '--system_outputs',
+            '--system-outputs',
             f'{top_path}/data/system_outputs/conll2003/conll2003-elmo-output.conll',
-            '--report_json',
+            '--report-json',
             '/dev/null',
         ]
         with patch('sys.argv', args):
@@ -289,11 +289,11 @@ class CLITest(TestCase):
             'explainaboard.explainaboard_main',
             '--task',
             'named-entity-recognition',
-            '--custom_dataset_paths',
+            '--custom-dataset-paths',
             f'{top_path}/data/system_outputs/conll2003/conll2003-dataset.conll',
-            '--system_outputs',
+            '--system-outputs',
             f'{top_path}/data/system_outputs/conll2003/conll2003-elmo-output.conll',
-            '--report_json',
+            '--report-json',
             '/dev/null',
         ]
         with patch('sys.argv', args):
@@ -308,9 +308,9 @@ class CLITest(TestCase):
             'fig_qa',
             '--split',
             'validation',
-            '--system_outputs',
+            '--system-outputs',
             f'{top_path}/data/system_outputs/fig_qa/fig_qa-gptneo-output.json',  # noqa
-            '--report_json',
+            '--report-json',
             '/dev/null',
         ]
         with patch('sys.argv', args):
@@ -321,11 +321,11 @@ class CLITest(TestCase):
             'explainaboard.explainaboard_main',
             '--task',
             'qa-multiple-choice',
-            '--custom_dataset_paths',
+            '--custom-dataset-paths',
             f'{top_path}/data/system_outputs/fig_qa/fig_qa-dataset.json',
-            '--system_outputs',
+            '--system-outputs',
             f'{top_path}/data/system_outputs/fig_qa/fig_qa-gptneo-output.json',  # noqa
-            '--report_json',
+            '--report-json',
             '/dev/null',
         ]
         with patch('sys.argv', args):
@@ -336,11 +336,11 @@ class CLITest(TestCase):
             'explainaboard.explainaboard_main',
             '--task',
             'qa-extractive',
-            '--custom_dataset_paths',
+            '--custom-dataset-paths',
             f'{top_path}/data/system_outputs/squad/squad_mini-dataset.json',
-            '--system_outputs',
+            '--system-outputs',
             f'{top_path}/data/system_outputs/squad/squad_mini-example-output.json',
-            '--report_json',
+            '--report-json',
             '/dev/null',
         ]
         with patch('sys.argv', args):
@@ -357,9 +357,9 @@ class CLITest(TestCase):
             'kg-link-tail-prediction',
             '--dataset',
             'fb15k_237',
-            '--system_outputs',
+            '--system-outputs',
             f'{top_path}/data/system_outputs/fb15k-237/test-kg-prediction-no-user-defined.json',  # noqa
-            '--report_json',
+            '--report-json',
             '/dev/null',
         ]
         with patch('sys.argv', args):
@@ -370,11 +370,11 @@ class CLITest(TestCase):
             'explainaboard.explainaboard_main',
             '--task',
             'kg-link-tail-prediction',
-            '--custom_dataset_paths',
+            '--custom-dataset-paths',
             f'{top_path}/data/system_outputs/fb15k-237/test-kg-prediction-no-user-defined.json',  # noqa
-            '--system_outputs',
+            '--system-outputs',
             f'{top_path}/data/system_outputs/fb15k-237/test-kg-prediction-no-user-defined.json',  # noqa
-            '--report_json',
+            '--report-json',
             '/dev/null',
         ]
         with patch('sys.argv', args):
@@ -385,11 +385,11 @@ class CLITest(TestCase):
             'explainaboard.explainaboard_main',
             '--task',
             'aspect-based-sentiment-classification',
-            '--custom_dataset_paths',
+            '--custom-dataset-paths',
             f'{top_path}/data/system_outputs/absa/absa-dataset.tsv',
-            '--system_outputs',
+            '--system-outputs',
             f'{top_path}/data/system_outputs/absa/absa-example-output.txt',
-            '--report_json',
+            '--report-json',
             '/dev/null',
         ]
         with patch('sys.argv', args):


### PR DESCRIPTION
Context: https://github.com/neulab/ExplainaBoard/issues/390

This PR changes the format of "long" CLI options to follow the GNU guideline.