### PR TITLE
Use Serializable for Tokenizers

### DIFF
--- a/explainaboard/info.py
+++ b/explainaboard/info.py
@@ -15,7 +15,7 @@ from explainaboard.analysis.result import Result
 from explainaboard.metrics.metric import MetricStats
 from explainaboard.utils.logging import get_logger
 from explainaboard.utils.serialization import general_to_dict
-from explainaboard.utils.tokenizer import Tokenizer
+from explainaboard.utils.tokenizer import get_tokenizer_serializer, Tokenizer
 
 logger = get_logger(__name__)
 
@@ -208,7 +208,7 @@ class SysOutputInfo:
         if k == 'results':
             return Result.from_dict(v)
         elif k.endswith('tokenizer'):
-            return Tokenizer.from_dict(v)
+            return get_tokenizer_serializer().deserialize(v)
         elif k == 'analysis_levels':
             return [AnalysisLevel.from_dict(v1) for v1 in v]
         elif k == 'analyses':

--- a/explainaboard/utils/serialization.py
+++ b/explainaboard/utils/serialization.py
@@ -1,11 +1,17 @@
+"""DEPRECATED: do not use this module for new implementations."""
+
 import copy
 import dataclasses
 from inspect import getsource
-from typing import Callable
+
+from explainaboard.utils.tokenizer import get_tokenizer_serializer, Tokenizer
 
 
 def general_to_dict(data):
-    if hasattr(data, 'to_dict'):
+    """DEPRECATED: do not use this function for new implementations."""
+    if isinstance(data, Tokenizer):
+        return get_tokenizer_serializer().serialize(data)
+    elif hasattr(data, 'to_dict'):
         return general_to_dict(getattr(data, 'to_dict')())
     elif dataclasses.is_dataclass(data):
         return dataclasses.asdict(data, dict_factory=explainaboard_dict_factory)
@@ -14,14 +20,15 @@ def general_to_dict(data):
     elif isinstance(data, list):
         return [general_to_dict(v) for v in data]
     # sanitize functions
-    elif isinstance(data, Callable):
+    elif callable(data):
         return getsource(data)
     else:
         return copy.deepcopy(data)
 
 
 def explainaboard_dict_factory(data):
-    """
+    """DEPRECATED: do not use this function for new implementations.
+
     This can be used to serialize data through the following command:
     serialized_data = dataclasses.asdict(data, dict_factory=explainaboard_dict_factory)
     """

--- a/explainaboard/utils/tokenizer_test.py
+++ b/explainaboard/utils/tokenizer_test.py
@@ -1,0 +1,109 @@
+"""Tests for explainaboard.utils.tokenizer."""
+
+import unittest
+
+from explainaboard.utils.tokenizer import (
+    get_tokenizer_serializer,
+    MLQAMixTokenizer,
+    SacreBleuTokenizer,
+    SingleSpaceTokenizer,
+    TokenSeq,
+)
+
+
+class TokenSeqTest(unittest.TestCase):
+    def test_data(self) -> None:
+        seq = TokenSeq(["foo", "bar"], [0, 4])
+        self.assertEqual(seq.strs, ["foo", "bar"])
+        self.assertEqual(seq.positions, [0, 4])
+
+    def test_sequence_interface(self) -> None:
+        seq = TokenSeq(["foo", "bar"], [0, 4])
+        self.assertEqual(seq[0], "foo")
+        self.assertEqual(seq[:1], ["foo"])
+        self.assertEqual(len(seq), 2)
+
+        it = iter(seq)
+        self.assertEqual(next(it), "foo")
+        self.assertEqual(next(it), "bar")
+        with self.assertRaises(StopIteration):
+            next(it)
+
+    def test_invalid_data(self) -> None:
+        with self.assertRaisesRegex(ValueError, r"^strs and positions"):
+            TokenSeq(["foo"], [0, 4])
+
+    def test_from_orig_and_tokens(self) -> None:
+        seq = TokenSeq.from_orig_and_tokens("foo bar", ["foo", "bar"])
+        self.assertEqual(seq.strs, ["foo", "bar"])
+        self.assertEqual(seq.positions, [0, 4])
+
+    def test_from_orig_and_tokens_invalid(self) -> None:
+        with self.assertRaisesRegex(ValueError, r"^Could not find"):
+            TokenSeq.from_orig_and_tokens("foo bar", ["baz"])
+
+
+class TokenizerSerializerTest(unittest.TestCase):
+    def test_serialize(self) -> None:
+        serializer = get_tokenizer_serializer()
+        self.assertEqual(
+            serializer.serialize(SingleSpaceTokenizer()),
+            {"cls_name": "SingleSpaceTokenizer"},
+        )
+        self.assertEqual(
+            serializer.serialize(SacreBleuTokenizer()),
+            {"cls_name": "SacreBleuTokenizer", "variety": "intl"},
+        )
+        self.assertEqual(
+            serializer.serialize(MLQAMixTokenizer()),
+            {"cls_name": "MLQAMixTokenizer"},
+        )
+
+    def test_deserialize(self) -> None:
+        serializer = get_tokenizer_serializer()
+        self.assertIsInstance(
+            serializer.deserialize({"cls_name": "SingleSpaceTokenizer"}),
+            SingleSpaceTokenizer,
+        )
+        self.assertIsInstance(
+            serializer.deserialize(
+                {"cls_name": "SacreBleuTokenizer", "variety": "intl"}
+            ),
+            SacreBleuTokenizer,
+        )
+        self.assertIsInstance(
+            serializer.deserialize({"cls_name": "MLQAMixTokenizer"}),
+            MLQAMixTokenizer,
+        )
+
+
+class TokenizersTest(unittest.TestCase):
+    def test_single_space_tokenizer(self):
+        src = 'this,  is an example '
+        gold_toks = ['this,', '', 'is', 'an', 'example', '']
+        gold_poss = [0, 6, 7, 10, 13, 21]
+        tokenizer = SingleSpaceTokenizer()
+        out_tokseq = tokenizer(src)
+        self.assertEqual(gold_toks, out_tokseq.strs)
+        self.assertEqual(gold_poss, out_tokseq.positions)
+
+    def test_sacrebleu_intl_tokenizer(self):
+        src = '"this," she   said, is an example.'
+        gold_toks = [
+            '"',
+            'this',
+            ',',
+            '"',
+            'she',
+            'said',
+            ',',
+            'is',
+            'an',
+            'example',
+            '.',
+        ]
+        gold_poss = [0, 1, 5, 6, 8, 14, 18, 20, 23, 26, 33]
+        tokenizer = SacreBleuTokenizer()
+        out_tokseq = tokenizer(src)
+        self.assertEqual(gold_toks, out_tokseq.strs)
+        self.assertEqual(gold_poss, out_tokseq.positions)


### PR DESCRIPTION
This pull request implements `Serializable` interface to `Tokenizer`s and removes existing code that directly treats dicts.

This PR also fixes some typing/interface issues around `tokenizer.py` encountered during applying this change, and moved code in `integration_tests/tokenizers_test.py` to `explainaboard/utils/tokenizer_test.py` because it is actually unit tests.