### PR TITLE
Refactor dtype of Value feature

### DIFF
--- a/docs/add_new_features.md
+++ b/docs/add_new_features.md
@@ -34,12 +34,12 @@ class TextClassificationProcessor(Processor):
         # ---- Features ----
         features: dict[str, FeatureType] = {
             "chars_per_word": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="character count divided by token count",
                 func=lambda info, x, c: float(len(x['text'])) / count_tokens(info, x['text']),
             ),
             "contains_question": feature.Value(
-                dtype="string",
+                dtype=feature.DataType.STRING,
                 description="",
                 func=lambda info, x, c: "yes" if "?" in x['text'] else "no",
             ),

--- a/explainaboard/analysis/feature.py
+++ b/explainaboard/analysis/feature.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from abc import ABCMeta, abstractmethod
 from collections.abc import Callable
+from enum import Enum
 from typing import Any, final, TypeVar
 
 from explainaboard.serialization.registry import TypeRegistry
@@ -43,7 +44,6 @@ class FeatureType(Serializable, metaclass=ABCMeta):
     def __init__(
         self,
         *,
-        dtype: str | None = None,
         description: str | None = None,
         func: Callable[..., Any] | None = None,
         require_training_set: bool | None = None,
@@ -51,12 +51,10 @@ class FeatureType(Serializable, metaclass=ABCMeta):
         """Initializes FeatureType object.
 
         Args:
-            dtype: Data type specifier.
             description: Description of this feature.
             func: Function to calculate this feature from other features.
             require_training_set: Whether this feature relies on the training samples.
         """
-        self._dtype = dtype
         self._description = description
         self._func = func
         self._require_training_set = (
@@ -87,32 +85,30 @@ class FeatureType(Serializable, metaclass=ABCMeta):
             True if `other` has the same base members with `self`, False otherwise.
         """
         return (
-            self._dtype == other._dtype
-            and self._description == other._description
+            self._description == other._description
             and self._func is other._func
             and self._require_training_set == other._require_training_set
         )
 
     @final
     @property
-    def dtype(self) -> str | None:
-        return self._dtype
-
-    @final
-    @property
     def description(self) -> str | None:
+        """Returns the description of this feature."""
         return self._description
 
     @final
     @property
     def func(self) -> Callable[..., Any] | None:
+        """Returns the callable to calculate this feature."""
         return self._func
 
     @final
     @property
     def require_training_set(self) -> bool:
+        """Returns whether this feature requires training set or not."""
         return self._require_training_set
 
+    @final
     def _serialize_base(self) -> dict[str, SerializableData]:
         """Helper to serialize base members.
 
@@ -128,7 +124,6 @@ class FeatureType(Serializable, metaclass=ABCMeta):
             get_logger(__name__).warning("`func` member is not serializable.")
 
         return {
-            "dtype": self._dtype,
             "description": self._description,
             "require_training_set": self._require_training_set,
         }
@@ -154,7 +149,6 @@ class Sequence(FeatureType):
             feature: Feature type of elements.
         """
         super().__init__(
-            dtype="list",
             description=description,
             func=func,
             require_training_set=require_training_set,
@@ -171,6 +165,7 @@ class Sequence(FeatureType):
 
     @property
     def feature(self) -> FeatureType:
+        """Returns the element type of this sequence."""
         return self._feature
 
     def serialize(self) -> dict[str, SerializableData]:
@@ -211,7 +206,6 @@ class Dict(FeatureType):
             feature: Definitions of member types.
         """
         super().__init__(
-            dtype="dict",
             description=description,
             func=func,
             require_training_set=require_training_set,
@@ -228,6 +222,7 @@ class Dict(FeatureType):
 
     @property
     def feature(self) -> dict[str, FeatureType]:
+        """Returns the types of underlying members in this dict."""
         return self._feature
 
     def serialize(self) -> dict[str, SerializableData]:
@@ -253,13 +248,27 @@ class Dict(FeatureType):
         )
 
 
+# TODO(odashi): Follow well-known schema to define this struct, e.g., JSON Schema.
+@final
+class DataType(Enum):
+    """Data types for Value FeatureType."""
+
+    INT = "int"
+    FLOAT = "float"
+    STRING = "string"
+
+
 @final
 @_feature_type_registry.register("Value")
 class Value(FeatureType):
+    _dtype: DataType
+    _max_value: int | float | None
+    _min_value: int | float | None
+
     def __init__(
         self,
         *,
-        dtype: str | None = None,
+        dtype: DataType,
         description: str | None = None,
         func: Callable[..., Any] | None = None,
         require_training_set: bool | None = None,
@@ -269,50 +278,81 @@ class Value(FeatureType):
         """Initializes Value object.
 
         Args:
-            dtype: See FeatureType.__init__.
+            dtype: Data type of this value.
             description: See FeatureType.__init__.
             func: See FeatureType.__init__.
             require_training_set: See FeatureType.__init__.
             max_value: The maximum value (inclusive) of values with int/float dtype.
             min_value: The minimum value (inclusive) of values with int/float dtype.
         """
-        # Fix inferred types.
-        if dtype == "double":
-            dtype = "float64"
-        elif dtype == "float":
-            dtype = "float32"
-
         super().__init__(
-            dtype=dtype,
             description=description,
             func=func,
             require_training_set=require_training_set,
         )
-        self._max_value = max_value
-        self._min_value = min_value
+
+        self._dtype = dtype
+
+        if max_value is not None and min_value is not None and max_value < min_value:
+            raise ValueError("max_value must be greater than or equal to min_value.")
+
+        if self._dtype == DataType.INT:
+            if isinstance(max_value, float):
+                raise ValueError("max_value must be an int when the dtype is integer.")
+            if isinstance(min_value, float):
+                raise ValueError("min_value must be an int when the dtype is integer.")
+            self._max_value = max_value
+            self._min_value = min_value
+        elif self._dtype == DataType.FLOAT:
+            self._max_value = float(max_value) if max_value is not None else None
+            self._min_value = float(min_value) if min_value is not None else None
+        else:
+            if max_value is not None:
+                raise ValueError(
+                    "max_value must not be specified when dtype is not a numeric type."
+                )
+            if min_value is not None:
+                raise ValueError(
+                    "min_value must not be specified when dtype is not a numeric type."
+                )
+            self._max_value = max_value
+            self._min_value = min_value
 
     def __eq__(self, other: object) -> bool:
         """See FeatureType.__eq__."""
         return (
             isinstance(other, Value)
             and self._eq_base(other)
+            and self._dtype == other._dtype
             and self._max_value == other._max_value
             and self._min_value == other._min_value
         )
 
     @property
+    def dtype(self) -> DataType:
+        """Returns the data type of this value."""
+        return self._dtype
+
+    @property
     def max_value(self) -> int | float | None:
+        """Returns the maximum value (inclusive) of this value."""
         return self._max_value
 
     @property
     def min_value(self) -> int | float | None:
+        """Returns the minimum value (inclusive) of this value."""
         return self._min_value
 
     def serialize(self) -> dict[str, SerializableData]:
         """See Serializable.serialize."""
         data = self._serialize_base()
-        data["max_value"] = self._max_value
-        data["min_value"] = self._min_value
+        data.update(
+            {
+                "dtype": str(self._dtype.value),
+                "max_value": self._max_value,
+                "min_value": self._min_value,
+            }
+        )
         return data
 
     @classmethod
@@ -320,17 +360,14 @@ class Value(FeatureType):
         """See Serializable.deserialize."""
         max_value = data.get("max_value")
         min_value = data.get("min_value")
+
         if max_value is not None and not isinstance(max_value, (int, float)):
-            raise ValueError(
-                f"Unexpected type of `max_value`: {type(max_value).__name__}"
-            )
+            raise ValueError("max_value must be either int, float, or None.")
         if min_value is not None and not isinstance(min_value, (int, float)):
-            raise ValueError(
-                f"Unexpected type of `min_value`: {type(min_value).__name__}"
-            )
+            raise ValueError("min_value must be either int, float, or None.")
 
         return cls(
-            dtype=_get_value(str, data, "dtype"),
+            dtype=DataType(data["dtype"]),
             description=_get_value(str, data, "description"),
             func=None,
             require_training_set=_get_value(bool, data, "require_training_set"),

--- a/explainaboard/analysis/feature_test.py
+++ b/explainaboard/analysis/feature_test.py
@@ -3,6 +3,7 @@
 import unittest
 
 from explainaboard.analysis.feature import (
+    DataType,
     Dict,
     get_feature_type_serializer,
     Sequence,
@@ -16,27 +17,25 @@ class SequenceTest(unittest.TestCase):
             return 123
 
         feature = Sequence(
-            feature=Value(dtype="string"),
+            feature=Value(dtype=DataType.STRING),
             description="test",
             func=dummy_fn,
             require_training_set=True,
         )
-        self.assertEqual(feature.dtype, "list")
         self.assertEqual(feature.description, "test")
         self.assertIs(feature.func, dummy_fn)
         self.assertEqual(feature.require_training_set, True)
-        self.assertEqual(feature.feature, Value(dtype="string"))
+        self.assertEqual(feature.feature, Value(dtype=DataType.STRING))
 
     def test_serialize(self) -> None:
         serializer = get_feature_type_serializer()
         feature = Sequence(
-            feature=Value(dtype="string"),
+            feature=Value(dtype=DataType.STRING),
             description="test",
             require_training_set=True,
         )
         serialized = {
             "cls_name": "Sequence",
-            "dtype": "list",
             "description": "test",
             "require_training_set": True,
             "feature": {
@@ -53,13 +52,12 @@ class SequenceTest(unittest.TestCase):
     def test_deserialize(self) -> None:
         serializer = get_feature_type_serializer()
         feature = Sequence(
-            feature=Value(dtype="string"),
+            feature=Value(dtype=DataType.STRING),
             description="test",
             require_training_set=True,
         )
         serialized = {
             "cls_name": "Sequence",
-            "dtype": "list",
             "description": "test",
             "require_training_set": True,
             "feature": {
@@ -80,27 +78,25 @@ class DictTest(unittest.TestCase):
             return 123
 
         feature = Dict(
-            feature={"foo": Value(dtype="string")},
+            feature={"foo": Value(dtype=DataType.STRING)},
             description="test",
             func=dummy_fn,
             require_training_set=True,
         )
-        self.assertEqual(feature.dtype, "dict")
         self.assertEqual(feature.description, "test")
         self.assertIs(feature.func, dummy_fn)
         self.assertEqual(feature.require_training_set, True)
-        self.assertEqual(feature.feature, {"foo": Value(dtype="string")})
+        self.assertEqual(feature.feature, {"foo": Value(dtype=DataType.STRING)})
 
     def test_serialize(self) -> None:
         serializer = get_feature_type_serializer()
         feature = Dict(
-            feature={"foo": Value(dtype="string")},
+            feature={"foo": Value(dtype=DataType.STRING)},
             description="test",
             require_training_set=True,
         )
         serialized = {
             "cls_name": "Dict",
-            "dtype": "dict",
             "description": "test",
             "require_training_set": True,
             "feature": {
@@ -119,13 +115,12 @@ class DictTest(unittest.TestCase):
     def test_deserialize(self) -> None:
         serializer = get_feature_type_serializer()
         feature = Dict(
-            feature={"foo": Value(dtype="string")},
+            feature={"foo": Value(dtype=DataType.STRING)},
             description="test",
             require_training_set=True,
         )
         serialized = {
             "cls_name": "Dict",
-            "dtype": "dict",
             "description": "test",
             "require_training_set": True,
             "feature": {
@@ -148,24 +143,36 @@ class ValueTest(unittest.TestCase):
             return 123
 
         feature = Value(
-            dtype="string",
+            dtype=DataType.INT,
             description="test",
             func=dummy_fn,
             require_training_set=True,
             max_value=123,
             min_value=45,
         )
-        self.assertEqual(feature.dtype, "string")
+        self.assertEqual(feature.dtype, DataType.INT)
         self.assertEqual(feature.description, "test")
         self.assertIs(feature.func, dummy_fn)
         self.assertEqual(feature.require_training_set, True)
         self.assertEqual(feature.max_value, 123)
         self.assertEqual(feature.min_value, 45)
 
+    def test_invalid_minmax(self) -> None:
+        with self.assertRaisesRegex(ValueError, r"max_value must be greater"):
+            Value(dtype=DataType.FLOAT, max_value=1.0, min_value=1.0001)
+        with self.assertRaisesRegex(ValueError, r"max_value must be an int"):
+            Value(dtype=DataType.INT, max_value=1.0)
+        with self.assertRaisesRegex(ValueError, r"min_value must be an int"):
+            Value(dtype=DataType.INT, min_value=1.0)
+        with self.assertRaisesRegex(ValueError, r"max_value must not be specified"):
+            Value(dtype=DataType.STRING, max_value=1.0)
+        with self.assertRaisesRegex(ValueError, r"min_value must not be specified"):
+            Value(dtype=DataType.STRING, min_value=1.0)
+
     def test_serialize(self) -> None:
         serializer = get_feature_type_serializer()
         feature = Value(
-            dtype="string",
+            dtype=DataType.INT,
             description="test",
             require_training_set=True,
             max_value=123,
@@ -173,7 +180,7 @@ class ValueTest(unittest.TestCase):
         )
         serialized = {
             "cls_name": "Value",
-            "dtype": "string",
+            "dtype": "int",
             "max_value": 123,
             "min_value": 45,
             "description": "test",
@@ -184,7 +191,7 @@ class ValueTest(unittest.TestCase):
     def test_deserialize(self) -> None:
         serializer = get_feature_type_serializer()
         feature = Value(
-            dtype="string",
+            dtype=DataType.INT,
             description="test",
             require_training_set=True,
             max_value=123,
@@ -192,7 +199,7 @@ class ValueTest(unittest.TestCase):
         )
         serialized = {
             "cls_name": "Value",
-            "dtype": "string",
+            "dtype": "int",
             "max_value": 123,
             "min_value": 45,
             "description": "test",

--- a/explainaboard/processors/argument_pair_extraction.py
+++ b/explainaboard/processors/argument_pair_extraction.py
@@ -56,16 +56,22 @@ class ArgumentPairExtractionProcessor(Processor):
 
     def default_analysis_levels(self) -> list[AnalysisLevel]:
         features = {
-            "sentences": feature.Sequence(feature=feature.Value(dtype="string")),
-            "true_tags": feature.Sequence(feature=feature.Value(dtype="string")),
-            "pred_tags": feature.Sequence(feature=feature.Value(dtype="string")),
+            "sentences": feature.Sequence(
+                feature=feature.Value(dtype=feature.DataType.STRING)
+            ),
+            "true_tags": feature.Sequence(
+                feature=feature.Value(dtype=feature.DataType.STRING)
+            ),
+            "pred_tags": feature.Sequence(
+                feature=feature.Value(dtype=feature.DataType.STRING)
+            ),
             "num_sent": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="the number of sentences",
                 func=lambda info, x, c: len(x['sentences']),
             ),
             "text_length": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="the length of all sentences",
                 func=lambda info, x, c: len(" ".join(x['sentences'])),
             ),
@@ -73,37 +79,37 @@ class ArgumentPairExtractionProcessor(Processor):
 
         block_features: dict[str, FeatureType] = {
             "text": feature.Value(
-                dtype="string",
+                dtype=feature.DataType.STRING,
                 description="text of the block",
                 func=lambda info, x, c: c.text,
             ),
             "n_review_sentences": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="the number of review sentence",
                 func=lambda info, x, c: c.block_review_sentences,
             ),
             "n_review_tokens": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="the number of review tokens",
                 func=lambda info, x, c: c.block_review_tokens,
             ),
             "n_review_position": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="the relative position of review sentence",
                 func=lambda info, x, c: c.block_review_position,
             ),
             "n_reply_sentences": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="the number of reply sentence",
                 func=lambda info, x, c: c.block_reply_sentences,
             ),
             "n_reply_tokens": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="the number of reply tokens",
                 func=lambda info, x, c: c.block_reply_tokens,
             ),
             "n_reply_position": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="the relative position of reply sentence",
                 func=lambda info, x, c: c.block_reply_position,
             ),

--- a/explainaboard/processors/aspect_based_sentiment_classification.py
+++ b/explainaboard/processors/aspect_based_sentiment_classification.py
@@ -30,43 +30,43 @@ class AspectBasedSentimentClassificationProcessor(Processor):
     def default_analysis_levels(self) -> list[AnalysisLevel]:
         features: dict[str, FeatureType] = {
             "aspect": feature.Value(
-                dtype="string",
+                dtype=feature.DataType.STRING,
                 description="the aspect to analyze",
             ),
             "text": feature.Value(
-                dtype="string",
+                dtype=feature.DataType.STRING,
                 description="the text regarding the aspect",
             ),
             "true_label": feature.Value(
-                dtype="string",
+                dtype=feature.DataType.STRING,
                 description="the true label of the input",
             ),
             "predicted_label": feature.Value(
-                dtype="string",
+                dtype=feature.DataType.STRING,
                 description="the predicted label",
             ),
             "text_length": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="text length in tokens",
                 func=lambda info, x, c: count_tokens(info, x['text'], side='source'),
             ),
             "text_chars": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="text length in characters",
                 func=lambda info, x, c: len(x['text']),
             ),
             "entity_number": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="number of named entities in the text",
                 func=lambda info, x, c: len(get_named_entities(x['text'])),
             ),
             "aspect_length": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="aspect length in tokens",
                 func=lambda info, x, c: count_tokens(info, x['aspect'], side='source'),
             ),
             "aspect_position": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="relative position of the aspect in the text",
                 func=lambda info, x, c: float(x["text"].find(x["aspect"]))
                 / len(x["text"]),

--- a/explainaboard/processors/cloze_generative.py
+++ b/explainaboard/processors/cloze_generative.py
@@ -33,17 +33,19 @@ class ClozeGenerativeProcessor(Processor):
 
     def default_analysis_levels(self) -> list[AnalysisLevel]:
         features: dict[str, FeatureType] = {
-            "context": feature.Value(dtype="string"),
-            "question_mark": feature.Value(dtype="string"),
-            "hint": feature.Value(dtype="string"),
-            "answers": feature.Sequence(feature=feature.Value(dtype="string")),
+            "context": feature.Value(dtype=feature.DataType.STRING),
+            "question_mark": feature.Value(dtype=feature.DataType.STRING),
+            "hint": feature.Value(dtype=feature.DataType.STRING),
+            "answers": feature.Sequence(
+                feature=feature.Value(dtype=feature.DataType.STRING)
+            ),
             "context_length": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="the length of context",
                 func=lambda info, x, c: count_tokens(info, x['context']),
             ),
             "relative_blank_position": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="the relative position of blank (question mark)"
                 " in the whole context",
                 func=lambda info, x, c: relative_position(
@@ -51,7 +53,7 @@ class ClozeGenerativeProcessor(Processor):
                 ),
             ),
             "absolute_blank_position": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="the absolute position of blank (question mark)"
                 " in the whole context",
                 func=lambda info, x, c: absolute_position(
@@ -59,14 +61,14 @@ class ClozeGenerativeProcessor(Processor):
                 ),
             ),
             "answer_length": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="the length of answer",
                 func=lambda info, x, c: float(
                     np.mean([count_tokens(info, y) for y in x['answers']])
                 ),
             ),
             "num_oov": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="the number of out-of-vocabulary words",
                 require_training_set=True,
                 func=lambda info, x, c, stat: feat_num_oov(
@@ -74,7 +76,7 @@ class ClozeGenerativeProcessor(Processor):
                 ),
             ),
             "fre_rank": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description=(
                     "the average rank of each word based on its frequency in "
                     "training set"

--- a/explainaboard/processors/cloze_multiple_choice.py
+++ b/explainaboard/processors/cloze_multiple_choice.py
@@ -31,24 +31,26 @@ class ClozeMultipleChoiceProcessor(Processor):
 
     def default_analysis_levels(self) -> list[AnalysisLevel]:
         features: dict[str, FeatureType] = {
-            "context": feature.Value(dtype="string"),
-            "question_mark": feature.Value(dtype="string"),
-            "options": feature.Sequence(feature=feature.Value(dtype="string")),
+            "context": feature.Value(dtype=feature.DataType.STRING),
+            "question_mark": feature.Value(dtype=feature.DataType.STRING),
+            "options": feature.Sequence(
+                feature=feature.Value(dtype=feature.DataType.STRING)
+            ),
             "answers": feature.Sequence(
                 feature=feature.Dict(
                     feature={
-                        "text": feature.Value(dtype="string"),
-                        "option_index": feature.Value(dtype="int32"),
+                        "text": feature.Value(dtype=feature.DataType.STRING),
+                        "option_index": feature.Value(dtype=feature.DataType.INT),
                     }
                 )
             ),
             "context_length": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="the length of context",
                 func=lambda info, x, c: count_tokens(info, x['context']),
             ),
             "relative_blank_position": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="the relative position of blank (question mark)"
                 " in the whole context",
                 func=lambda info, x, c: relative_position(
@@ -56,7 +58,7 @@ class ClozeMultipleChoiceProcessor(Processor):
                 ),
             ),
             "absolute_blank_position": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="the absolute position of blank (question mark)"
                 " in the whole context",
                 func=lambda info, x, c: absolute_position(
@@ -64,12 +66,12 @@ class ClozeMultipleChoiceProcessor(Processor):
                 ),
             ),
             "answer_length": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="the length of answer",
                 func=lambda info, x, c: count_tokens(info, x['answers']['text']),
             ),
             "num_oov": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="the number of out-of-vocabulary words",
                 require_training_set=True,
                 func=lambda info, x, c, stat: feat_num_oov(
@@ -77,7 +79,7 @@ class ClozeMultipleChoiceProcessor(Processor):
                 ),
             ),
             "fre_rank": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description=(
                     "the average rank of each word based on its frequency in "
                     "training set"

--- a/explainaboard/processors/conditional_generation.py
+++ b/explainaboard/processors/conditional_generation.py
@@ -46,30 +46,30 @@ class ConditionalGenerationProcessor(Processor):
 
     def default_analysis_levels(self) -> list[AnalysisLevel]:
         examp_features: dict[str, FeatureType] = {
-            "source": feature.Value(dtype="string"),
-            "reference": feature.Value(dtype="string"),
-            "hypothesis": feature.Value(dtype="string"),
+            "source": feature.Value(dtype=feature.DataType.STRING),
+            "reference": feature.Value(dtype=feature.DataType.STRING),
+            "hypothesis": feature.Value(dtype=feature.DataType.STRING),
             "source_length": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="length of the source",
                 func=lambda info, x, c: count_tokens(info, x['source'], side='source'),
             ),
             "reference_length": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="length of the reference",
                 func=lambda info, x, c: count_tokens(
                     info, x['reference'], side='target'
                 ),
             ),
             "hypothesis_length": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="length of the hypothesis",
                 func=lambda info, x, c: count_tokens(
                     info, x['hypothesis'], side='target'
                 ),
             ),
             "src_num_oov": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="OOV words in the source",
                 func=lambda info, x, c, stat: feat_num_oov(
                     info, x['source'], stat['source_vocab'], side='source'
@@ -77,7 +77,7 @@ class ConditionalGenerationProcessor(Processor):
                 require_training_set=True,
             ),
             "src_fre_rank": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="average training-set frequency rank of words in source",
                 func=lambda info, x, c, stat: feat_freq_rank(
                     info, x['source'], stat['source_vocab_rank'], side='source'
@@ -85,7 +85,7 @@ class ConditionalGenerationProcessor(Processor):
                 require_training_set=True,
             ),
             "ref_num_oov": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="number of OOV words in reference",
                 func=lambda info, x, c, stat: feat_num_oov(
                     info, x['reference'], stat['target_vocab'], side='target'
@@ -93,7 +93,7 @@ class ConditionalGenerationProcessor(Processor):
                 require_training_set=True,
             ),
             "ref_fre_rank": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description=(
                     "average training-set frequency rank of words in reference"
                 ),
@@ -106,28 +106,28 @@ class ConditionalGenerationProcessor(Processor):
 
         tok_features: dict[str, FeatureType] = {
             "tok_text": feature.Value(
-                dtype="string",
+                dtype=feature.DataType.STRING,
                 description="text of the token",
                 func=lambda info, x, c: self._get_tok_text(c),
             ),
             "tok_capitalness": feature.Value(
-                dtype="string",
+                dtype=feature.DataType.STRING,
                 description="whether the token is capitalized",
                 func=lambda info, x, c: cap_feature(c.features['tok_text']),
             ),
             "tok_position": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="relative position of token in sentence",
                 func=self._get_tok_position,
             ),
             "tok_chars": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="number of characters in the token",
                 func=lambda info, x, c: len(c.features['tok_text']),
             ),
             # TODO(gneubig): commented out because less important and harder to impl
             # "tok_test_freq": feature.Value(
-            #     dtype="float",
+            #     dtype=feature.DataType.FLOAT,
             #     description="tok frequency in the test set",
             #     is_bucket=True,
             #     require_training_set=False,
@@ -138,7 +138,7 @@ class ConditionalGenerationProcessor(Processor):
             #     ),
             # ),
             "tok_train_freq": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="tok frequency in the training set",
                 require_training_set=True,
                 func=lambda info, x, c, stat: stat['target_vocab'].get(

--- a/explainaboard/processors/extractive_qa.py
+++ b/explainaboard/processors/extractive_qa.py
@@ -28,23 +28,25 @@ class QAExtractiveProcessor(Processor):
 
     def default_analysis_levels(self) -> list[AnalysisLevel]:
         features = {
-            "context": feature.Value(dtype="string"),
-            "question": feature.Value(dtype="string"),
-            "id": feature.Value(dtype="string"),
-            "answers": feature.Sequence(feature=feature.Value(dtype="string")),
-            "predicted_answers": feature.Value(dtype="string"),
+            "context": feature.Value(dtype=feature.DataType.STRING),
+            "question": feature.Value(dtype=feature.DataType.STRING),
+            "id": feature.Value(dtype=feature.DataType.STRING),
+            "answers": feature.Sequence(
+                feature=feature.Value(dtype=feature.DataType.STRING)
+            ),
+            "predicted_answers": feature.Value(dtype=feature.DataType.STRING),
             "context_length": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="context length in tokens",
                 func=lambda info, x, c: count_tokens(info, x['context']),
             ),
             "question_length": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="context length in tokens",
                 func=lambda info, x, c: count_tokens(info, x['question']),
             ),
             "answer_length": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="context length in tokens",
                 func=lambda info, x, c: count_tokens(
                     info,
@@ -55,7 +57,7 @@ class QAExtractiveProcessor(Processor):
                 ),
             ),
             "num_oov": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="the number of out-of-vocabulary words in the context",
                 require_training_set=True,
                 func=lambda info, x, c, stat: feat_num_oov(
@@ -63,7 +65,7 @@ class QAExtractiveProcessor(Processor):
                 ),
             ),
             "fre_rank": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description=(
                     "average rank of context words based on training set freq"
                 ),

--- a/explainaboard/processors/grammatical_error_correction.py
+++ b/explainaboard/processors/grammatical_error_correction.py
@@ -23,18 +23,24 @@ class GrammaticalErrorCorrection(Processor):
 
     def default_analysis_levels(self) -> list[AnalysisLevel]:
         features: dict[str, FeatureType] = {
-            "text": feature.Value(dtype="string"),
+            "text": feature.Value(dtype=feature.DataType.STRING),
             "edits": feature.Dict(
                 feature={
-                    "start_idx": feature.Sequence(feature=feature.Value(dtype="int32")),
-                    "end_idx": feature.Sequence(feature=feature.Value(dtype="int32")),
+                    "start_idx": feature.Sequence(
+                        feature=feature.Value(dtype=feature.DataType.INT)
+                    ),
+                    "end_idx": feature.Sequence(
+                        feature=feature.Value(dtype=feature.DataType.INT)
+                    ),
                     "corrections": feature.Sequence(
-                        feature=feature.Sequence(feature=feature.Value(dtype="string"))
+                        feature=feature.Sequence(
+                            feature=feature.Value(dtype=feature.DataType.STRING)
+                        )
                     ),
                 }
             ),
             "text_length": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="length of the text",
                 func=lambda info, x, c: count_tokens(info, x['text']),
             ),

--- a/explainaboard/processors/kg_link_tail_prediction.py
+++ b/explainaboard/processors/kg_link_tail_prediction.py
@@ -30,29 +30,33 @@ class KGLinkTailPredictionProcessor(Processor):
 
     def default_analysis_levels(self) -> list[AnalysisLevel]:
         features = {
-            "true_head": feature.Value(dtype="string"),
-            "true_head_decipher": feature.Value(dtype="string"),
-            "true_link": feature.Value(dtype="string", description="the relation type"),
-            "true_tail": feature.Value(dtype="string"),
-            "true_tail_decipher": feature.Value(dtype="string"),
-            "predict": feature.Value(dtype="string"),
-            "predictions": feature.Sequence(feature=feature.Value(dtype="string")),
+            "true_head": feature.Value(dtype=feature.DataType.STRING),
+            "true_head_decipher": feature.Value(dtype=feature.DataType.STRING),
+            "true_link": feature.Value(
+                dtype=feature.DataType.STRING, description="the relation type"
+            ),
+            "true_tail": feature.Value(dtype=feature.DataType.STRING),
+            "true_tail_decipher": feature.Value(dtype=feature.DataType.STRING),
+            "predict": feature.Value(dtype=feature.DataType.STRING),
+            "predictions": feature.Sequence(
+                feature=feature.Value(dtype=feature.DataType.STRING)
+            ),
             "tail_entity_length": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="length of the tail entity in tokens",
                 func=lambda info, x, c: count_tokens(
                     info, x['true_tail_decipher'], side='target'
                 ),
             ),
             "head_entity_length": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="length of the head entity in tokens",
                 func=lambda info, x, c: count_tokens(
                     info, x['true_head_decipher'], side='target'
                 ),
             ),
             "tail_fre": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="average frequency of the tail entity",
                 require_training_set=True,
                 func=lambda info, x, c, stat: stat['tail_fre'].get(
@@ -60,13 +64,13 @@ class KGLinkTailPredictionProcessor(Processor):
                 ),
             ),
             "link_fre": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="frequency of relation in training set",
                 require_training_set=True,
                 func=lambda info, x, c, stat: stat['link_fre'].get(x['true_link'], 0),
             ),
             "head_fre": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="frequency of head entity in training set",
                 require_training_set=True,
                 func=lambda info, x, c, stat: stat['head_fre'].get(
@@ -74,14 +78,14 @@ class KGLinkTailPredictionProcessor(Processor):
                 ),
             ),
             "symmetry": feature.Value(
-                dtype="string",
+                dtype=feature.DataType.STRING,
                 description="whether the relation is symmetric",
                 func=lambda info, x, c: 'symmetric'
                 if x['true_link'] in self._symmetric_relations
                 else 'asymmetric',
             ),
             "entity_type_level": feature.Value(
-                dtype="string",
+                dtype=feature.DataType.STRING,
                 description="most specific entity type level of the true tail entity",
                 func=lambda info, x, c: self._get_entity_type_level(x),
             ),

--- a/explainaboard/processors/language_modeling.py
+++ b/explainaboard/processors/language_modeling.py
@@ -9,7 +9,7 @@ from explainaboard import TaskType
 from explainaboard.analysis import feature
 from explainaboard.analysis.analyses import Analysis, AnalysisLevel, BucketAnalysis
 from explainaboard.analysis.case import AnalysisCase, AnalysisCaseSpan
-from explainaboard.analysis.feature import FeatureType
+from explainaboard.analysis.feature import DataType, FeatureType, Value
 from explainaboard.analysis.feature_funcs import (
     cap_feature,
     count_tokens,
@@ -34,20 +34,20 @@ class LanguageModelingProcessor(Processor):
 
     def default_analysis_levels(self) -> list[AnalysisLevel]:
         examp_features: dict[str, FeatureType] = {
-            "text": feature.Value(dtype="string"),
-            "log_probs": feature.Value(dtype="string"),
+            "text": feature.Value(dtype=feature.DataType.STRING),
+            "log_probs": feature.Value(dtype=feature.DataType.STRING),
             "text_length": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="text length in tokens",
                 func=lambda info, x, c: count_tokens(info, x['text']),
             ),
             "text_chars": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="text length in characters",
                 func=lambda info, x, c: len(x['text']),
             ),
             "num_oov": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="the number of out-of-vocabulary words",
                 require_training_set=True,
                 func=lambda info, x, c, stat: feat_num_oov(
@@ -55,7 +55,7 @@ class LanguageModelingProcessor(Processor):
                 ),
             ),
             "fre_rank": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description=(
                     "the average rank of each word based on its frequency in "
                     "training set"
@@ -66,7 +66,7 @@ class LanguageModelingProcessor(Processor):
                 ),
             ),
             "length_fre": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="the frequency of text length in training set",
                 require_training_set=True,
                 func=lambda info, x, c, stat: feat_length_freq(
@@ -77,11 +77,11 @@ class LanguageModelingProcessor(Processor):
 
         tok_features: dict[str, FeatureType] = {
             "tok_log_prob": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description=("log probability of the token according to the LM"),
             ),
             "tok_capitalness": feature.Value(
-                dtype="string",
+                dtype=feature.DataType.STRING,
                 description=(
                     "The capitalness of an token. For example, "
                     "first_caps represents only the first character of "
@@ -91,24 +91,24 @@ class LanguageModelingProcessor(Processor):
                 func=lambda info, x, c: cap_feature(c.text),
             ),
             "tok_position": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description=("The relative position of a token in a sentence"),
                 func=lambda info, x, c: c.token_span[0] / count_tokens(info, x['text']),
             ),
             "tok_chars": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="The number of characters in a token",
                 func=lambda info, x, c: len(c.text),
             ),
             # TODO(gneubig): commented out because probably less important
             # "tok_test_freq": feature.Value(
-            #     dtype="float",
+            #     dtype=feature.DataType.FLOAT,
             #     description="tok frequency in the test set",
             #     require_training_set=False,
             #     func=...
             # ),
             "tok_train_freq": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="tok frequency in the training set",
                 require_training_set=True,
                 func=lambda info, x, c, stat: stat['vocab'].get(c.text, 0.0),
@@ -133,7 +133,11 @@ class LanguageModelingProcessor(Processor):
         analysis_levels = self.default_analysis_levels()
         for lev in analysis_levels:
             for k, v in lev.features.items():
-                if v.dtype == 'float32' and k != 'tok_log_prob':
+                if (
+                    isinstance(v, Value)
+                    and v.dtype == DataType.FLOAT
+                    and k != 'tok_log_prob'
+                ):
                     analyses.append(
                         BucketAnalysis(
                             level=lev.name,

--- a/explainaboard/processors/machine_translation.py
+++ b/explainaboard/processors/machine_translation.py
@@ -26,7 +26,7 @@ class MachineTranslationProcessor(ConditionalGenerationProcessor):
         f = super().default_analysis_levels()
         f = copy.deepcopy(f)
         f[0].features["attr_compression"] = feature.Value(
-            dtype="float",
+            dtype=feature.DataType.FLOAT,
             description="the ratio between source and reference length",
             func=lambda info, x, c: c.features['source_length']
             / c.features['reference_length'],

--- a/explainaboard/processors/nlg_meta_evaluation.py
+++ b/explainaboard/processors/nlg_meta_evaluation.py
@@ -27,64 +27,64 @@ class NLGMetaEvaluationProcessor(Processor):
     def default_analysis_levels(self) -> list[AnalysisLevel]:
         features: dict[str, FeatureType] = {
             "sys_name": feature.Value(
-                dtype="string",
+                dtype=feature.DataType.STRING,
                 description="the name of the system",
             ),
             "seg_id": feature.Value(
-                dtype="string",
+                dtype=feature.DataType.STRING,
                 description="the ID of the segment",
             ),
             "test_set": feature.Value(
-                dtype="string",
+                dtype=feature.DataType.STRING,
                 description="the set from which the example came from",
             ),
             "src": feature.Value(
-                dtype="string",
+                dtype=feature.DataType.STRING,
                 description="the source sentence",
             ),
             "ref": feature.Value(
-                dtype="string",
+                dtype=feature.DataType.STRING,
                 description="the reference sentence",
             ),
             "sys": feature.Value(
-                dtype="string",
+                dtype=feature.DataType.STRING,
                 description="the system output",
             ),
             "manual_raw": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="the raw score provided by annotators",
             ),
             "manual_z": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="the z-normalized score provided by annotators",
             ),
             "auto_score": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="the score provided by the automatic system",
             ),
             "src_length": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="source length",
                 func=lambda info, x, c: count_tokens(info, x['src']),
             ),
             "ref_length": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="reference length",
                 func=lambda info, x, c: count_tokens(info, x['ref'], side='target'),
             ),
             "sys_length": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="system output length",
                 func=lambda info, x, c: count_tokens(info, x['ref'], side='target'),
             ),
             "src_divided_ref": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="ratio of source length to reference length",
                 func=lambda info, x, c: c.features['src_length']
                 / c.features['ref_length'],
             ),
             "sys_divided_ref": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="ratio of system output length to reference length",
                 func=lambda info, x, c: c.features['sys_length']
                 / c.features['ref_length'],

--- a/explainaboard/processors/processor.py
+++ b/explainaboard/processors/processor.py
@@ -16,7 +16,12 @@ from explainaboard.analysis.analyses import (
     BucketAnalysisResult,
 )
 from explainaboard.analysis.case import AnalysisCase
-from explainaboard.analysis.feature import FeatureType, get_feature_type_serializer
+from explainaboard.analysis.feature import (
+    DataType,
+    FeatureType,
+    get_feature_type_serializer,
+    Value,
+)
 from explainaboard.analysis.performance import BucketPerformance, Performance
 from explainaboard.analysis.result import Result
 from explainaboard.info import OverallStatistics, SysOutputInfo
@@ -61,7 +66,7 @@ class Processor(metaclass=abc.ABCMeta):
         for lev in analysis_levels:
             # Continuous features
             for k, v in lev.features.items():
-                if v.dtype == 'float32':
+                if isinstance(v, Value) and v.dtype == DataType.FLOAT:
                     analyses.append(
                         BucketAnalysis(
                             level=lev.name,

--- a/explainaboard/processors/qa_multiple_choice.py
+++ b/explainaboard/processors/qa_multiple_choice.py
@@ -28,36 +28,38 @@ class QAMultipleChoiceProcessor(Processor):
 
     def default_analysis_levels(self) -> list[AnalysisLevel]:
         features = {
-            "context": feature.Value(dtype="string"),
-            "question": feature.Value(dtype="string"),
-            "options": feature.Sequence(feature=feature.Value(dtype="string")),
+            "context": feature.Value(dtype=feature.DataType.STRING),
+            "question": feature.Value(dtype=feature.DataType.STRING),
+            "options": feature.Sequence(
+                feature=feature.Value(dtype=feature.DataType.STRING)
+            ),
             "answers": feature.Sequence(
                 feature=feature.Dict(
                     feature={
-                        "text": feature.Value(dtype="string"),
-                        "option_index": feature.Value(dtype="int32"),
+                        "text": feature.Value(dtype=feature.DataType.STRING),
+                        "option_index": feature.Value(dtype=feature.DataType.INT),
                     }
                 )
             ),
             "context_length": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="context length in tokens",
                 func=lambda info, x, c: count_tokens(info, x['context']),
             ),
             "question_length": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="context length in tokens",
                 func=lambda info, x, c: count_tokens(info, x['question']),
             ),
             "answer_length": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="context length in tokens",
                 func=lambda info, x, c: count_tokens(
                     info, x['answers']['text'], side='target'
                 ),
             ),
             "num_oov": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="the number of out-of-vocabulary words in the context",
                 require_training_set=True,
                 func=lambda info, x, c, stat: feat_num_oov(
@@ -65,7 +67,7 @@ class QAMultipleChoiceProcessor(Processor):
                 ),
             ),
             "fre_rank": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description=(
                     "average rank of context words based on training set freq"
                 ),

--- a/explainaboard/processors/qa_open_domain.py
+++ b/explainaboard/processors/qa_open_domain.py
@@ -28,23 +28,25 @@ class QAOpenDomainProcessor(Processor):
 
     def default_analysis_levels(self) -> list[AnalysisLevel]:
         features = {
-            "question": feature.Value(dtype="string"),
+            "question": feature.Value(dtype=feature.DataType.STRING),
             # "question_types": feature.Sequence(feature=feature.Value("string")),
-            "answers": feature.Sequence(feature=feature.Value(dtype="string")),
+            "answers": feature.Sequence(
+                feature=feature.Value(dtype=feature.DataType.STRING)
+            ),
             "question_length": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="context length in tokens",
                 func=lambda info, x, c: count_tokens(info, x['question']),
             ),
             "answer_length": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="context length in tokens",
                 func=lambda info, x, c: count_tokens(
                     info, x['answers'][0], side='target'
                 ),
             ),
             "num_oov": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="the number of out-of-vocabulary words in the context",
                 require_training_set=True,
                 func=lambda info, x, c, stat: feat_num_oov(
@@ -52,7 +54,7 @@ class QAOpenDomainProcessor(Processor):
                 ),
             ),
             "fre_rank": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description=(
                     "average rank of context words based on training set freq"
                 ),

--- a/explainaboard/processors/qa_tat.py
+++ b/explainaboard/processors/qa_tat.py
@@ -30,46 +30,54 @@ class QATatProcessor(Processor):
 
     def default_analysis_levels(self) -> list[AnalysisLevel]:
         features = {
-            "question": feature.Value(dtype="string"),
-            "context": feature.Sequence(feature=feature.Value(dtype="string")),
-            "table": feature.Sequence(feature=feature.Value(dtype="string")),
-            "true_answer": feature.Sequence(feature=feature.Value(dtype="string")),
-            "predicted_answer": feature.Sequence(feature=feature.Value(dtype="string")),
-            "predicted_answer_scale": feature.Value(dtype="string"),
+            "question": feature.Value(dtype=feature.DataType.STRING),
+            "context": feature.Sequence(
+                feature=feature.Value(dtype=feature.DataType.STRING)
+            ),
+            "table": feature.Sequence(
+                feature=feature.Value(dtype=feature.DataType.STRING)
+            ),
+            "true_answer": feature.Sequence(
+                feature=feature.Value(dtype=feature.DataType.STRING)
+            ),
+            "predicted_answer": feature.Sequence(
+                feature=feature.Value(dtype=feature.DataType.STRING)
+            ),
+            "predicted_answer_scale": feature.Value(dtype=feature.DataType.STRING),
             "answer_type": feature.Value(
-                dtype="string",
+                dtype=feature.DataType.STRING,
                 description="type of answer",
             ),
             "answer_scale": feature.Value(
-                dtype="string",
+                dtype=feature.DataType.STRING,
                 description="scale of answer",
             ),
             "context_length": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="context length in tokens",
                 func=lambda info, x, c: sum(
                     [count_tokens(info, text) for text in x['context']["text"]]
                 ),
             ),
             "table_rows": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="the number of table row",
                 func=lambda info, x, c: len(x['table']),
             ),
             "table_columns": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="the number of table column",
                 func=lambda info, x, c: len(x['table'][0])
                 if len(x['table']) > 0
                 else 0,
             ),
             "question_length": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="context length in tokens",
                 func=lambda info, x, c: count_tokens(info, x['question']),
             ),
             "answer_length": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="the length of answer",
                 func=lambda info, x, c: len(x['true_answer']),
             ),

--- a/explainaboard/processors/sequence_labeling.py
+++ b/explainaboard/processors/sequence_labeling.py
@@ -38,16 +38,22 @@ class SeqLabProcessor(Processor):
 
     def default_analysis_levels(self) -> list[AnalysisLevel]:
         examp_features: dict[str, FeatureType] = {
-            "tokens": feature.Sequence(feature=feature.Value(dtype="string")),
-            "true_tags": feature.Sequence(feature=feature.Value(dtype="string")),
-            "pred_tags": feature.Sequence(feature=feature.Value(dtype="string")),
+            "tokens": feature.Sequence(
+                feature=feature.Value(dtype=feature.DataType.STRING)
+            ),
+            "true_tags": feature.Sequence(
+                feature=feature.Value(dtype=feature.DataType.STRING)
+            ),
+            "pred_tags": feature.Sequence(
+                feature=feature.Value(dtype=feature.DataType.STRING)
+            ),
             "text_length": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="text length in tokens",
                 func=lambda info, x, c: len(x['tokens']),
             ),
             "span_density": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="ratio of entity tokens to all tokens",
                 func=lambda info, x, c: float(
                     len([y for y in x['true_tags'] if y != self._DEFAULT_TAG])
@@ -55,7 +61,7 @@ class SeqLabProcessor(Processor):
                 / len(x['true_tags']),
             ),
             "num_oov": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="the number of out-of-vocabulary words",
                 require_training_set=True,
                 func=lambda info, x, c, stat: feat_num_oov(
@@ -63,7 +69,7 @@ class SeqLabProcessor(Processor):
                 ),
             ),
             "fre_rank": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="average rank of each word based on training set frequency",
                 require_training_set=True,
                 func=lambda info, x, c, stat: feat_freq_rank(
@@ -74,42 +80,42 @@ class SeqLabProcessor(Processor):
 
         span_features: dict[str, FeatureType] = {
             "span_text": feature.Value(
-                dtype="string",
+                dtype=feature.DataType.STRING,
                 description="text of the span",
                 func=lambda info, x, c: c.text,
             ),
             "span_length": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="span length in tokens",
                 func=lambda info, x, c: c.token_span[1] - c.token_span[0],
             ),
             "span_true_label": feature.Value(
-                dtype="string",
+                dtype=feature.DataType.STRING,
                 description="true label of the span",
                 func=lambda info, x, c: c.true_label,
             ),
             "span_pred_label": feature.Value(
-                dtype="string",
+                dtype=feature.DataType.STRING,
                 description="predicted label of the span",
                 func=lambda info, x, c: c.predicted_label,
             ),
             "span_capitalness": feature.Value(
-                dtype="string",
+                dtype=feature.DataType.STRING,
                 description="whether the span is capitalized",
                 func=lambda info, x, c: cap_feature(c.text),
             ),
             "span_rel_pos": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="relative position of the span",
                 func=lambda info, x, c: c.token_span[0] / len(x['tokens']),
             ),
             "span_chars": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="number of characters in the span",
                 func=lambda info, x, c: len(c.text),
             ),
             "span_econ": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="consistency of the span labels",
                 require_training_set=True,
                 func=lambda info, x, c, stat: stat['econ_dic'].get(
@@ -117,7 +123,7 @@ class SeqLabProcessor(Processor):
                 ),
             ),
             "span_efre": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="frequency of the span in the training set",
                 require_training_set=True,
                 func=lambda info, x, c, stat: stat['efre_dic'].get(c.text.lower(), 0.0),

--- a/explainaboard/processors/summarization.py
+++ b/explainaboard/processors/summarization.py
@@ -30,31 +30,40 @@ class SummarizationProcessor(ConditionalGenerationProcessor):
     def default_analysis_levels(self) -> list[AnalysisLevel]:
         f = super().default_analysis_levels()
         new_examp_features = {
-            "sum_attributes": feature.Value(
-                dtype="dict",
+            "sum_attributes": feature.Dict(
+                feature={
+                    "attr_density": feature.Value(dtype=feature.DataType.FLOAT),
+                    "attr_coverage": feature.Value(dtype=feature.DataType.FLOAT),
+                    "attr_compression": feature.Value(dtype=feature.DataType.FLOAT),
+                    "attr_repetition": feature.Value(dtype=feature.DataType.FLOAT),
+                    "attr_novelty": feature.Value(dtype=feature.DataType.FLOAT),
+                    "attr_copy_len": feature.Value(dtype=feature.DataType.FLOAT),
+                    "attr_source_len": feature.Value(dtype=feature.DataType.INT),
+                    "attr_hypothesis_len": feature.Value(dtype=feature.DataType.INT),
+                },
                 func=lambda info, x, c: sum_attr.cal_attributes_each(
                     x["source"], x["reference"]
                 ),
             ),
             "attr_compression": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="compression",
                 func=lambda info, x, c: c.features['sum_attributes'][
                     "attr_compression"
                 ],
             ),
             "attr_copy_len": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="copy length",
                 func=lambda info, x, c: c.features['sum_attributes']["attr_copy_len"],
             ),
             "attr_coverage": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="coverage",
                 func=lambda info, x, c: c.features['sum_attributes']["attr_coverage"],
             ),
             "attr_novelty": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="novelty",
                 func=lambda info, x, c: c.features['sum_attributes']["attr_novelty"],
             ),

--- a/explainaboard/processors/tabular_classification.py
+++ b/explainaboard/processors/tabular_classification.py
@@ -28,11 +28,11 @@ class TextClassificationProcessor(Processor):
     def default_analysis_levels(self) -> list[AnalysisLevel]:
         features: dict[str, FeatureType] = {
             "true_label": feature.Value(
-                dtype="string",
+                dtype=feature.DataType.STRING,
                 description="the true label of the input",
             ),
             "predicted_label": feature.Value(
-                dtype="string",
+                dtype=feature.DataType.STRING,
                 description="the predicted label",
             ),
         }

--- a/explainaboard/processors/tabular_regression.py
+++ b/explainaboard/processors/tabular_regression.py
@@ -26,11 +26,11 @@ class TabularRegressionProcessor(Processor):
     def default_analysis_levels(self) -> list[AnalysisLevel]:
         features: dict[str, FeatureType] = {
             "true_value": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="the true value of the input",
             ),
             "predicted_value": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="the predicted value",
             ),
         }

--- a/explainaboard/processors/text_classification.py
+++ b/explainaboard/processors/text_classification.py
@@ -38,39 +38,39 @@ class TextClassificationProcessor(Processor):
     def default_analysis_levels(self) -> list[AnalysisLevel]:
         features: dict[str, FeatureType] = {
             "text": feature.Value(
-                dtype="string",
+                dtype=feature.DataType.STRING,
                 description="the text of the example",
             ),
             "true_label": feature.Value(
-                dtype="string",
+                dtype=feature.DataType.STRING,
                 description="the true label of the input",
             ),
             "predicted_label": feature.Value(
-                dtype="string",
+                dtype=feature.DataType.STRING,
                 description="the predicted label",
             ),
             "text_length": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="text length in tokens",
                 func=lambda info, x, c: count_tokens(info, x['text']),
             ),
             "text_chars": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="text length in characters",
                 func=lambda info, x, c: len(x['text']),
             ),
             "basic_words": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="the ratio of basic words",
                 func=lambda info, x, c: get_basic_words(x['text']),
             ),
             "lexical_richness": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="lexical diversity",
                 func=lambda info, x, c: get_lexical_richness(x['text']),
             ),
             "num_oov": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="the number of out-of-vocabulary words",
                 require_training_set=True,
                 func=lambda info, x, c, stat: feat_num_oov(
@@ -78,7 +78,7 @@ class TextClassificationProcessor(Processor):
                 ),
             ),
             "fre_rank": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description=(
                     "the average rank of each word based on its frequency in "
                     "training set"
@@ -89,7 +89,7 @@ class TextClassificationProcessor(Processor):
                 ),
             ),
             "length_fre": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="the frequency of text length in training set",
                 require_training_set=True,
                 func=lambda info, x, c, stat: feat_length_freq(

--- a/explainaboard/processors/text_pair_classification.py
+++ b/explainaboard/processors/text_pair_classification.py
@@ -36,46 +36,46 @@ class TextPairClassificationProcessor(Processor):
     def default_analysis_levels(self) -> list[AnalysisLevel]:
         features: dict[str, FeatureType] = {
             "text1": feature.Value(
-                dtype="string",
+                dtype=feature.DataType.STRING,
                 description="the first text",
             ),
             "text2": feature.Value(
-                dtype="string",
+                dtype=feature.DataType.STRING,
                 description="the second text",
             ),
             "true_label": feature.Value(
-                dtype="string",
+                dtype=feature.DataType.STRING,
                 description="the true label of the input",
             ),
             "predicted_label": feature.Value(
-                dtype="string",
+                dtype=feature.DataType.STRING,
                 description="the predicted label",
             ),
             "text1_length": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="text1 length in tokens",
                 func=lambda info, x, c: count_tokens(info, x['text1'], side='source'),
             ),
             "text2_length": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="text2 length in tokens",
                 func=lambda info, x, c: count_tokens(info, x['text2'], side='target'),
             ),
             "similarity": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="the two texts' similarity",
                 func=lambda info, x, c: get_similarity_by_sacrebleu(
                     x['text1'], x['text2']
                 ),
             ),
             "text1_divided_text2": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="ratio of two texts' lengths",
                 func=lambda info, x, c: c.features['text1_length']
                 / c.features['text2_length'],
             ),
             "num_oov": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description="the number of out-of-vocabulary words",
                 require_training_set=True,
                 func=lambda info, x, c, stat: feat_num_oov(
@@ -84,7 +84,7 @@ class TextPairClassificationProcessor(Processor):
                 + feat_num_oov(info, x['text2'], stat['target_vocab'], side='target'),
             ),
             "fre_rank": feature.Value(
-                dtype="float",
+                dtype=feature.DataType.FLOAT,
                 description=(
                     "the average rank of each word based on its frequency in "
                     "training set"


### PR DESCRIPTION
This PR attempts to apply following changes:

- Define `explainaboard.analysis.feature.FeatureType` enum, defining data type of `Value` feature. Currently there are 3 types: int, float, and string according to the current task definitions.
- Remove unclear `*32` and `*64` types from Value's dtype.
- Remove `dtype` member from `Sequence` and `Dict` because it provides no useful information.
- Add fine-grained value checking of `max_value` and `min_value`.