### PR TITLE
refactor AnalysisResult.print to generate_report.

### DIFF
--- a/docs/example_scripts/test_kg.py
+++ b/docs/example_scripts/test_kg.py
@@ -24,7 +24,7 @@ overall_res = unwrap(sys_info.results.overall)
 # print bucket information
 for analysis in fine_grained_res:
     if analysis is not None:
-        analysis.print()
+        print(analysis.generate_report())
 
 # save analysis report locally
 sys_info.print_as_json(file=open("./report.json", 'w'))

--- a/explainaboard/analysis/analyses.py
+++ b/explainaboard/analysis/analyses.py
@@ -35,7 +35,7 @@ class AnalysisResult(metaclass=abc.ABCMeta):
         Returns:
             Multi-lined string representing the report of this result.
         """
-        raise NotImplementedError
+        ...
 
     @staticmethod
     def from_dict(dikt):

--- a/explainaboard/analysis/analyses.py
+++ b/explainaboard/analysis/analyses.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import abc
 from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Any, Optional, TypeVar
+from typing import Any, final, Optional, TypeVar
 
 import numpy as np
 
@@ -12,12 +13,12 @@ from explainaboard.analysis.feature import FeatureType, get_feature_type_seriali
 from explainaboard.analysis.performance import BucketPerformance, Performance
 from explainaboard.metrics.metric import Metric, MetricConfig, MetricStats
 from explainaboard.metrics.registry import metric_config_from_dict
-from explainaboard.utils.logging import get_logger
 from explainaboard.utils.typing_utils import narrow, unwrap, unwrap_generator
 
 
-@dataclass
-class AnalysisResult:
+# See https://github.com/python/mypy/issues/5374
+@dataclass  # type: ignore
+class AnalysisResult(metaclass=abc.ABCMeta):
     """
     A result of an analysis, where the actual details of the result will be implemented
     by the inheriting class.
@@ -27,7 +28,13 @@ class AnalysisResult:
     name: str
     level: str
 
-    def print(self):
+    @abc.abstractmethod
+    def generate_report(self) -> str:
+        """Generate human-readable report.
+
+        Returns:
+            Multi-lined string representing the report of this result.
+        """
         raise NotImplementedError
 
     @staticmethod
@@ -94,6 +101,7 @@ class Analysis:
             )
 
 
+@final
 @dataclass
 class BucketAnalysisResult(AnalysisResult):
     """
@@ -118,27 +126,51 @@ class BucketAnalysisResult(AnalysisResult):
         )
 
     def __post_init__(self):
+        metric_names = [x.metric_name for x in self.bucket_performances[0].performances]
+        num_metrics = len(metric_names)
+        for bucket_perf in self.bucket_performances:
+            if len(bucket_perf.performances) != num_metrics:
+                raise ValueError(
+                    "Inconsistent number of metrics. "
+                    f"Required: {num_metrics}, got: {len(bucket_perf.performances)}"
+                )
+            for metric_name, perf in zip(metric_names, bucket_perf.performances):
+                if perf.metric_name != metric_name:
+                    raise ValueError(
+                        "Inconsistent metric names. "
+                        f"Required: {metric_name}, got: {perf.metric_name}"
+                    )
+
         self.cls_name: str = self.__class__.__name__
 
-    def print(self):
+    def generate_report(self) -> str:
+        """See AnalysisResult.generate_report"""
+        texts: list[str] = []
+
         metric_names = [x.metric_name for x in self.bucket_performances[0].performances]
+
         for i, metric_name in enumerate(metric_names):
-            get_logger('report').info(f"the information of #{self.name}#")
-            get_logger('report').info(f"bucket_name\t{metric_name}\t#samples")
+            texts.append(f"the information of #{self.name}#")
+            texts.append(f"bucket_name\t{metric_name}\t#samples")
+
             for bucket_perf in self.bucket_performances:
+                perf = bucket_perf.performances[i]
+
                 if bucket_perf.bucket_interval is not None:
                     bucket_name = f"{unwrap(bucket_perf.bucket_interval)}"
                 else:
                     bucket_name = unwrap(bucket_perf.bucket_name)
 
-                get_logger('report').info(
-                    f"{bucket_name}\t"
-                    f"{bucket_perf.performances[i].value}\t"
-                    f"{bucket_perf.n_samples}"
+                texts.append(
+                    f"{bucket_name}\t" f"{perf.value}\t" f"{bucket_perf.n_samples}"
                 )
-            get_logger('report').info('')
+
+            texts.append('')
+
+        return "\n".join(texts)
 
 
+@final
 @dataclass
 class BucketAnalysis(Analysis):
     """
@@ -240,6 +272,7 @@ class BucketAnalysis(Analysis):
         )
 
 
+@final
 @dataclass
 class ComboCountAnalysisResult(AnalysisResult):
     """
@@ -251,8 +284,8 @@ class ComboCountAnalysisResult(AnalysisResult):
       the count of that feature combination in the corpus.
     """
 
-    features: tuple
-    combo_counts: list[tuple[tuple, int]] | None = None
+    features: tuple[str, ...]
+    combo_counts: list[tuple[tuple[str, ...], int]]
     cls_name: Optional[str] = None
 
     @staticmethod
@@ -265,16 +298,31 @@ class ComboCountAnalysisResult(AnalysisResult):
         )
 
     def __post_init__(self):
+        num_features = len(self.features)
+        for k, _ in self.combo_counts:
+            if len(k) != num_features:
+                raise ValueError(
+                    "Inconsistent number of features. "
+                    f"Required: {num_features}, got: {len(k)}"
+                )
+
         self.cls_name: str = self.__class__.__name__
 
-    def print(self):
-        get_logger('report').info('feature combos for ' + ', '.join(self.features))
-        get_logger('report').info('\t'.join(self.features + ('#',)))
+    def generate_report(self) -> str:
+        """See AnalysisResult.generate_report."""
+        texts: list[str] = []
+
+        texts.append('feature combos for ' + ', '.join(self.features))
+        texts.append('\t'.join(self.features + ('#',)))
+
         for k, v in sorted(self.combo_counts):
-            get_logger('report').info('\t'.join(k + (str(v),)))
-        get_logger('report').info('')
+            texts.append('\t'.join(k + (str(v),)))
+
+        texts.append('')
+        return "\n".join(texts)
 
 
+@final
 @dataclass
 class ComboCountAnalysis(Analysis):
     """
@@ -285,7 +333,7 @@ class ComboCountAnalysis(Analysis):
         features: the name of the features over which to perform the analysis
     """
 
-    features: tuple
+    features: tuple[str, ...]
     cls_name: Optional[str] = None
 
     def __post_init__(self):
@@ -304,7 +352,7 @@ class ComboCountAnalysis(Analysis):
             if x not in cases[0].features:
                 raise RuntimeError(f"combo analysis: feature {x} not found.")
 
-        combo_map: dict[tuple, int] = {}
+        combo_map: dict[tuple[str, ...], int] = {}
         for case in cases:
             feat_vals = tuple([case.features[x] for x in self.features])
             combo_map[feat_vals] = combo_map.get(feat_vals, 0) + 1

--- a/explainaboard/analysis/analyses_test.py
+++ b/explainaboard/analysis/analyses_test.py
@@ -1,0 +1,178 @@
+"""Tests for explainaboard.analysis.analyses."""
+
+import textwrap
+import unittest
+
+from explainaboard.analysis.analyses import (
+    BucketAnalysisResult,
+    ComboCountAnalysisResult,
+)
+from explainaboard.analysis.performance import BucketPerformance, Performance
+
+
+class BucketAnalysisResultTest(unittest.TestCase):
+    def test_inconsistent_num_metrics(self) -> None:
+        with self.assertRaisesRegex(ValueError, r"^Inconsistent number of metrics"):
+            BucketAnalysisResult(
+                name="foo",
+                level="bar",
+                bucket_performances=[
+                    BucketPerformance(
+                        n_samples=5,
+                        bucket_samples=[0, 1, 2, 3, 4],
+                        performances=[
+                            Performance(metric_name="metric1", value=0.5),
+                            Performance(metric_name="metric2", value=0.25),
+                        ],
+                        bucket_name="baz",
+                    ),
+                    BucketPerformance(
+                        n_samples=5,
+                        bucket_samples=[5, 6, 7, 8, 9],
+                        performances=[
+                            Performance(metric_name="metric1", value=0.125),
+                        ],
+                        bucket_name="qux",
+                    ),
+                ],
+            )
+
+    def test_inconsistent_metric_names(self) -> None:
+        with self.assertRaisesRegex(ValueError, r"^Inconsistent metric names"):
+            BucketAnalysisResult(
+                name="foo",
+                level="bar",
+                bucket_performances=[
+                    BucketPerformance(
+                        n_samples=5,
+                        bucket_samples=[0, 1, 2, 3, 4],
+                        performances=[
+                            Performance(metric_name="metric1", value=0.5),
+                            Performance(metric_name="metric2", value=0.25),
+                        ],
+                        bucket_name="baz",
+                    ),
+                    BucketPerformance(
+                        n_samples=5,
+                        bucket_samples=[5, 6, 7, 8, 9],
+                        performances=[
+                            Performance(metric_name="metric1", value=0.125),
+                            Performance(metric_name="xxx", value=0.25),
+                        ],
+                        bucket_name="qux",
+                    ),
+                ],
+            )
+
+    def test_generate_report_with_interval(self) -> None:
+        result = BucketAnalysisResult(
+            name="foo",
+            level="bar",
+            bucket_performances=[
+                BucketPerformance(
+                    n_samples=5,
+                    bucket_samples=[0, 1, 2, 3, 4],
+                    performances=[
+                        Performance(metric_name="metric1", value=0.5),
+                        Performance(metric_name="metric2", value=0.25),
+                    ],
+                    bucket_interval=(1.0, 2.0),
+                ),
+                BucketPerformance(
+                    n_samples=5,
+                    bucket_samples=[5, 6, 7, 8, 9],
+                    performances=[
+                        Performance(metric_name="metric1", value=0.125),
+                        Performance(metric_name="metric2", value=0.0625),
+                    ],
+                    bucket_interval=(2.0, 3.0),
+                ),
+            ],
+        )
+        report = textwrap.dedent(
+            """\
+            the information of #foo#
+            bucket_name\tmetric1\t#samples
+            (1.0, 2.0)\t0.5\t5
+            (2.0, 3.0)\t0.125\t5
+
+            the information of #foo#
+            bucket_name\tmetric2\t#samples
+            (1.0, 2.0)\t0.25\t5
+            (2.0, 3.0)\t0.0625\t5
+            """
+        )
+        self.assertEqual(result.generate_report(), report)
+
+    def test_generate_report_with_name(self) -> None:
+        result = BucketAnalysisResult(
+            name="foo",
+            level="bar",
+            bucket_performances=[
+                BucketPerformance(
+                    n_samples=5,
+                    bucket_samples=[0, 1, 2, 3, 4],
+                    performances=[
+                        Performance(metric_name="metric1", value=0.5),
+                        Performance(metric_name="metric2", value=0.25),
+                    ],
+                    bucket_name="baz",
+                ),
+                BucketPerformance(
+                    n_samples=5,
+                    bucket_samples=[5, 6, 7, 8, 9],
+                    performances=[
+                        Performance(metric_name="metric1", value=0.125),
+                        Performance(metric_name="metric2", value=0.0625),
+                    ],
+                    bucket_name="qux",
+                ),
+            ],
+        )
+        report = textwrap.dedent(
+            """\
+            the information of #foo#
+            bucket_name\tmetric1\t#samples
+            baz\t0.5\t5
+            qux\t0.125\t5
+
+            the information of #foo#
+            bucket_name\tmetric2\t#samples
+            baz\t0.25\t5
+            qux\t0.0625\t5
+            """
+        )
+        self.assertEqual(result.generate_report(), report)
+
+
+class ComboCountAnalysisResultTest(unittest.TestCase):
+    def test_inconsistent_feature(self) -> None:
+        with self.assertRaisesRegex(ValueError, r"^Inconsistent number of features"):
+            ComboCountAnalysisResult(
+                name="foo",
+                level="bar",
+                features=("feat1", "feat2"),
+                combo_counts=[(("xyz",), 123)],
+            )
+
+    def test_generate_report(self) -> None:
+        result = ComboCountAnalysisResult(
+            name="foo",
+            level="bar",
+            features=("feat1", "feat2"),
+            combo_counts=[
+                (("aaa", "bbb"), 123),
+                (("iii", "jjj"), 456),
+                (("xxx", "yyy"), 789),
+            ],
+        )
+        report = textwrap.dedent(
+            """\
+            feature combos for feat1, feat2
+            feat1\tfeat2\t#
+            aaa\tbbb\t123
+            iii\tjjj\t456
+            xxx\tyyy\t789
+            """
+        )
+        self.assertEqual(result.generate_report(), report)

--- a/explainaboard/explainaboard_main.py
+++ b/explainaboard/explainaboard_main.py
@@ -490,17 +490,17 @@ def main():
             reports.append(report)
 
             # print to the console
-            get_logger('report').info('--- Overall Performance')
+            logger = get_logger('report')
+
+            logger.info('--- Overall Performance')
             for overall_level in report.results.overall:
                 for metric_stat in overall_level:
-                    get_logger('report').info(
-                        f'{metric_stat.metric_name}\t{metric_stat.value}'
-                    )
-            get_logger('report').info('')
-            get_logger('report').info('--- Fine-grained Analyses')
+                    logger.info(f'{metric_stat.metric_name}\t{metric_stat.value}')
+            logger.info('')
+            logger.info('--- Fine-grained Analyses')
             for analysis in report.results.analyses:
                 if analysis is not None:
-                    analysis.print()
+                    logger.info(analysis.generate_report())
 
             if output_dir:
 

--- a/integration_tests/text_classification_test.py
+++ b/integration_tests/text_classification_test.py
@@ -62,6 +62,7 @@ class TextClassificationTest(unittest.TestCase):
             output_file_type=FileType.text,
         )
         data = loader.load()
+        self.assertEqual(len(data), 1821)
 
         metadata = {
             "task_name": TaskType.text_classification.value,
@@ -75,9 +76,7 @@ class TextClassificationTest(unittest.TestCase):
 
         sys_info = processor.process(metadata, data.samples)
         for analysis in sys_info.results.analyses:
-            analysis.print()
-
-        self.assertEqual(len(data), 1821)
+            analysis.generate_report()  # Discard generated reports
 
     def test_process(self):
         metadata = {


### PR DESCRIPTION
This PR replaces `AnalysisResult.print()` with `AnalysisResult.generate_report()` that generates multi-line string of corresponding reports.

Applying this change, `AnalysisResult` no longer has any direct side-effects to the environment, and the report string becomes testable as this PR added some unit tests. 

This PR also fixes some typing ambiguities around `AnalysisResult`s.