### PR TITLE
Add test for explainaboard.metrics.registry.metric_config_from_dict

### DIFF
--- a/explainaboard/metrics/registry_test.py
+++ b/explainaboard/metrics/registry_test.py
@@ -1,0 +1,24 @@
+"""Tests for explainaboard.metrics.registry"""
+
+from dataclasses import dataclass
+import unittest
+
+from explainaboard.metrics.metric import MetricConfig
+from explainaboard.metrics.registry import (
+    metric_config_from_dict,
+    metric_config_registry,
+)
+
+
+@dataclass
+@metric_config_registry.register("FooConfig")
+class FooConfig(MetricConfig):
+    pass
+
+
+class RegistryTest(unittest.TestCase):
+    def test_metric_config_from_dict(self) -> None:
+        self.assertEqual(
+            metric_config_from_dict({"cls_name": "FooConfig", "name": "Foo"}),
+            FooConfig("Foo"),
+        )


### PR DESCRIPTION
This adds a unit test for `explainaboard.metrics.registry.metric_config_from_dict`. This is a preliminary change of #427.