### PR TITLE
Add initial tests for MetricConfig and its derived classes

### DIFF
--- a/explainaboard/metrics/accuracy_test.py
+++ b/explainaboard/metrics/accuracy_test.py
@@ -1,0 +1,35 @@
+"""Tests for explainaboard.metrics.accuracy"""
+
+from __future__ import annotations
+
+import unittest
+
+from explainaboard.metrics.accuracy import (
+    Accuracy,
+    AccuracyConfig,
+    CorrectCount,
+    CorrectCountConfig,
+    SeqCorrectCount,
+    SeqCorrectCountConfig,
+)
+
+
+class AccuracyConfigTest(unittest.TestCase):
+    def test_to_metric(self) -> None:
+        self.assertIsInstance(AccuracyConfig("Accuracy").to_metric(), Accuracy)
+
+
+class CorrectCountConfigTest(unittest.TestCase):
+    def test_to_metric(self) -> None:
+        self.assertIsInstance(
+            CorrectCountConfig("CorrectCount").to_metric(),
+            CorrectCount,
+        )
+
+
+class SeqCorrectCountConfigTest(unittest.TestCase):
+    def test_to_metric(self) -> None:
+        self.assertIsInstance(
+            SeqCorrectCountConfig("SeqCorrectCount").to_metric(),
+            SeqCorrectCount,
+        )

--- a/explainaboard/metrics/continuous_test.py
+++ b/explainaboard/metrics/continuous_test.py
@@ -1,0 +1,28 @@
+"""Tests for explainaboard.metrics.continuous"""
+
+from __future__ import annotations
+
+import unittest
+
+from explainaboard.metrics.continuous import (
+    AbsoluteError,
+    AbsoluteErrorConfig,
+    RootMeanSquaredError,
+    RootMeanSquaredErrorConfig,
+)
+
+
+class RootMeanSquaredErrorConfigTest(unittest.TestCase):
+    def test_to_metric(self) -> None:
+        self.assertIsInstance(
+            RootMeanSquaredErrorConfig("RootMeanSquaredError").to_metric(),
+            RootMeanSquaredError,
+        )
+
+
+class AbsoluteErrorConfigTest(unittest.TestCase):
+    def test_to_metric(self) -> None:
+        self.assertIsInstance(
+            AbsoluteErrorConfig("AbsoluteError").to_metric(),
+            AbsoluteError,
+        )

--- a/explainaboard/metrics/external_eval_test.py
+++ b/explainaboard/metrics/external_eval_test.py
@@ -1,0 +1,15 @@
+"""Tests for explainaboard.metrics.external_eval"""
+
+from __future__ import annotations
+
+import unittest
+
+from explainaboard.metrics.external_eval import ExternalEval, ExternalEvalConfig
+
+
+class ExternalEvalConfigTest(unittest.TestCase):
+    def test_to_metric(self) -> None:
+        self.assertIsInstance(
+            ExternalEvalConfig("ExternalEval").to_metric(),
+            ExternalEval,
+        )

--- a/explainaboard/metrics/extractive_qa_test.py
+++ b/explainaboard/metrics/extractive_qa_test.py
@@ -1,0 +1,28 @@
+"""Tests for explainaboard.metrics.extractive_qa"""
+
+from __future__ import annotations
+
+import unittest
+
+from explainaboard.metrics.extractive_qa import (
+    ExactMatchQA,
+    ExactMatchQAConfig,
+    F1ScoreQA,
+    F1ScoreQAConfig,
+)
+
+
+class ExactMatchQAConfigTest(unittest.TestCase):
+    def test_to_metric(self) -> None:
+        self.assertIsInstance(
+            ExactMatchQAConfig("ExactMatchQA").to_metric(),
+            ExactMatchQA,
+        )
+
+
+class F1ScoreQAConfigTest(unittest.TestCase):
+    def test_to_metric(self) -> None:
+        self.assertIsInstance(
+            F1ScoreQAConfig("F1ScoreQA").to_metric(),
+            F1ScoreQA,
+        )

--- a/explainaboard/metrics/f1_score_test.py
+++ b/explainaboard/metrics/f1_score_test.py
@@ -1,0 +1,28 @@
+"""Tests for explainaboard.metrics.f1_score"""
+
+from __future__ import annotations
+
+import unittest
+
+from explainaboard.metrics.f1_score import (
+    F1Score,
+    F1ScoreConfig,
+    SeqF1Score,
+    SeqF1ScoreConfig,
+)
+
+
+class F1ScoreConfigTest(unittest.TestCase):
+    def test_to_metric(self) -> None:
+        self.assertIsInstance(
+            F1ScoreConfig("F1Score").to_metric(),
+            F1Score,
+        )
+
+
+class SeqF1ScoreConfigTest(unittest.TestCase):
+    def test_to_metric(self) -> None:
+        self.assertIsInstance(
+            SeqF1ScoreConfig("SeqF1Score").to_metric(),
+            SeqF1Score,
+        )

--- a/explainaboard/metrics/log_prob_test.py
+++ b/explainaboard/metrics/log_prob_test.py
@@ -1,0 +1,12 @@
+"""Tests for explainaboard.metrics.log_prob"""
+
+from __future__ import annotations
+
+import unittest
+
+from explainaboard.metrics.log_prob import LogProb, LogProbConfig
+
+
+class LogProbConfigTest(unittest.TestCase):
+    def test_to_metric(self) -> None:
+        self.assertIsInstance(LogProbConfig("LogProb").to_metric(), LogProb)

--- a/explainaboard/metrics/metric_test.py
+++ b/explainaboard/metrics/metric_test.py
@@ -1,0 +1,13 @@
+"""Tests for explainaboard.metrics.metric"""
+
+from __future__ import annotations
+
+import unittest
+
+from explainaboard.metrics.metric import MetricConfig
+
+
+class MetricConfigTest(unittest.TestCase):
+    def test_to_metric(self) -> None:
+        with self.assertRaises(NotImplementedError):
+            MetricConfig("foo").to_metric()

--- a/explainaboard/metrics/nlg_meta_evaluation_test.py
+++ b/explainaboard/metrics/nlg_meta_evaluation_test.py
@@ -1,0 +1,35 @@
+"""Tests for explainaboard.metrics.nlg_meta_evaluation"""
+
+from __future__ import annotations
+
+import unittest
+
+from explainaboard.metrics.nlg_meta_evaluation import (
+    CorrelationConfig,
+    KtauCorrelation,
+    KtauCorrelationConfig,
+    PearsonCorrelation,
+    PearsonCorrelationConfig,
+)
+
+
+class CorrelationConfigTest(unittest.TestCase):
+    def test_to_metric(self) -> None:
+        with self.assertRaises(NotImplementedError):
+            CorrelationConfig("Correlation").to_metric()
+
+
+class KtauCorrelationConfigTest(unittest.TestCase):
+    def test_to_metric(self) -> None:
+        self.assertIsInstance(
+            KtauCorrelationConfig("KtauCorrelation").to_metric(),
+            KtauCorrelation,
+        )
+
+
+class PearsonCorrelationConfigTest(unittest.TestCase):
+    def test_to_metric(self) -> None:
+        self.assertIsInstance(
+            PearsonCorrelationConfig("PearsonCorrelation").to_metric(),
+            PearsonCorrelation,
+        )

--- a/explainaboard/metrics/ranking_test.py
+++ b/explainaboard/metrics/ranking_test.py
@@ -1,0 +1,32 @@
+"""Tests for explainaboard.metrics.ranking"""
+
+from __future__ import annotations
+
+import unittest
+
+from explainaboard.metrics.ranking import (
+    Hits,
+    HitsConfig,
+    MeanRank,
+    MeanRankConfig,
+    MeanReciprocalRank,
+    MeanReciprocalRankConfig,
+)
+
+
+class HitsConfigTest(unittest.TestCase):
+    def test_to_metric(self) -> None:
+        self.assertIsInstance(HitsConfig("Hits").to_metric(), Hits)
+
+
+class MeanReciprocalRankConfigTest(unittest.TestCase):
+    def test_to_metric(self) -> None:
+        self.assertIsInstance(
+            MeanReciprocalRankConfig("MeanReciprocalRank").to_metric(),
+            MeanReciprocalRank,
+        )
+
+
+class MeanRankConfigTest(unittest.TestCase):
+    def test_to_metric(self) -> None:
+        self.assertIsInstance(MeanRankConfig("MeanRank").to_metric(), MeanRank)


### PR DESCRIPTION
This PR adds initial tests for MetricConfig and its derived classes. This is a preliminary change of #427.