### PR TITLE
Fix SysOutputInfo.write_to_directory.

### DIFF
--- a/explainaboard/info.py
+++ b/explainaboard/info.py
@@ -117,7 +117,7 @@ class SysOutputInfo:
     ) -> None:
         """Write `SysOutputInfo` as JSON to `dataset_info_dir`.
 
-        This function is not thread-safe. Modify the target directory/files by other
+        This function is not thread-safe. Modification of the target directory/files by other
         processes/threads may cause unintended behavior.
 
         Args:

--- a/explainaboard/info.py
+++ b/explainaboard/info.py
@@ -117,8 +117,8 @@ class SysOutputInfo:
     ) -> None:
         """Write `SysOutputInfo` as JSON to `dataset_info_dir`.
 
-        This function is not thread-safe. Modification of the target directory/files by other
-        processes/threads may cause unintended behavior.
+        This function is not thread-safe. Modification of the target directory/files by
+        other processes/threads may cause unintended behavior.
 
         Args:
             dataset_info_dir: Directory path to store the JSON file. If the directory

--- a/explainaboard/info.py
+++ b/explainaboard/info.py
@@ -109,13 +109,49 @@ class SysOutputInfo:
                 data[str(key)] = data[key]
                 del data[key]
 
-    def write_to_directory(self, dataset_info_dir, file_name=""):
-        """Write `SysOutputInfo` as JSON to `dataset_info_dir`."""
-        file_path = (
-            os.path.join(dataset_info_dir, config.SYS_OUTPUT_INFO_FILENAME)
-            if file_name == ""
-            else os.path.join(dataset_info_dir, file_name)
+    def write_to_directory(
+        self,
+        dataset_info_dir: str,
+        file_name: str | None = None,
+        overwrite: bool = False,
+    ) -> None:
+        """Write `SysOutputInfo` as JSON to `dataset_info_dir`.
+
+        This function is not thread-safe. Modify the target directory/files by other
+        processes/threads may cause unintended behavior.
+
+        Args:
+            dataset_info_dir: Directory path to store the JSON file. If the directory
+                does not exist, this function craetes it recursively.
+            file_name: JSON file name under `dataset_info_dir`. If None, default file
+                name is used.
+            overwrite: If True, this function overwrites the existing file. If Fasle, it
+                raises an Exception if the file already exists.
+
+        Raises:
+            RuntimeError: File already exists.
+        """
+        file_name = (
+            file_name if file_name is not None else config.SYS_OUTPUT_INFO_FILENAME
         )
+        file_path = os.path.join(dataset_info_dir, file_name)
+
+        # Checks the directory.
+        if os.path.exists(dataset_info_dir):
+            if not os.path.isdir(dataset_info_dir):
+                raise RuntimeError(f"Not a directory: {dataset_info_dir}")
+        else:
+            os.makedirs(dataset_info_dir)
+
+        # Checks the file.
+        if os.path.exists(file_path):
+            if not os.path.isfile(file_path):
+                raise RuntimeError(f"Not a file: {file_path}")
+            if not overwrite:
+                raise RuntimeError(
+                    f"Attempted to overwrite the existing file: {file_path}"
+                )
+
         with open(file_path, "wb") as f:
             self._dump_info(f)
 

--- a/explainaboard/info_test.py
+++ b/explainaboard/info_test.py
@@ -1,0 +1,79 @@
+"""Tests for explainaboard.info."""
+
+import pathlib
+import tempfile
+import unittest
+
+from explainaboard.config import SYS_OUTPUT_INFO_FILENAME
+from explainaboard.info import SysOutputInfo
+
+
+class SysOutputInfoTest(unittest.TestCase):
+    def test_write_to_directory(self) -> None:
+        info = SysOutputInfo(task_name="test")
+
+        def assert_content(path: pathlib.Path) -> None:
+            """Helper to check if the file is written correctly."""
+            self.assertTrue(path.exists())
+            with path.open() as f:
+                self.assertEqual(f.readline(), "{\n")  # Checks only the first line.
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            td = pathlib.Path(tmpdir)
+
+            # w/o directory
+            dir1 = td / "dir1"
+            dir2 = td / "dir2"
+            info.write_to_directory(str(dir1))
+            info.write_to_directory(str(dir2), "my.json")
+            assert_content(dir1 / SYS_OUTPUT_INFO_FILENAME)
+            assert_content(dir2 / "my.json")
+
+            # w/ directory, w/o file
+            dir3 = td / "dir3"
+            dir3.mkdir()
+            info.write_to_directory(str(dir3))
+            info.write_to_directory(str(dir3), "my.json")
+            assert_content(dir3 / SYS_OUTPUT_INFO_FILENAME)
+            assert_content(dir3 / "my.json")
+
+            # w/ directory, w/ file
+            dir4 = td / "dir4"
+            dir4.mkdir()
+            (dir4 / SYS_OUTPUT_INFO_FILENAME).touch()
+            (dir4 / "my.json").touch()
+            with self.assertRaisesRegex(RuntimeError, r"^Attempted to overwrite"):
+                info.write_to_directory(str(dir4))
+            with self.assertRaisesRegex(RuntimeError, r"^Attempted to overwrite"):
+                info.write_to_directory(str(dir4), "my.json")
+            info.write_to_directory(str(dir4), overwrite=True)
+            info.write_to_directory(str(dir4), "my.json", overwrite=True)
+            assert_content(dir4 / SYS_OUTPUT_INFO_FILENAME)
+            assert_content(dir4 / "my.json")
+
+            # Overwrite directory with file
+            dir5 = td / "dir5"
+            dir5.mkdir()
+            (dir5 / SYS_OUTPUT_INFO_FILENAME).mkdir()
+            (dir5 / "my.json").mkdir()
+            with self.assertRaisesRegex(RuntimeError, r"^Not a file"):
+                info.write_to_directory(str(dir5))
+            with self.assertRaisesRegex(RuntimeError, r"^Not a file"):
+                info.write_to_directory(str(dir5), "my.json")
+            with self.assertRaisesRegex(RuntimeError, r"^Not a file"):
+                info.write_to_directory(str(dir5), overwrite=True)
+            with self.assertRaisesRegex(RuntimeError, r"^Not a file"):
+                info.write_to_directory(str(dir5), "my.json", overwrite=True)
+
+            # Overwrite file with directory
+            dir6 = td / "dir6"
+            dir6.mkdir()
+            (dir6 / "mydir").touch()
+            with self.assertRaisesRegex(RuntimeError, r"^Not a directory"):
+                info.write_to_directory(str(dir6 / "mydir"))
+            with self.assertRaisesRegex(RuntimeError, r"^Not a directory"):
+                info.write_to_directory(str(dir6 / "mydir"), "my.json")
+            with self.assertRaisesRegex(RuntimeError, r"^Not a directory"):
+                info.write_to_directory(str(dir6 / "mydir"), overwrite=True)
+            with self.assertRaisesRegex(RuntimeError, r"^Not a directory"):
+                info.write_to_directory(str(dir6 / "mydir"), "my.json", overwrite=True)

--- a/integration_tests/example_code_test.py
+++ b/integration_tests/example_code_test.py
@@ -1,6 +1,7 @@
+import tempfile
 import unittest
 
-from integration_tests.utils import test_output_path, top_path
+from integration_tests.utils import top_path
 
 from explainaboard import FileType, get_processor, Source, TaskType
 from explainaboard.loaders import get_loader_class
@@ -23,7 +24,9 @@ class ExampleCodeTest(unittest.TestCase):
         data = loader.load().samples
         processor = get_processor(TaskType.text_classification)
         analysis = processor.process(metadata={}, sys_output=data)
-        analysis.write_to_directory(test_output_path)
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            analysis.write_to_directory(tempdir)
 
     def test_readme_custom_dataset(self):
         dataset = f"{top_path}/integration_tests/artifacts/summarization/dataset.tsv"
@@ -34,4 +37,6 @@ class ExampleCodeTest(unittest.TestCase):
         data = loader.load().samples
         processor = get_processor(TaskType.summarization)
         analysis = processor.process(metadata={}, sys_output=data)
-        analysis.write_to_directory(test_output_path)
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            analysis.write_to_directory(tempdir)

--- a/integration_tests/kg_link_tail_prediction_test.py
+++ b/integration_tests/kg_link_tail_prediction_test.py
@@ -1,7 +1,8 @@
 import os
+import tempfile
 import unittest
 
-from integration_tests.utils import test_artifacts_path, test_output_path
+from integration_tests.utils import test_artifacts_path
 
 from explainaboard import FileType, get_processor, TaskType
 from explainaboard.loaders.file_loader import FileLoaderMetadata
@@ -30,8 +31,10 @@ class KgLinkTailPredictionTest(unittest.TestCase):
         # Initialize the processor and perform the processing
         processor = get_processor(TaskType.kg_link_tail_prediction.value)
         sys_info = processor.process(metadata={}, sys_output=data.samples)
-        # If you want to write out to disk you can use
-        sys_info.write_to_directory(test_output_path)
+
+        with tempfile.TemporaryDirectory() as tempdir:
+            # If you want to write out to disk you can use
+            sys_info.write_to_directory(tempdir)
 
     def test_no_user_defined_features(self):
         loader = get_loader_class(TaskType.kg_link_tail_prediction)(

--- a/integration_tests/utils.py
+++ b/integration_tests/utils.py
@@ -24,10 +24,6 @@ test_artifacts_path: Final = os.path.join(
     os.path.dirname(pathlib.Path(__file__)), "artifacts"
 )
 
-test_output_path: Final = os.path.join(
-    os.path.dirname(pathlib.Path(__file__)), "output"
-)
-
 top_path: Final = os.path.join(
     pathlib.Path(__file__).parent.parent.absolute(),
 )


### PR DESCRIPTION
This PR implements detailed behaviors of `SysOutputInfo.write_to_directory` in various situations of the target filesystems. Also adds `overwrite` option to avoid unintended changes on the existing files.

This PR also removes `test_output_dir` which causes some errors by applying this change. This config should not be used since running multiple tests on the shared environment brings causality problems.

Fixes https://github.com/neulab/ExplainaBoard/issues/382