### PR TITLE
Split bucket interval

### DIFF
--- a/docs/example_scripts/test_kg.py
+++ b/docs/example_scripts/test_kg.py
@@ -57,11 +57,12 @@ for analyses in fine_grained_res:
             confidence_score_high = bucket_performance.confidence_score_high
 
             print("------------------------------------------------------")
+
+            bucket_name = unwrap(bucket_info.bucket_name)
+            print(f"feature_name:{buckets.name} bucket_name:{bucket_name}")
+
             print(
-                f"feature_name:{buckets.name} "
-                f"bucket_name:{bucket_info.bucket_interval}"
-            )
-            print(
+                "\n"
                 f"metric_name:{metric_name}\n"
                 f"value:{value}\n"
                 f"confidence_score_low:{confidence_score_low}\n"

--- a/explainaboard/analysis/analyses.py
+++ b/explainaboard/analysis/analyses.py
@@ -13,7 +13,7 @@ from explainaboard.analysis.performance import BucketPerformance, Performance
 from explainaboard.metrics.metric import Metric, MetricConfig, MetricStats
 from explainaboard.metrics.registry import metric_config_from_dict
 from explainaboard.utils.logging import get_logger
-from explainaboard.utils.typing_utils import unwrap_generator
+from explainaboard.utils.typing_utils import unwrap, unwrap_generator
 
 
 @dataclass
@@ -124,10 +124,15 @@ class BucketAnalysisResult(AnalysisResult):
         metric_names = [x.metric_name for x in self.bucket_performances[0].performances]
         for i, metric_name in enumerate(metric_names):
             get_logger('report').info(f"the information of #{self.name}#")
-            get_logger('report').info(f"bucket_interval\t{metric_name}\t#samples")
+            get_logger('report').info(f"bucket_name\t{metric_name}\t#samples")
             for bucket_perf in self.bucket_performances:
+                if bucket_perf.bucket_interval is not None:
+                    bucket_name = f"{unwrap(bucket_perf.bucket_interval)}"
+                else:
+                    bucket_name = unwrap(bucket_perf.bucket_name)
+
                 get_logger('report').info(
-                    f"{bucket_perf.bucket_interval}\t"
+                    f"{bucket_name}\t"
                     f"{bucket_perf.performances[i].value}\t"
                     f"{bucket_perf.n_samples}"
                 )
@@ -198,9 +203,10 @@ class BucketAnalysis(Analysis):
             subsampled_ids = self._subsample_analysis_cases(bucket_collection.samples)
 
             bucket_performance = BucketPerformance(
-                bucket_interval=bucket_collection.interval,
-                n_samples=len(bucket_collection.samples),
+                n_samples=float(len(bucket_collection.samples)),
                 bucket_samples=subsampled_ids,
+                bucket_interval=bucket_collection.interval,
+                bucket_name=bucket_collection.name,
             )
 
             for metric_func, metric_stat in zip(

--- a/explainaboard/analysis/bucketing.py
+++ b/explainaboard/analysis/bucketing.py
@@ -1,33 +1,40 @@
 from __future__ import annotations
 
-from typing import Any, TypeVar
+from collections.abc import Hashable, Iterable
+
+# List and Tuple is required for the first argument of narrow().
+from typing import Any, cast, List, Tuple
 
 import numpy as np
 
 from explainaboard.analysis.case import AnalysisCase, AnalysisCaseCollection
-from explainaboard.utils.typing_utils import unwrap
-
-T = TypeVar('T')
 
 _INFINITE_INTERVAL = (-1e10, 1e10)
 
 
-def find_key(dict_obj, x):
-    for k, v in dict_obj.items():
-        if len(k) == 1:
-            if x == k[0]:
-                return k
-        elif len(k) == 2 and x >= k[0] and x <= k[1]:  # Attention !!!
-            return k
+def find_range(
+    keys: Iterable[tuple[float, float]], x: float
+) -> tuple[float, float] | None:
+    """Finds the range that covers the given value.
+
+    Args:
+        keys: iterable of ranges.
+        x: target value.
+
+    Returns:
+        The range `k` in `keys` that satisfies `k[0] <= x <= k[1]`, or None if there are
+        no such range in `keys`.
+    """
+    return next(filter(lambda k: k[0] <= x <= k[1], keys))
 
 
 def continuous(
-    sample_features: list[tuple[AnalysisCase, T]],
+    sample_features: list[tuple[AnalysisCase, Any]],
     bucket_number: int = 4,
     bucket_setting: Any = None,
 ) -> list[AnalysisCaseCollection]:
     if len(sample_features) == 0:
-        return [AnalysisCaseCollection(_INFINITE_INTERVAL, [])]
+        return [AnalysisCaseCollection(samples=[], interval=_INFINITE_INTERVAL)]
     if bucket_setting is not None and len(bucket_setting) > 0:
         raise NotImplementedError('bucket_setting incompatible with continuous')
     # Bucketing different Attributes
@@ -38,7 +45,12 @@ def continuous(
     # Special case of one bucket
     if bucket_number == 1:
         max_val, min_val = conv(np.max(vals)), conv(np.min(vals))
-        return [AnalysisCaseCollection((min_val, max_val), list(range(len(cases))))]
+        return [
+            AnalysisCaseCollection(
+                samples=list(range(len(cases))),
+                interval=(min_val, max_val),
+            )
+        ]
 
     n_examps = len(vals)
     sorted_idxs = np.argsort(vals)
@@ -54,8 +66,8 @@ def continuous(
             if i >= cutoff_i:
                 bucket_collections.append(
                     AnalysisCaseCollection(
-                        (conv(start_val), conv(last_val)),
-                        [int(j) for j in sorted_idxs[start_i:i]],
+                        samples=[int(j) for j in sorted_idxs[start_i:i]],
+                        interval=(conv(start_val), conv(last_val)),
                     )
                 )
                 start_val = val
@@ -67,8 +79,8 @@ def continuous(
     # Return the last bucket
     bucket_collections.append(
         AnalysisCaseCollection(
-            (conv(start_val), max_val),
-            [int(j) for j in sorted_idxs[start_i:]],
+            samples=[int(j) for j in sorted_idxs[start_i:]],
+            interval=(conv(start_val), max_val),
         )
     )
 
@@ -76,7 +88,7 @@ def continuous(
 
 
 def discrete(
-    sample_features: list[tuple[AnalysisCase, T]],
+    sample_features: list[tuple[AnalysisCase, Any]],
     bucket_number: int = int(1e10),
     bucket_setting: Any = 1,
 ) -> list[AnalysisCaseCollection]:
@@ -95,7 +107,7 @@ def discrete(
         else:
             feat2idx[feat].append(idx)
     bucket_collections = [
-        AnalysisCaseCollection((feat,), idxs)
+        AnalysisCaseCollection(samples=idxs, name=feat)
         for feat, idxs in feat2idx.items()
         if len(idxs) >= bucket_setting
     ]
@@ -106,26 +118,37 @@ def discrete(
 
 
 def fixed(
-    sample_features: list[tuple[AnalysisCase, T]],
+    sample_features: list[tuple[AnalysisCase, Any]],
     bucket_number: int,
-    bucket_setting: list[tuple],
+    bucket_setting: Any,
 ) -> list[AnalysisCaseCollection]:
-    intervals = unwrap(bucket_setting)
-    bucket2idx: dict[tuple, list[int]] = {k: list() for k in intervals}
+    interval_or_names = cast(List[Hashable], bucket_setting)
+    if len(interval_or_names) == 0:
+        raise ValueError("Can not determine bucket keys.")
 
-    if isinstance(list(intervals)[0][0], str):  # discrete value, such as entity tags
-        for idx, (case, feat) in enumerate(sample_features):
-            if feat in bucket2idx:
-                bucket2idx[(feat,)].append(idx)
+    features = [x[1] for x in sample_features]
+
+    if isinstance(interval_or_names[0], str):
+        names = cast(List[str], interval_or_names)
+        name2idx: dict[str, list[int]] = {k: [] for k in names}
+        name_features = cast(List[str], features)
+
+        for idx, name in enumerate(name_features):
+            if name in names:
+                name2idx[name].append(idx)
+
+        return [AnalysisCaseCollection(samples=v, name=k) for k, v in name2idx.items()]
     else:
-        for idx, (case, feat) in enumerate(sample_features):
-            res_key = find_key(bucket2idx, feat)
-            if res_key is None:
-                continue
-            bucket2idx[res_key].append(idx)
+        intervals = cast(List[Tuple[float, float]], interval_or_names)
+        interval2idx: dict[tuple[float, float], list[int]] = {k: [] for k in intervals}
+        interval_features = cast(List[float], features)
 
-    bucket_collections = [
-        AnalysisCaseCollection((k,), v) for k, v in bucket2idx.items()
-    ]
+        for idx, interval in enumerate(interval_features):
+            key = find_range(intervals, interval)
+            if key is not None:
+                interval2idx[key].append(idx)
 
-    return bucket_collections
+        return [
+            AnalysisCaseCollection(samples=v, interval=k)
+            for k, v in interval2idx.items()
+        ]

--- a/explainaboard/analysis/bucketing.py
+++ b/explainaboard/analysis/bucketing.py
@@ -25,7 +25,10 @@ def find_range(
         The range `k` in `keys` that satisfies `k[0] <= x <= k[1]`, or None if there are
         no such range in `keys`.
     """
-    return next(filter(lambda k: k[0] <= x <= k[1], keys))
+    return next(
+        filter(lambda k: k is not None and k[0] <= x <= k[1], keys),
+        None,
+    )
 
 
 def continuous(

--- a/explainaboard/analysis/bucketing.py
+++ b/explainaboard/analysis/bucketing.py
@@ -25,10 +25,7 @@ def find_range(
         The range `k` in `keys` that satisfies `k[0] <= x <= k[1]`, or None if there are
         no such range in `keys`.
     """
-    return next(
-        filter(lambda k: k is not None and k[0] <= x <= k[1], keys),
-        None,
-    )
+    return next(filter(lambda k: k is not None and k[0] <= x <= k[1], keys), None)
 
 
 def continuous(

--- a/explainaboard/analysis/case.py
+++ b/explainaboard/analysis/case.py
@@ -82,12 +82,17 @@ class AnalysisCaseLabeledSpan(AnalysisCaseSpan):
 
 @dataclass
 class AnalysisCaseCollection:
-    # This tuple is either tuple[float,float] (for continuous values) or tuple[str] for
-    # discrete values
-    # TODO(gneubig): add actual type annotation to this effect. at the moment it's a
-    #    bit complicated due to the implementation of the bucketing functions
-    interval: tuple
     samples: list[int]
+    interval: tuple[float, float] | None = None
+    name: str | None = None
 
-    def __len__(self):
+    def __post_init__(self) -> None:
+        if self.interval is None and self.name is None:
+            raise ValueError("Either interval or name must have a value.")
+        if self.interval is not None and self.name is not None:
+            raise ValueError(
+                "Both interval and name must not have values at the same time."
+            )
+
+    def __len__(self) -> int:
         return len(self.samples)

--- a/explainaboard/analysis/case_test.py
+++ b/explainaboard/analysis/case_test.py
@@ -1,0 +1,25 @@
+"""Tests for explainaboard.analysis.case."""
+
+import unittest
+
+from explainaboard.analysis.case import AnalysisCaseCollection
+
+
+class AnalysisCaseCollectionTest(unittest.TestCase):
+    def test_values(self):
+        # These invocation does not raise anything.
+        case1 = AnalysisCaseCollection(samples=[1], interval=[1.0, 2.0])
+        self.assertEqual(case1.samples, [1])
+        self.assertEqual(case1.interval, [1.0, 2.0])
+        self.assertIsNone(case1.name)
+
+        case2 = AnalysisCaseCollection(samples=[1], name="test")
+        self.assertEqual(case2.samples, [1])
+        self.assertIsNone(case2.interval)
+        self.assertEqual(case2.name, "test")
+
+        with self.assertRaisesRegex(ValueError, r"^Either"):
+            AnalysisCaseCollection(samples=[1])
+
+        with self.assertRaisesRegex(ValueError, r"^Both"):
+            AnalysisCaseCollection(samples=[1], interval=[1.0, 2.0], name="test")

--- a/explainaboard/analysis/performance.py
+++ b/explainaboard/analysis/performance.py
@@ -8,10 +8,11 @@ from explainaboard.metrics.metric import AuxiliaryMetricResult
 
 @dataclass
 class BucketPerformance:
-    bucket_interval: tuple
     n_samples: float
     bucket_samples: list[int] = field(default_factory=list)
     performances: list[Performance] = field(default_factory=list)
+    bucket_interval: tuple[float, float] | None = None
+    bucket_name: str | None = None
 
     @classmethod
     def dict_conv(cls, k: str, v: dict):

--- a/explainaboard/meta_analyses/rank_flipping.py
+++ b/explainaboard/meta_analyses/rank_flipping.py
@@ -122,8 +122,8 @@ class RankFlippingMetaAnalysis:  # (can inherit from an abstract MetaAnalysis cl
         paired_score_examples = []
         for m1_bucket, m2_bucket in zip(model1_buckets, model2_buckets):
 
-            # bucket info (feature name, bucket interval, bucket size) should match
-            # exactly
+            # bucket info (feature name, bucket interval, bucket name, bucket size)
+            # should match exactly
             if m1_bucket['feature_name'] != m2_bucket['feature_name']:
                 raise ValueError(
                     f'feature name does not match:\n{m1_bucket} vs {m2_bucket}'
@@ -131,6 +131,10 @@ class RankFlippingMetaAnalysis:  # (can inherit from an abstract MetaAnalysis cl
             if m1_bucket['bucket_interval'] != m2_bucket['bucket_interval']:
                 raise ValueError(
                     f'bucket interval does not match:\n{m1_bucket} vs {m2_bucket}'
+                )
+            if m1_bucket['bucket_name'] != m2_bucket['bucket_name']:
+                raise ValueError(
+                    f'bucket name does not match:\n{m1_bucket} vs {m2_bucket}'
                 )
             if m1_bucket['bucket_size'] != m2_bucket['bucket_size']:
                 raise ValueError(
@@ -141,6 +145,7 @@ class RankFlippingMetaAnalysis:  # (can inherit from an abstract MetaAnalysis cl
             example = {
                 'feature_name': m1_bucket['feature_name'],
                 'bucket_interval': m1_bucket['bucket_interval'],
+                'bucket_name': m1_bucket['bucket_name'],
                 'bucket_size': m1_bucket['bucket_size'],
             }
             for feature in metadata['custom_features'].keys():

--- a/explainaboard/meta_analyses/ranking.py
+++ b/explainaboard/meta_analyses/ranking.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import itertools
-from typing import Union
+from typing import Any, Union
 
 import numpy as np
 import pandas as pd
@@ -112,9 +112,10 @@ class RankingMetaAnalysis:  # (can inherit from an abstract MetaAnalysis class)
             list(itertools.chain.from_iterable(unwrap(r.results.overall)))
             for r in self.model_reports
         ]
-        reference_info = {
+        reference_info: dict[str, Any] = {
             'feature_name': 'overall',
-            'bucket_interval': '',
+            'bucket_interval': None,
+            'bucket_name': '',
             'bucket_size': -1,
         }
         for feature_id, feature in enumerate(metadata['custom_features'].keys()):
@@ -164,13 +165,14 @@ class RankingMetaAnalysis:  # (can inherit from an abstract MetaAnalysis class)
             ]
             bucket_info = buckets_per_model[0]
             bucket_names.append(
-                f'{bucket_info["feature_name"]}_{bucket_info["bucket_interval"]}'
+                f'{bucket_info["feature_name"]}_{bucket_info["bucket_name"]}'
             )
 
             # calculate difference metrics
             example = {
                 'feature_name': bucket_info['feature_name'],
                 'bucket_interval': bucket_info['bucket_interval'],
+                'bucket_name': bucket_info['bucket_name'],
                 'bucket_size': bucket_info['bucket_size'],
             }
             for feature_id, feature in enumerate(metadata['custom_features'].keys()):

--- a/explainaboard/meta_analyses/utils.py
+++ b/explainaboard/meta_analyses/utils.py
@@ -32,6 +32,7 @@ def report_to_sysout(report: SysOutputInfo) -> list[dict]:
 
                 example_features['feature_name'] = feature_buckets.name
                 example_features['bucket_interval'] = bucket.bucket_interval
+                example_features['bucket_name'] = bucket.bucket_name
                 example_features['bucket_size'] = bucket.n_samples
                 example_features[perf.metric_name] = perf.value
                 # example_features[f'{perf.metric_name}_CI'] = \

--- a/explainaboard/processors/processor.py
+++ b/explainaboard/processors/processor.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import abc
-from typing import Any, cast, Optional
+from typing import Any, Optional
 
 from datalabs import aggregating, Dataset, DatasetDict, load_dataset
 from eaas.async_client import AsyncClient
@@ -406,13 +406,16 @@ class Processor(metaclass=abc.ABCMeta):
         for analysis_result in analysis_results:
             if not isinstance(analysis_result, BucketAnalysisResult):
                 continue
-            bucket_result = cast(
-                BucketAnalysisResult, analysis_result
-            ).bucket_performances
+            bucket_result = analysis_result.bucket_performances
 
             # based on alphabetical order of the bucket lower boundary; low to high
             if sort_by == 'key':
-                bucket_result.sort(key=lambda x: x.bucket_interval)
+                if bucket_result[0].bucket_interval is not None:
+                    # Sort by intervals.
+                    bucket_result.sort(key=lambda x: unwrap(x.bucket_interval))
+                else:
+                    # Sort by names.
+                    bucket_result.sort(key=lambda x: unwrap(x.bucket_name))
             # sort based on the value of the first perf value, whatever that may
             # be; high to low
             elif sort_by == 'performance_value':

--- a/explainaboard/visualizers/draw_charts.py
+++ b/explainaboard/visualizers/draw_charts.py
@@ -132,8 +132,10 @@ def plot_buckets(
     """
     feature_name = bucket_results[0].name
 
-    bucket0_ticklabels = [
-        x.bucket_name or render_interval_to_tick_label(unwrap(x.bucket_interval))
+    bucket0_ticklabels: list[str] = [
+        x.bucket_name
+        if x.bucket_name is not None
+        else render_interval_to_tick_label(unwrap(x.bucket_interval))
         for x in bucket_results[0].bucket_performances
     ]
     bucket0_names = [

--- a/explainaboard/visualizers/draw_charts.py
+++ b/explainaboard/visualizers/draw_charts.py
@@ -112,6 +112,15 @@ def plot_combo_counts(
         plt.savefig(out_file, format='png', bbox_inches='tight')
 
 
+def render_interval_to_tick_label(interval: tuple[float, float]) -> str:
+    """
+    Render a bucket interval (tuple of floats) to a tick label to display on the chart
+    :param interval: the input value range
+    :returns: a string-rendered tick label
+    """
+    return f'[{interval[0]:.2f},{interval[0]:.2f}]'
+
+
 def plot_buckets(
     bucket_results: list[BucketAnalysisResult], output_dir: str, sys_names: list[str]
 ) -> None:
@@ -124,7 +133,8 @@ def plot_buckets(
     feature_name = bucket_results[0].name
 
     bucket0_ticklabels = [
-        unwrap(x.bucket_name) for x in bucket_results[0].bucket_performances
+        x.bucket_name or render_interval_to_tick_label(unwrap(x.bucket_interval))
+        for x in bucket_results[0].bucket_performances
     ]
     bucket0_names = [
         x.metric_name for x in bucket_results[0].bucket_performances[0].performances

--- a/explainaboard/visualizers/draw_charts.py
+++ b/explainaboard/visualizers/draw_charts.py
@@ -120,8 +120,8 @@ def plot_buckets(
     """
     feature_name = bucket_results[0].name
 
-    bucket0_intervals = [
-        x.bucket_interval for x in bucket_results[0].bucket_performances
+    bucket0_ticklabels = [
+        unwrap(x.bucket_name) for x in bucket_results[0].bucket_performances
     ]
     bucket0_names = [
         x.metric_name for x in bucket_results[0].bucket_performances[0].performances
@@ -154,7 +154,7 @@ def plot_buckets(
             errs=y_errs,
             title=None,
             xlabel=feature_name,
-            xticklabels=bucket0_intervals,
+            xticklabels=bucket0_ticklabels,
             ylabel=metric_name,
         )
 

--- a/integration_tests/kg_link_tail_prediction_test.py
+++ b/integration_tests/kg_link_tail_prediction_test.py
@@ -5,6 +5,7 @@ import unittest
 from integration_tests.utils import test_artifacts_path
 
 from explainaboard import FileType, get_processor, TaskType
+from explainaboard.analysis.analyses import BucketAnalysisResult
 from explainaboard.loaders.file_loader import FileLoaderMetadata
 from explainaboard.loaders.loader_registry import get_loader_class
 from explainaboard.metrics.ranking import (
@@ -12,6 +13,7 @@ from explainaboard.metrics.ranking import (
     MeanRankConfig,
     MeanReciprocalRankConfig,
 )
+from explainaboard.utils.typing_utils import narrow, unwrap
 
 
 class KgLinkTailPredictionTest(unittest.TestCase):
@@ -115,7 +117,9 @@ class KgLinkTailPredictionTest(unittest.TestCase):
         self.assertGreater(len(sys_info.results.overall), 0)
 
         analysis_map = {x.name: x for x in sys_info.results.analyses if x is not None}
-        symmetry_performances = analysis_map['symmetry'].bucket_performances
+        symmetry_performances = narrow(
+            BucketAnalysisResult, analysis_map['symmetry']
+        ).bucket_performances
         if len(symmetry_performances) <= 1:  # can't sort if only 1 item
             return
         for i in range(len(symmetry_performances) - 1):
@@ -150,10 +154,12 @@ class KgLinkTailPredictionTest(unittest.TestCase):
         self.assertGreater(len(sys_info.results.overall), 0)
 
         analysis_map = {x.name: x for x in sys_info.results.analyses if x is not None}
-        symmetry_performances = analysis_map['symmetry'].bucket_performances
+        symmetry_performances = narrow(
+            BucketAnalysisResult, analysis_map['symmetry']
+        ).bucket_performances
         if len(symmetry_performances) <= 1:  # can't sort if only 1 item
             return
         for i in range(len(symmetry_performances) - 1):
-            first_item = symmetry_performances[i].bucket_interval
-            second_item = symmetry_performances[i + 1].bucket_interval
+            first_item = unwrap(symmetry_performances[i].bucket_name)
+            second_item = unwrap(symmetry_performances[i + 1].bucket_name)
             self.assertGreater(second_item, first_item)

--- a/integration_tests/ner_test.py
+++ b/integration_tests/ner_test.py
@@ -10,6 +10,7 @@ from explainaboard.analysis.analyses import BucketAnalysisResult
 from explainaboard.loaders.file_loader import DatalabLoaderOption
 from explainaboard.loaders.loader_registry import get_loader_class
 from explainaboard.utils import cache_api
+from explainaboard.utils.typing_utils import unwrap
 
 
 class NERTest(unittest.TestCase):
@@ -94,14 +95,15 @@ class NERTest(unittest.TestCase):
         # 3. Unittest: test detailed bucket information: bucket interval
         # [0.007462686567164179,0.9565217391304348]
         second_bucket = span_econ_analysis.bucket_performances[1]
+        second_bucket_interval = unwrap(second_bucket.bucket_interval)
         self.assertAlmostEqual(
-            second_bucket.bucket_interval[0],
+            second_bucket_interval[0],
             0.007462686567164179,
             4,
             "almost equal",
         )
         self.assertAlmostEqual(
-            second_bucket.bucket_interval[1],
+            second_bucket_interval[1],
             0.8571428571428571,
             4,
             "almost equal",
@@ -118,7 +120,7 @@ class NERTest(unittest.TestCase):
         for bucket_vals in sys_info.results.analyses:
             if not isinstance(bucket_vals, BucketAnalysisResult):
                 continue
-            for bucket in cast(BucketAnalysisResult, bucket_vals).bucket_performances:
+            for bucket in bucket_vals.bucket_performances:
                 for performance in bucket.performances:
                     if performance.confidence_score_low is not None:
                         self.assertGreaterEqual(


### PR DESCRIPTION
This pull request splits bucket intervals into two variables: interval ([float, float]) and name (str).

Fixes #431.