### PR TITLE
Add --skip-failed-analyses option

### DIFF
--- a/explainaboard/analysis/analyses.py
+++ b/explainaboard/analysis/analyses.py
@@ -59,7 +59,7 @@ class Analysis:
         metrics: list[Metric],
         stats: list[MetricStats],
         conf_value: float,
-    ) -> AnalysisResult | None:
+    ) -> AnalysisResult:
         """
         A super-class for analyses, which take in examples and analyze their features in
         some way. The exact analysis performed will vary depending on the inheriting
@@ -68,7 +68,7 @@ class Analysis:
           These could be examples, spans, tokens, etc.
         :param metrics: The metrics used to evaluate the cases.
         :param stats: The statistics calculated by each metric.
-        :conf_value: In the case that any significance analysis is performed, the
+        :param conf_value: In the case that any significance analysis is performed, the
           confidence level.
         """
         raise NotImplementedError
@@ -175,17 +175,16 @@ class BucketAnalysis(Analysis):
         metrics: list[Metric],
         stats: list[MetricStats],
         conf_value: float,
-    ) -> AnalysisResult | None:
+    ) -> AnalysisResult:
         # Preparation for bucketing
         bucket_func: Callable[..., list[AnalysisCaseCollection]] = getattr(
             explainaboard.analysis.bucketing,
             self.method,
         )
+
         if len(cases) == 0 or self.feature not in cases[0].features:
-            get_logger().warning(
-                f'bucket analysis: feature {self.feature} not found, ' f'skipping'
-            )
-            return None
+            raise RuntimeError(f"bucket analysis: feature {self.feature} not found.")
+
         samples_over_bucket = bucket_func(
             sample_features=[(x, x.features[self.feature]) for x in cases],
             bucket_number=self.number,
@@ -294,15 +293,11 @@ class ComboCountAnalysis(Analysis):
         metrics: list[Metric],
         stats: list[MetricStats],
         conf_value: float,
-    ) -> AnalysisResult | None:
-        if len(cases) == 0:
-            return None
+    ) -> AnalysisResult:
         for x in self.features:
             if x not in cases[0].features:
-                get_logger().warning(
-                    f'combo analysis: feature {x} not found, ' f'skipping'
-                )
-                return None
+                raise RuntimeError(f"combo analysis: feature {x} not found.")
+
         combo_map: dict[tuple, int] = {}
         for case in cases:
             feat_vals = tuple([case.features[x] for x in self.features])

--- a/explainaboard/explainaboard_main.py
+++ b/explainaboard/explainaboard_main.py
@@ -301,7 +301,7 @@ def create_parser():
     )
 
     parser.add_argument(
-        '--skip-failures',
+        '--skip-failed-analyses',
         action='store_true',
         help="whether to skip failed analysis or report errors.",
     )
@@ -483,7 +483,7 @@ def main():
             report = processor.process(
                 metadata=metadata,
                 sys_output=system_dataset.samples,
-                skip_failures=args.skip_failures,
+                skip_failed_analyses=args.skip_failed_analyses,
             )
             reports.append(report)
 

--- a/explainaboard/explainaboard_main.py
+++ b/explainaboard/explainaboard_main.py
@@ -299,6 +299,12 @@ def create_parser():
         type=str,
         help="file types for custom datasets",
     )
+
+    parser.add_argument(
+        '--skip-failures',
+        action='store_true',
+        help="whether to skip failed analysis or report errors.",
+    )
     return parser
 
 
@@ -475,7 +481,9 @@ def main():
 
             processor = get_processor(task=task)
             report = processor.process(
-                metadata=metadata, sys_output=system_dataset.samples
+                metadata=metadata,
+                sys_output=system_dataset.samples,
+                skip_failures=args.skip_failures,
             )
             reports.append(report)
 

--- a/explainaboard/explainaboard_main.py
+++ b/explainaboard/explainaboard_main.py
@@ -303,7 +303,7 @@ def create_parser():
     parser.add_argument(
         '--skip-failed-analyses',
         action='store_true',
-        help="whether to skip failed analysis or report errors.",
+        help="whether to skip failed analyses or report errors.",
     )
     return parser
 

--- a/explainaboard/processors/processor.py
+++ b/explainaboard/processors/processor.py
@@ -240,14 +240,15 @@ class Processor(metaclass=abc.ABCMeta):
         sys_info: SysOutputInfo,
         analysis_cases: list[list[AnalysisCase]],
         metric_stats: list[list[MetricStats]],
-        skip_failures: bool = False,
+        skip_failed_analyses: bool = False,
     ) -> list[AnalysisResult]:
         """
         Perform fine-grained analyses
         :param sys_info: Information about the system output
         :param analysis_cases: They cases to analyze
         :param metric_stats: The stats from which to calculate performance
-        :param skip_failures: Whether to skip analysis when it encountered some errors.
+        :param skip_failed_analyses: Whether to skip analysis when it encountered some
+            errors.
         :return:
             performances_over_bucket:
                 a dictionary of feature name -> list of performances by bucket
@@ -271,7 +272,7 @@ class Processor(metaclass=abc.ABCMeta):
                     )
                 )
             except Exception as ex:
-                if not skip_failures:
+                if not skip_failed_analyses:
                     raise
                 get_logger().warning(f"Analysis failed, skipped. Reason: {ex}")
 
@@ -489,7 +490,7 @@ class Processor(metaclass=abc.ABCMeta):
 
     @final
     def process(
-        self, metadata: dict, sys_output: list[dict], skip_failures: bool = False
+        self, metadata: dict, sys_output: list[dict], skip_failed_analyses: bool = False
     ) -> SysOutputInfo:
         """"""
         overall_statistics = self.get_overall_statistics(metadata, sys_output)
@@ -498,7 +499,7 @@ class Processor(metaclass=abc.ABCMeta):
             sys_info,
             overall_statistics.analysis_cases,
             metric_stats=overall_statistics.metric_stats,
-            skip_failures=skip_failures,
+            skip_failed_analyses=skip_failed_analyses,
         )
         self.sort_bucket_info(
             analyses,

--- a/explainaboard/processors/processor.py
+++ b/explainaboard/processors/processor.py
@@ -247,7 +247,7 @@ class Processor(metaclass=abc.ABCMeta):
         :param sys_info: Information about the system output
         :param analysis_cases: They cases to analyze
         :param metric_stats: The stats from which to calculate performance
-        :param skip_failed_analyses: Whether to skip analysis when it encountered some
+        :param skip_failed_analyses: Whether to skip analyses when they encountered some
             errors.
         :return:
             performances_over_bucket:

--- a/explainaboard/utils/logging.py
+++ b/explainaboard/utils/logging.py
@@ -1,5 +1,7 @@
 """Logging utilities."""
 
+from __future__ import annotations
+
 from collections.abc import Iterable
 import logging
 import os

--- a/explainaboard/utils/logging.py
+++ b/explainaboard/utils/logging.py
@@ -1,13 +1,18 @@
+"""Logging utilities."""
+
+from collections.abc import Iterable
 import logging
 import os
-from typing import Optional
+from typing import Optional, TypeVar
 
 from tqdm import tqdm
 
 hide_progress = 'EXPLAINABOARD_HIDE_PROGRESS' in os.environ
 
+T = TypeVar("T")
 
-def progress(gen, desc: str = None):
+
+def progress(gen: Iterable[T], desc: Optional[str] = None) -> Iterable[T]:
     return gen if hide_progress else tqdm(gen, desc=desc)
 
 

--- a/explainaboard/visualizers/draw_charts.py
+++ b/explainaboard/visualizers/draw_charts.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+from typing import cast
 
 from matplotlib import pyplot as plt
 import numpy as np
@@ -231,10 +232,20 @@ def draw_charts_from_reports(
                 f'mismatched analyses: {[x.name for x in analysis_result]}'
             )
 
+        analysis_result_list = list(analysis_result)
+
         if all(isinstance(x, BucketAnalysisResult) for x in analysis_result):
-            plot_buckets(analysis_result, output_dir, sys_names)
+            plot_buckets(
+                cast(list[BucketAnalysisResult], analysis_result_list),
+                output_dir,
+                sys_names,
+            )
         elif all(isinstance(x, ComboCountAnalysisResult) for x in analysis_result):
-            plot_combo_counts(analysis_result, output_dir, sys_names)
+            plot_combo_counts(
+                cast(list[ComboCountAnalysisResult], analysis_result_list),
+                output_dir,
+                sys_names,
+            )
         else:
             raise ValueError('illegal types of analyses')
 

--- a/explainaboard/visualizers/draw_charts.py
+++ b/explainaboard/visualizers/draw_charts.py
@@ -21,7 +21,9 @@ from __future__ import annotations
 import argparse
 import json
 import os
-from typing import cast
+
+# NOTE(odashi): List is required to set the first argument of cast() in Python 3.8.
+from typing import cast, List
 
 from matplotlib import pyplot as plt
 import numpy as np
@@ -236,13 +238,13 @@ def draw_charts_from_reports(
 
         if all(isinstance(x, BucketAnalysisResult) for x in analysis_result):
             plot_buckets(
-                cast(list[BucketAnalysisResult], analysis_result_list),
+                cast(List[BucketAnalysisResult], analysis_result_list),
                 output_dir,
                 sys_names,
             )
         elif all(isinstance(x, ComboCountAnalysisResult) for x in analysis_result):
             plot_combo_counts(
-                cast(list[ComboCountAnalysisResult], analysis_result_list),
+                cast(List[ComboCountAnalysisResult], analysis_result_list),
                 output_dir,
                 sys_names,
             )

--- a/integration_tests/cli_test.py
+++ b/integration_tests/cli_test.py
@@ -99,6 +99,7 @@ class CLITest(TestCase):
             f'{top_path}/data/system_outputs/sst2/sst2-dataset.tsv',
             '--report-json',
             '/dev/null',
+            '--skip-failures',
         ]
         with patch('sys.argv', args):
             explainaboard.explainaboard_main.main()
@@ -160,6 +161,7 @@ class CLITest(TestCase):
             f'{top_path}/data/system_outputs/snli/snli-dataset.tsv',
             '--report-json',
             '/dev/null',
+            '--skip-failures',
         ]
         with patch('sys.argv', args):
             explainaboard.explainaboard_main.main()
@@ -178,6 +180,7 @@ class CLITest(TestCase):
             'chrf',
             '--report-json',
             '/dev/null',
+            '--skip-failures',
         ]
         with patch('sys.argv', args):
             explainaboard.explainaboard_main.main()
@@ -217,6 +220,7 @@ class CLITest(TestCase):
             'bleu',
             '--report-json',
             '/dev/null',
+            '--skip-failures',
         ]
         with patch('sys.argv', args):
             explainaboard.explainaboard_main.main()
@@ -236,6 +240,7 @@ class CLITest(TestCase):
             f"{top_path}/data/system_outputs/conala/conala-baseline-output.json",
             "--report-json",
             "report.json",
+            '--skip-failures',
         ]
         with patch('sys.argv', args):
             explainaboard.explainaboard_main.main()
@@ -268,6 +273,7 @@ class CLITest(TestCase):
             f'{top_path}/data/system_outputs/wikitext/wikitext-sys1-output.txt',
             '--report-json',
             '/dev/null',
+            '--skip-failures',
         ]
         with patch('sys.argv', args):
             explainaboard.explainaboard_main.main()
@@ -300,6 +306,7 @@ class CLITest(TestCase):
             f'{top_path}/data/system_outputs/conll2003/conll2003-elmo-output.conll',
             '--report-json',
             '/dev/null',
+            '--skip-failures',
         ]
         with patch('sys.argv', args):
             explainaboard.explainaboard_main.main()
@@ -332,6 +339,7 @@ class CLITest(TestCase):
             f'{top_path}/data/system_outputs/fig_qa/fig_qa-gptneo-output.json',  # noqa
             '--report-json',
             '/dev/null',
+            '--skip-failures',
         ]
         with patch('sys.argv', args):
             explainaboard.explainaboard_main.main()
@@ -347,6 +355,7 @@ class CLITest(TestCase):
             f'{top_path}/data/system_outputs/squad/squad_mini-example-output.json',
             '--report-json',
             '/dev/null',
+            '--skip-failures',
         ]
         with patch('sys.argv', args):
             explainaboard.explainaboard_main.main()
@@ -381,6 +390,7 @@ class CLITest(TestCase):
             f'{top_path}/data/system_outputs/fb15k-237/test-kg-prediction-no-user-defined.json',  # noqa
             '--report-json',
             '/dev/null',
+            '--skip-failures',
         ]
         with patch('sys.argv', args):
             explainaboard.explainaboard_main.main()

--- a/integration_tests/cli_test.py
+++ b/integration_tests/cli_test.py
@@ -99,7 +99,7 @@ class CLITest(TestCase):
             f'{top_path}/data/system_outputs/sst2/sst2-dataset.tsv',
             '--report-json',
             '/dev/null',
-            '--skip-failures',
+            '--skip-failed-analyses',
         ]
         with patch('sys.argv', args):
             explainaboard.explainaboard_main.main()
@@ -161,7 +161,7 @@ class CLITest(TestCase):
             f'{top_path}/data/system_outputs/snli/snli-dataset.tsv',
             '--report-json',
             '/dev/null',
-            '--skip-failures',
+            '--skip-failed-analyses',
         ]
         with patch('sys.argv', args):
             explainaboard.explainaboard_main.main()
@@ -180,7 +180,7 @@ class CLITest(TestCase):
             'chrf',
             '--report-json',
             '/dev/null',
-            '--skip-failures',
+            '--skip-failed-analyses',
         ]
         with patch('sys.argv', args):
             explainaboard.explainaboard_main.main()
@@ -220,7 +220,7 @@ class CLITest(TestCase):
             'bleu',
             '--report-json',
             '/dev/null',
-            '--skip-failures',
+            '--skip-failed-analyses',
         ]
         with patch('sys.argv', args):
             explainaboard.explainaboard_main.main()
@@ -240,7 +240,7 @@ class CLITest(TestCase):
             f"{top_path}/data/system_outputs/conala/conala-baseline-output.json",
             "--report-json",
             "report.json",
-            '--skip-failures',
+            '--skip-failed-analyses',
         ]
         with patch('sys.argv', args):
             explainaboard.explainaboard_main.main()
@@ -273,7 +273,7 @@ class CLITest(TestCase):
             f'{top_path}/data/system_outputs/wikitext/wikitext-sys1-output.txt',
             '--report-json',
             '/dev/null',
-            '--skip-failures',
+            '--skip-failed-analyses',
         ]
         with patch('sys.argv', args):
             explainaboard.explainaboard_main.main()
@@ -306,7 +306,7 @@ class CLITest(TestCase):
             f'{top_path}/data/system_outputs/conll2003/conll2003-elmo-output.conll',
             '--report-json',
             '/dev/null',
-            '--skip-failures',
+            '--skip-failed-analyses',
         ]
         with patch('sys.argv', args):
             explainaboard.explainaboard_main.main()
@@ -339,7 +339,7 @@ class CLITest(TestCase):
             f'{top_path}/data/system_outputs/fig_qa/fig_qa-gptneo-output.json',  # noqa
             '--report-json',
             '/dev/null',
-            '--skip-failures',
+            '--skip-failed-analyses',
         ]
         with patch('sys.argv', args):
             explainaboard.explainaboard_main.main()
@@ -355,7 +355,7 @@ class CLITest(TestCase):
             f'{top_path}/data/system_outputs/squad/squad_mini-example-output.json',
             '--report-json',
             '/dev/null',
-            '--skip-failures',
+            '--skip-failed-analyses',
         ]
         with patch('sys.argv', args):
             explainaboard.explainaboard_main.main()
@@ -390,7 +390,7 @@ class CLITest(TestCase):
             f'{top_path}/data/system_outputs/fb15k-237/test-kg-prediction-no-user-defined.json',  # noqa
             '--report-json',
             '/dev/null',
-            '--skip-failures',
+            '--skip-failed-analyses',
         ]
         with patch('sys.argv', args):
             explainaboard.explainaboard_main.main()

--- a/integration_tests/cloze_hint_test.py
+++ b/integration_tests/cloze_hint_test.py
@@ -28,7 +28,7 @@ class ClozeGenerativeTest(unittest.TestCase):
             "metric_names": ["CorrectCount"],
         }
         processor = get_processor(TaskType.cloze_generative.value)
-        sys_info = processor.process(metadata, data, skip_failures=True)
+        sys_info = processor.process(metadata, data, skip_failed_analyses=True)
         self.assertIsNotNone(sys_info.results.analyses)
 
 

--- a/integration_tests/cloze_hint_test.py
+++ b/integration_tests/cloze_hint_test.py
@@ -28,7 +28,7 @@ class ClozeGenerativeTest(unittest.TestCase):
             "metric_names": ["CorrectCount"],
         }
         processor = get_processor(TaskType.cloze_generative.value)
-        sys_info = processor.process(metadata, data)
+        sys_info = processor.process(metadata, data, skip_failures=True)
         self.assertIsNotNone(sys_info.results.analyses)
 
 

--- a/integration_tests/cloze_multiple_choice_test.py
+++ b/integration_tests/cloze_multiple_choice_test.py
@@ -28,7 +28,7 @@ class ClozeMultipleChoiceTest(unittest.TestCase):
             "metric_names": ["CorrectCount"],
         }
         processor = get_processor(TaskType.cloze_mutiple_choice.value)
-        sys_info = processor.process(metadata, data)
+        sys_info = processor.process(metadata, data, skip_failures=True)
         self.assertIsNotNone(sys_info.results.analyses)
 
 

--- a/integration_tests/cloze_multiple_choice_test.py
+++ b/integration_tests/cloze_multiple_choice_test.py
@@ -28,7 +28,7 @@ class ClozeMultipleChoiceTest(unittest.TestCase):
             "metric_names": ["CorrectCount"],
         }
         processor = get_processor(TaskType.cloze_mutiple_choice.value)
-        sys_info = processor.process(metadata, data, skip_failures=True)
+        sys_info = processor.process(metadata, data, skip_failed_analyses=True)
         self.assertIsNotNone(sys_info.results.analyses)
 
 

--- a/integration_tests/dynamic_hits_metric_test.py
+++ b/integration_tests/dynamic_hits_metric_test.py
@@ -33,7 +33,7 @@ class KgLinkTailPredictionTest(unittest.TestCase):
 
         processor = get_processor(TaskType.kg_link_tail_prediction.value)
 
-        sys_info = processor.process(metadata, data.samples, skip_failures=True)
+        sys_info = processor.process(metadata, data.samples, skip_failed_analyses=True)
 
         self.assertIsNotNone(sys_info.results.analyses)
         self.assertGreater(len(sys_info.results.overall), 0)

--- a/integration_tests/dynamic_hits_metric_test.py
+++ b/integration_tests/dynamic_hits_metric_test.py
@@ -33,7 +33,7 @@ class KgLinkTailPredictionTest(unittest.TestCase):
 
         processor = get_processor(TaskType.kg_link_tail_prediction.value)
 
-        sys_info = processor.process(metadata, data.samples)
+        sys_info = processor.process(metadata, data.samples, skip_failures=True)
 
         self.assertIsNotNone(sys_info.results.analyses)
         self.assertGreater(len(sys_info.results.overall), 0)

--- a/integration_tests/example_code_test.py
+++ b/integration_tests/example_code_test.py
@@ -23,7 +23,7 @@ class ExampleCodeTest(unittest.TestCase):
         )
         data = loader.load().samples
         processor = get_processor(TaskType.text_classification)
-        analysis = processor.process(metadata={}, sys_output=data)
+        analysis = processor.process(metadata={}, sys_output=data, skip_failures=True)
 
         with tempfile.TemporaryDirectory() as tempdir:
             analysis.write_to_directory(tempdir)
@@ -36,7 +36,7 @@ class ExampleCodeTest(unittest.TestCase):
         )
         data = loader.load().samples
         processor = get_processor(TaskType.summarization)
-        analysis = processor.process(metadata={}, sys_output=data)
+        analysis = processor.process(metadata={}, sys_output=data, skip_failures=True)
 
         with tempfile.TemporaryDirectory() as tempdir:
             analysis.write_to_directory(tempdir)

--- a/integration_tests/example_code_test.py
+++ b/integration_tests/example_code_test.py
@@ -23,7 +23,9 @@ class ExampleCodeTest(unittest.TestCase):
         )
         data = loader.load().samples
         processor = get_processor(TaskType.text_classification)
-        analysis = processor.process(metadata={}, sys_output=data, skip_failures=True)
+        analysis = processor.process(
+            metadata={}, sys_output=data, skip_failed_analyses=True
+        )
 
         with tempfile.TemporaryDirectory() as tempdir:
             analysis.write_to_directory(tempdir)
@@ -36,7 +38,9 @@ class ExampleCodeTest(unittest.TestCase):
         )
         data = loader.load().samples
         processor = get_processor(TaskType.summarization)
-        analysis = processor.process(metadata={}, sys_output=data, skip_failures=True)
+        analysis = processor.process(
+            metadata={}, sys_output=data, skip_failed_analyses=True
+        )
 
         with tempfile.TemporaryDirectory() as tempdir:
             analysis.write_to_directory(tempdir)

--- a/integration_tests/kg_link_tail_prediction_test.py
+++ b/integration_tests/kg_link_tail_prediction_test.py
@@ -30,7 +30,9 @@ class KgLinkTailPredictionTest(unittest.TestCase):
         data = loader.load()
         # Initialize the processor and perform the processing
         processor = get_processor(TaskType.kg_link_tail_prediction.value)
-        sys_info = processor.process(metadata={}, sys_output=data.samples)
+        sys_info = processor.process(
+            metadata={}, sys_output=data.samples, skip_failures=True
+        )
 
         with tempfile.TemporaryDirectory() as tempdir:
             # If you want to write out to disk you can use
@@ -58,7 +60,7 @@ class KgLinkTailPredictionTest(unittest.TestCase):
 
         processor = get_processor(TaskType.kg_link_tail_prediction.value)
 
-        sys_info = processor.process(metadata, data.samples)
+        sys_info = processor.process(metadata, data.samples, skip_failures=True)
 
         self.assertIsNotNone(sys_info.results.analyses)
         self.assertGreater(len(sys_info.results.overall), 0)
@@ -109,7 +111,7 @@ class KgLinkTailPredictionTest(unittest.TestCase):
         }
 
         processor = get_processor(TaskType.kg_link_tail_prediction.value)
-        sys_info = processor.process(metadata, data.samples)
+        sys_info = processor.process(metadata, data.samples, skip_failures=True)
 
         self.assertIsNotNone(sys_info.results.analyses)
         self.assertGreater(len(sys_info.results.overall), 0)
@@ -144,7 +146,7 @@ class KgLinkTailPredictionTest(unittest.TestCase):
 
         processor = get_processor(TaskType.kg_link_tail_prediction.value)
 
-        sys_info = processor.process(metadata, data.samples)
+        sys_info = processor.process(metadata, data.samples, skip_failures=True)
 
         self.assertIsNotNone(sys_info.results.analyses)
         self.assertGreater(len(sys_info.results.overall), 0)

--- a/integration_tests/kg_link_tail_prediction_test.py
+++ b/integration_tests/kg_link_tail_prediction_test.py
@@ -31,7 +31,7 @@ class KgLinkTailPredictionTest(unittest.TestCase):
         # Initialize the processor and perform the processing
         processor = get_processor(TaskType.kg_link_tail_prediction.value)
         sys_info = processor.process(
-            metadata={}, sys_output=data.samples, skip_failures=True
+            metadata={}, sys_output=data.samples, skip_failed_analyses=True
         )
 
         with tempfile.TemporaryDirectory() as tempdir:
@@ -60,7 +60,7 @@ class KgLinkTailPredictionTest(unittest.TestCase):
 
         processor = get_processor(TaskType.kg_link_tail_prediction.value)
 
-        sys_info = processor.process(metadata, data.samples, skip_failures=True)
+        sys_info = processor.process(metadata, data.samples, skip_failed_analyses=True)
 
         self.assertIsNotNone(sys_info.results.analyses)
         self.assertGreater(len(sys_info.results.overall), 0)
@@ -111,7 +111,7 @@ class KgLinkTailPredictionTest(unittest.TestCase):
         }
 
         processor = get_processor(TaskType.kg_link_tail_prediction.value)
-        sys_info = processor.process(metadata, data.samples, skip_failures=True)
+        sys_info = processor.process(metadata, data.samples, skip_failed_analyses=True)
 
         self.assertIsNotNone(sys_info.results.analyses)
         self.assertGreater(len(sys_info.results.overall), 0)
@@ -146,7 +146,7 @@ class KgLinkTailPredictionTest(unittest.TestCase):
 
         processor = get_processor(TaskType.kg_link_tail_prediction.value)
 
-        sys_info = processor.process(metadata, data.samples, skip_failures=True)
+        sys_info = processor.process(metadata, data.samples, skip_failed_analyses=True)
 
         self.assertIsNotNone(sys_info.results.analyses)
         self.assertGreater(len(sys_info.results.overall), 0)

--- a/integration_tests/machine_translation_test.py
+++ b/integration_tests/machine_translation_test.py
@@ -56,7 +56,7 @@ class MachineTranslationTest(unittest.TestCase):
 
         processor = get_processor(TaskType.machine_translation.value)
 
-        sys_info = processor.process(metadata, data)
+        sys_info = processor.process(metadata, data, skip_failures=True)
 
         self.assertIsNotNone(sys_info.results.analyses)
         self.assertGreater(len(sys_info.results.overall), 0)
@@ -105,7 +105,9 @@ class MachineTranslationTest(unittest.TestCase):
 
         processor = get_processor(TaskType.machine_translation.value)
 
-        sys_info = processor.process(dataclasses.asdict(data.metadata), data.samples)
+        sys_info = processor.process(
+            dataclasses.asdict(data.metadata), data.samples, skip_failures=True
+        )
         analysis_map = {x.name: x for x in sys_info.results.analyses if x is not None}
         self.assertTrue('num_capital_letters' in analysis_map)
 

--- a/integration_tests/machine_translation_test.py
+++ b/integration_tests/machine_translation_test.py
@@ -56,7 +56,7 @@ class MachineTranslationTest(unittest.TestCase):
 
         processor = get_processor(TaskType.machine_translation.value)
 
-        sys_info = processor.process(metadata, data, skip_failures=True)
+        sys_info = processor.process(metadata, data, skip_failed_analyses=True)
 
         self.assertIsNotNone(sys_info.results.analyses)
         self.assertGreater(len(sys_info.results.overall), 0)
@@ -106,7 +106,7 @@ class MachineTranslationTest(unittest.TestCase):
         processor = get_processor(TaskType.machine_translation.value)
 
         sys_info = processor.process(
-            dataclasses.asdict(data.metadata), data.samples, skip_failures=True
+            dataclasses.asdict(data.metadata), data.samples, skip_failed_analyses=True
         )
         analysis_map = {x.name: x for x in sys_info.results.analyses if x is not None}
         self.assertTrue('num_capital_letters' in analysis_map)

--- a/integration_tests/ner_test.py
+++ b/integration_tests/ner_test.py
@@ -41,7 +41,7 @@ class NERTest(unittest.TestCase):
             "metric_names": ["F1Score"],
         }
         processor = get_processor(TaskType.named_entity_recognition)
-        sys_info = processor.process(metadata, data)
+        sys_info = processor.process(metadata, data, skip_failures=True)
 
         self.assertIsNotNone(sys_info.results.analyses)
         self.assertGreater(len(sys_info.results.overall), 0)

--- a/integration_tests/ner_test.py
+++ b/integration_tests/ner_test.py
@@ -41,7 +41,7 @@ class NERTest(unittest.TestCase):
             "metric_names": ["F1Score"],
         }
         processor = get_processor(TaskType.named_entity_recognition)
-        sys_info = processor.process(metadata, data, skip_failures=True)
+        sys_info = processor.process(metadata, data, skip_failed_analyses=True)
 
         self.assertIsNotNone(sys_info.results.analyses)
         self.assertGreater(len(sys_info.results.overall), 0)

--- a/integration_tests/qa_open_domain_test.py
+++ b/integration_tests/qa_open_domain_test.py
@@ -27,5 +27,5 @@ class QAOpenDomainTest(unittest.TestCase):
             "metric_names": ["ExactMatchQA"],
         }
         processor = get_processor(TaskType.qa_open_domain.value)
-        sys_info = processor.process(metadata, data.samples, skip_failures=True)
+        sys_info = processor.process(metadata, data.samples, skip_failed_analyses=True)
         self.assertIsNotNone(sys_info.results.analyses)

--- a/integration_tests/qa_open_domain_test.py
+++ b/integration_tests/qa_open_domain_test.py
@@ -27,5 +27,5 @@ class QAOpenDomainTest(unittest.TestCase):
             "metric_names": ["ExactMatchQA"],
         }
         processor = get_processor(TaskType.qa_open_domain.value)
-        sys_info = processor.process(metadata, data.samples)
+        sys_info = processor.process(metadata, data.samples, skip_failures=True)
         self.assertIsNotNone(sys_info.results.analyses)

--- a/integration_tests/summarization_test.py
+++ b/integration_tests/summarization_test.py
@@ -52,7 +52,7 @@ class SummarizationTest(unittest.TestCase):
 
         processor = get_processor(TaskType.summarization.value)
 
-        sys_info = processor.process(metadata, data, skip_failures=True)
+        sys_info = processor.process(metadata, data, skip_failed_analyses=True)
 
         self.assertIsNotNone(sys_info.results.analyses)
         self.assertGreater(len(sys_info.results.overall), 0)

--- a/integration_tests/summarization_test.py
+++ b/integration_tests/summarization_test.py
@@ -52,7 +52,7 @@ class SummarizationTest(unittest.TestCase):
 
         processor = get_processor(TaskType.summarization.value)
 
-        sys_info = processor.process(metadata, data)
+        sys_info = processor.process(metadata, data, skip_failures=True)
 
         self.assertIsNotNone(sys_info.results.analyses)
         self.assertGreater(len(sys_info.results.overall), 0)

--- a/integration_tests/system_details_test.py
+++ b/integration_tests/system_details_test.py
@@ -40,7 +40,7 @@ class SysDetailsTest(unittest.TestCase):
         data = loader.load()
         processor = get_processor(TaskType.text_classification)
 
-        sys_info = processor.process(metadata, data, skip_failures=True)
+        sys_info = processor.process(metadata, data, skip_failed_analyses=True)
 
         self.assertIsNotNone(
             sys_info.system_details, {"learning_rate": 0.0001, "number_of_layers": 10}

--- a/integration_tests/system_details_test.py
+++ b/integration_tests/system_details_test.py
@@ -40,7 +40,7 @@ class SysDetailsTest(unittest.TestCase):
         data = loader.load()
         processor = get_processor(TaskType.text_classification)
 
-        sys_info = processor.process(metadata, data)
+        sys_info = processor.process(metadata, data, skip_failures=True)
 
         self.assertIsNotNone(
             sys_info.system_details, {"learning_rate": 0.0001, "number_of_layers": 10}

--- a/integration_tests/text_classification_test.py
+++ b/integration_tests/text_classification_test.py
@@ -94,7 +94,7 @@ class TextClassificationTest(unittest.TestCase):
         )
         data = loader.load()
         processor = get_processor(TaskType.text_classification)
-        sys_info = processor.process(metadata, data)
+        sys_info = processor.process(metadata, data, skip_failures=True)
 
         self.assertIsNotNone(sys_info.results.analyses)
         self.assertGreater(len(sys_info.results.overall), 0)

--- a/integration_tests/text_classification_test.py
+++ b/integration_tests/text_classification_test.py
@@ -94,7 +94,7 @@ class TextClassificationTest(unittest.TestCase):
         )
         data = loader.load()
         processor = get_processor(TaskType.text_classification)
-        sys_info = processor.process(metadata, data, skip_failures=True)
+        sys_info = processor.process(metadata, data, skip_failed_analyses=True)
 
         self.assertIsNotNone(sys_info.results.analyses)
         self.assertGreater(len(sys_info.results.overall), 0)

--- a/integration_tests/text_pair_classification_test.py
+++ b/integration_tests/text_pair_classification_test.py
@@ -52,7 +52,7 @@ class TextPairClassificationTest(unittest.TestCase):
         data = loader.load()
         processor = get_processor(TaskType.text_pair_classification)
 
-        sys_info = processor.process(metadata, data, skip_failures=True)
+        sys_info = processor.process(metadata, data, skip_failed_analyses=True)
 
         self.assertIsNotNone(sys_info.results.analyses)
         self.assertGreater(len(sys_info.results.overall), 0)

--- a/integration_tests/text_pair_classification_test.py
+++ b/integration_tests/text_pair_classification_test.py
@@ -52,7 +52,7 @@ class TextPairClassificationTest(unittest.TestCase):
         data = loader.load()
         processor = get_processor(TaskType.text_pair_classification)
 
-        sys_info = processor.process(metadata, data)
+        sys_info = processor.process(metadata, data, skip_failures=True)
 
         self.assertIsNotNone(sys_info.results.analyses)
         self.assertGreater(len(sys_info.results.overall), 0)

--- a/integration_tests/word_segmentation_test.py
+++ b/integration_tests/word_segmentation_test.py
@@ -32,7 +32,7 @@ class WordSegmentationTest(unittest.TestCase):
 
         processor = get_processor(TaskType.word_segmentation)
 
-        sys_info = processor.process(metadata, data)
+        sys_info = processor.process(metadata, data, skip_failures=True)
 
         self.assertIsNotNone(sys_info.results.analyses)
         self.assertGreater(len(sys_info.results.overall), 0)

--- a/integration_tests/word_segmentation_test.py
+++ b/integration_tests/word_segmentation_test.py
@@ -32,7 +32,7 @@ class WordSegmentationTest(unittest.TestCase):
 
         processor = get_processor(TaskType.word_segmentation)
 
-        sys_info = processor.process(metadata, data, skip_failures=True)
+        sys_info = processor.process(metadata, data, skip_failed_analyses=True)
 
         self.assertIsNotNone(sys_info.results.analyses)
         self.assertGreater(len(sys_info.results.overall), 0)


### PR DESCRIPTION
This PR adds ~~`skip_failures`~~ `skip_failed_analyses` flag to `Processor` and ~~`--skip-failures`~~ `--skip-failed-analyses` CLI option to provide a user-side control to choose whether all analyses should succeed or not. Each `Analysis` now returns just `AnalysisResult` or raise errors, and error handling is delegated to `Processor`.

This PR also contains several typing fixes encountered during applying this change.