### PR TITLE
Use TypeRegistry for MetricConfig's registry

### DIFF
--- a/explainaboard/explainaboard_main.py
+++ b/explainaboard/explainaboard_main.py
@@ -16,7 +16,7 @@ from explainaboard.loaders.file_loader import (
 )
 from explainaboard.metrics.eaas import EaaSMetricConfig
 from explainaboard.metrics.metric import MetricConfig
-from explainaboard.metrics.registry import get_metric_config_class
+from explainaboard.metrics.registry import metric_config_registry
 from explainaboard.utils.io_utils import text_writer
 from explainaboard.utils.logging import get_logger
 from explainaboard.utils.tensor_analysis import (
@@ -315,7 +315,7 @@ def get_metric_config_or_eaas(name: str) -> type[MetricConfig]:
         ValueError: `name` is not registered in neither the registry nor EaaS.
     """
     try:
-        return get_metric_config_class(name)
+        return metric_config_registry.get_type(name)
     except ValueError:
         if name in eaas.endpoint.EndpointConfig().valid_metrics:
             return EaaSMetricConfig

--- a/explainaboard/metrics/accuracy.py
+++ b/explainaboard/metrics/accuracy.py
@@ -11,11 +11,11 @@ from explainaboard.metrics.metric import (
     MetricStats,
     SimpleMetricStats,
 )
-from explainaboard.metrics.registry import register_metric_config
+from explainaboard.metrics.registry import metric_config_registry
 
 
 @dataclass
-@register_metric_config
+@metric_config_registry.register("AccuracyConfig")
 class AccuracyConfig(MetricConfig):
     def to_metric(self):
         return Accuracy(self)
@@ -41,7 +41,7 @@ class Accuracy(Metric):
 
 
 @dataclass
-@register_metric_config
+@metric_config_registry.register("CorrectCountConfig")
 class CorrectCountConfig(MetricConfig):
     def to_metric(self):
         return CorrectCount(self)
@@ -82,7 +82,7 @@ class CorrectCount(Accuracy):
 
 
 @dataclass
-@register_metric_config
+@metric_config_registry.register("SeqCorrectCountConfig")
 class SeqCorrectCountConfig(MetricConfig):
     def to_metric(self):
         return SeqCorrectCount(self)

--- a/explainaboard/metrics/continuous.py
+++ b/explainaboard/metrics/continuous.py
@@ -11,11 +11,11 @@ from explainaboard.metrics.metric import (
     MetricStats,
     SimpleMetricStats,
 )
-from explainaboard.metrics.registry import register_metric_config
+from explainaboard.metrics.registry import metric_config_registry
 
 
 @dataclass
-@register_metric_config
+@metric_config_registry.register("RootMeanSquaredErrorConfig")
 class RootMeanSquaredErrorConfig(MetricConfig):
     def to_metric(self):
         return RootMeanSquaredError(self)
@@ -43,7 +43,7 @@ class RootMeanSquaredError(Metric):
 
 
 @dataclass
-@register_metric_config
+@metric_config_registry.register("AbsoluteErrorConfig")
 class AbsoluteErrorConfig(MetricConfig):
     def to_metric(self):
         return AbsoluteError(self)

--- a/explainaboard/metrics/external_eval.py
+++ b/explainaboard/metrics/external_eval.py
@@ -13,7 +13,7 @@ from explainaboard.metrics.metric import (
     MetricStats,
     SimpleMetricStats,
 )
-from explainaboard.metrics.registry import register_metric_config
+from explainaboard.metrics.registry import metric_config_registry
 from explainaboard.utils.agreement import fleiss_kappa
 from explainaboard.utils.typing_utils import unwrap
 
@@ -31,7 +31,7 @@ class ExternalEvalResult(AuxiliaryMetricResult):
 
 
 @dataclass
-@register_metric_config
+@metric_config_registry.register("ExternalEvalConfig")
 class ExternalEvalConfig(MetricConfig):
     aspect: str = "fluency"
     n_annotators: int = 3

--- a/explainaboard/metrics/extractive_qa.py
+++ b/explainaboard/metrics/extractive_qa.py
@@ -13,7 +13,7 @@ from explainaboard.metrics.metric import (
     MetricStats,
     SimpleMetricStats,
 )
-from explainaboard.metrics.registry import register_metric_config
+from explainaboard.metrics.registry import metric_config_registry
 from explainaboard.utils.preprocessor import ExtractiveQAPreprocessor, Preprocessor
 from explainaboard.utils.typing_utils import unwrap_or
 
@@ -54,7 +54,7 @@ class ExtractiveQAMetric(Metric):
 
 
 @dataclass
-@register_metric_config
+@metric_config_registry.register("ExactMatchQAConfig")
 class ExactMatchQAConfig(MetricConfig):
     def to_metric(self):
         return ExactMatchQA(self)
@@ -72,7 +72,7 @@ class ExactMatchQA(ExtractiveQAMetric):
 
 
 @dataclass
-@register_metric_config
+@metric_config_registry.register("F1ScoreQAConfig")
 class F1ScoreQAConfig(MetricConfig):
     def to_metric(self):
         return F1ScoreQA(self)

--- a/explainaboard/metrics/f1_score.py
+++ b/explainaboard/metrics/f1_score.py
@@ -12,13 +12,13 @@ from explainaboard.metrics.metric import (
     MetricStats,
     SimpleMetricStats,
 )
-from explainaboard.metrics.registry import register_metric_config
+from explainaboard.metrics.registry import metric_config_registry
 from explainaboard.utils.span_utils import BIOSpanOps, BMESSpanOps, SpanOps
 from explainaboard.utils.typing_utils import unwrap_or
 
 
 @dataclass
-@register_metric_config
+@metric_config_registry.register("F1ScoreConfig")
 class F1ScoreConfig(MetricConfig):
     average: str = 'micro'
     separate_match: bool = False
@@ -119,7 +119,7 @@ class F1Score(Metric):
 
 
 @dataclass
-@register_metric_config
+@metric_config_registry.register("SeqF1ScoreConfig")
 class SeqF1ScoreConfig(F1ScoreConfig):
     tag_schema: str = 'bio'
 

--- a/explainaboard/metrics/log_prob.py
+++ b/explainaboard/metrics/log_prob.py
@@ -11,12 +11,12 @@ from explainaboard.metrics.metric import (
     MetricStats,
     SimpleMetricStats,
 )
-from explainaboard.metrics.registry import register_metric_config
+from explainaboard.metrics.registry import metric_config_registry
 from explainaboard.utils.typing_utils import unwrap_or
 
 
 @dataclass
-@register_metric_config
+@metric_config_registry.register("LogProbConfig")
 class LogProbConfig(MetricConfig):
     # If false, return log probability, if true return perplexity
     ppl: bool = False

--- a/explainaboard/metrics/nlg_meta_evaluation.py
+++ b/explainaboard/metrics/nlg_meta_evaluation.py
@@ -12,12 +12,12 @@ from explainaboard.metrics.metric import (
     MetricStats,
     SimpleMetricStats,
 )
-from explainaboard.metrics.registry import register_metric_config
+from explainaboard.metrics.registry import metric_config_registry
 from explainaboard.utils.typing_utils import narrow, unwrap_or
 
 
 @dataclass
-@register_metric_config
+@metric_config_registry.register("CorrelationConfig")
 class CorrelationConfig(MetricConfig):
     """
     Configuration for a correlation.
@@ -129,7 +129,7 @@ class CorrelationMetric(Metric):
 
 # TODO: (1) Make Segment/System level configurable (2) Document this function
 @dataclass
-@register_metric_config
+@metric_config_registry.register("KtauCorrelationConfig")
 class KtauCorrelationConfig(CorrelationConfig):
     """
     :param threshold: Following ‘Results of the WMT20 Metrics Shared Task
@@ -188,7 +188,7 @@ class KtauCorrelation(CorrelationMetric):
 
 
 @dataclass
-@register_metric_config
+@metric_config_registry.register("PearsonCorrelationConfig")
 class PearsonCorrelationConfig(CorrelationConfig):
     def to_metric(self):
         return PearsonCorrelation(self)

--- a/explainaboard/metrics/ranking.py
+++ b/explainaboard/metrics/ranking.py
@@ -11,12 +11,12 @@ from explainaboard.metrics.metric import (
     MetricStats,
     SimpleMetricStats,
 )
-from explainaboard.metrics.registry import register_metric_config
+from explainaboard.metrics.registry import metric_config_registry
 from explainaboard.utils.typing_utils import unwrap_or
 
 
 @dataclass
-@register_metric_config
+@metric_config_registry.register("HitsConfig")
 class HitsConfig(MetricConfig):
     hits_k: int = 5
 
@@ -53,7 +53,7 @@ class Hits(Metric):
 
 
 @dataclass
-@register_metric_config
+@metric_config_registry.register("MeanReciprocalRankConfig")
 class MeanReciprocalRankConfig(MetricConfig):
     def to_metric(self):
         return MeanReciprocalRank(self)
@@ -92,7 +92,7 @@ class MeanReciprocalRank(Metric):
 
 
 @dataclass
-@register_metric_config
+@metric_config_registry.register("MeanRankConfig")
 class MeanRankConfig(MetricConfig):
     def to_metric(self):
         return MeanRank(self)

--- a/explainaboard/metrics/registry.py
+++ b/explainaboard/metrics/registry.py
@@ -5,7 +5,6 @@ import dataclasses
 from explainaboard.metrics.metric import MetricConfig
 from explainaboard.serialization.registry import TypeRegistry
 
-
 metric_config_registry = TypeRegistry[MetricConfig]()
 
 

--- a/explainaboard/metrics/registry.py
+++ b/explainaboard/metrics/registry.py
@@ -1,49 +1,17 @@
 from __future__ import annotations
 
 import dataclasses
-from typing import TypeVar
 
 from explainaboard.metrics.metric import MetricConfig
-
-MetricConfigT = TypeVar("MetricConfigT", bound=MetricConfig)
-
-_metric_config_registry: dict[str, type[MetricConfig]] = {}
+from explainaboard.serialization.registry import TypeRegistry
 
 
-def register_metric_config(cls: type[MetricConfigT]) -> type[MetricConfigT]:
-    """Decorator function to register a MetricConfig class to the registry.
-
-    Args:
-        cls: A MetricConfig subclass.
-
-    Returns:
-        `cls` itself. The type information is preserved.
-    """
-    _metric_config_registry[cls.__name__] = cls
-    return cls
-
-
-def get_metric_config_class(name: str) -> type[MetricConfig]:
-    """Obtains a MetricConfig class associated to the given name.
-
-    Args:
-        name: MetricConfig name.
-
-    Returns:
-        MetricConfig subclass associated to `name`.
-
-    Raises:
-        ValueError: `name` is not associated.
-    """
-    config_cls = _metric_config_registry.get(name)
-    if config_cls is None:
-        raise ValueError(f'Invalid MetricConfig name: {name}')
-    return config_cls
+metric_config_registry = TypeRegistry[MetricConfig]()
 
 
 def metric_config_from_dict(dikt: dict):
     type = dikt.pop('cls_name')
-    config_cls = get_metric_config_class(type)
+    config_cls = metric_config_registry.get_type(type)
     field_names = set(f.name for f in dataclasses.fields(config_cls))
     return config_cls(
         **{k: config_cls.dict_conv(k, v) for k, v in dikt.items() if k in field_names}


### PR DESCRIPTION
This PR switches the implementation of the registry for `MetricConfig` from its own implementation to TypeRegistry based one.

Fixes #420.