### PR TITLE
Move external_stats from MetricConfig to ExternalEvalConfig

### DIFF
--- a/explainaboard/metrics/external_eval.py
+++ b/explainaboard/metrics/external_eval.py
@@ -37,9 +37,10 @@ class ExternalEvalConfig(MetricConfig):
     n_annotators: int = 3
     categories: int = 5
     instruction: str = "Annotation instruction"
-    # The row size is equal to the number of test samples, the column size is
-    # equal to `n_annotators`. NOTE: Use of `list` rather than `numpy.ndarray`
-    # is to make this class serializable.
+    # The external statistics for metrics. The row size is equal to the number
+    # of test samples, the column size is equal to `n_annotators`.
+    # NOTE: Use of `list` rather than `numpy.ndarray` is to make this class
+    # serializable.
     external_stats: list[list[int]] | None = None
 
     def to_metric(self):

--- a/explainaboard/metrics/external_eval.py
+++ b/explainaboard/metrics/external_eval.py
@@ -37,9 +37,9 @@ class ExternalEvalConfig(MetricConfig):
     n_annotators: int = 3
     categories: int = 5
     instruction: str = "Annotation instruction"
-    # The row size is the number of test samples, the column size is equal to
-    # `n_annotators`. NOTE: Use of list rather than np.ndarray is to make this
-    # class serializable.
+    # The row size is equal to the number of test samples, the column size is
+    # equal to `n_annotators`. NOTE: Use of `list` rather than `numpy.ndarray`
+    # is to make this class serializable.
     external_stats: list[list[int]] | None = None
 
     def to_metric(self):

--- a/explainaboard/metrics/external_eval_test.py
+++ b/explainaboard/metrics/external_eval_test.py
@@ -43,17 +43,15 @@ class ExternalEvalTest(unittest.TestCase):
             true_data,
             pred_data,
             ExternalEvalConfig(
-                "ExternalEval",
-                n_annotators=2,
-                external_stats=np.array([[1, 2], [3, 4]]),
+                "ExternalEval", n_annotators=1, external_stats=np.array([[1], [2]])
             ),
         )
         self.assertEqual(len(stats), 2)
-        self.assertEqual(stats.num_statistics(), 2)
-        np.testing.assert_array_equal(stats.get_data(), np.array([[1, 2], [3, 4]]))
+        self.assertEqual(stats.num_statistics(), 1)
+        np.testing.assert_array_equal(stats.get_data(), np.array([[1], [2]]))
 
     def test_calc_stats_from_data_without_external_stats(self) -> None:
-        metric = ExternalEvalConfig("ExternalEval", n_annotators=1).to_metric()
+        metric = ExternalEvalConfig("ExternalEval", n_annotators=2).to_metric()
         true_data = [1, 0]
         pred_data = [1, 1]
         stats = metric.calc_stats_from_data(

--- a/explainaboard/metrics/external_eval_test.py
+++ b/explainaboard/metrics/external_eval_test.py
@@ -43,12 +43,12 @@ class ExternalEvalTest(unittest.TestCase):
             true_data,
             pred_data,
             ExternalEvalConfig(
-                "ExternalEval", n_annotators=1, external_stats=np.array([[1], [2]])
+                "ExternalEval", n_annotators=1, external_stats=np.array([[1], [0]])
             ),
         )
         self.assertEqual(len(stats), 2)
         self.assertEqual(stats.num_statistics(), 1)
-        np.testing.assert_array_equal(stats.get_data(), np.array([[1], [2]]))
+        np.testing.assert_array_equal(stats.get_data(), np.array([[1], [0]]))
 
     def test_calc_stats_from_data_without_external_stats(self) -> None:
         metric = ExternalEvalConfig("ExternalEval", n_annotators=2).to_metric()

--- a/explainaboard/metrics/external_eval_test.py
+++ b/explainaboard/metrics/external_eval_test.py
@@ -43,15 +43,17 @@ class ExternalEvalTest(unittest.TestCase):
             true_data,
             pred_data,
             ExternalEvalConfig(
-                "ExternalEval", n_annotators=1, external_stats=np.array([[1], [2]])
+                "ExternalEval",
+                n_annotators=2,
+                external_stats=np.array([[1, 2], [3, 4]]),
             ),
         )
         self.assertEqual(len(stats), 2)
-        self.assertEqual(stats.num_statistics(), 1)
-        np.testing.assert_array_equal(stats.get_data(), np.array([[1], [2]]))
+        self.assertEqual(stats.num_statistics(), 2)
+        np.testing.assert_array_equal(stats.get_data(), np.array([[1, 2], [3, 4]]))
 
     def test_calc_stats_from_data_without_external_stats(self) -> None:
-        metric = ExternalEvalConfig("ExternalEval", n_annotators=2).to_metric()
+        metric = ExternalEvalConfig("ExternalEval", n_annotators=1).to_metric()
         true_data = [1, 0]
         pred_data = [1, 1]
         stats = metric.calc_stats_from_data(

--- a/explainaboard/metrics/external_eval_test.py
+++ b/explainaboard/metrics/external_eval_test.py
@@ -4,7 +4,13 @@ from __future__ import annotations
 
 import unittest
 
-from explainaboard.metrics.external_eval import ExternalEval, ExternalEvalConfig
+import numpy as np
+
+from explainaboard.metrics.external_eval import (
+    ExternalEval,
+    ExternalEvalConfig,
+    UNANNOTATED_SYMBOL,
+)
 
 
 class ExternalEvalConfigTest(unittest.TestCase):
@@ -12,4 +18,47 @@ class ExternalEvalConfigTest(unittest.TestCase):
         self.assertIsInstance(
             ExternalEvalConfig("ExternalEval").to_metric(),
             ExternalEval,
+        )
+
+
+class ExternalEvalTest(unittest.TestCase):
+    def test_calc_stats_from_external(self) -> None:
+        metric = ExternalEvalConfig("ExternalEval", n_annotators=2).to_metric()
+        stats = metric.calc_stats_from_external(
+            ExternalEvalConfig(
+                "ExternalEval", n_annotators=2, external_stats=[[1, 2], [3, 4]]
+            )
+        )
+        self.assertEqual(len(stats), 2)
+        self.assertEqual(stats.num_statistics(), 2)
+        np.testing.assert_array_equal(stats.get_data(), np.array([[1, 2], [3, 4]]))
+
+    def test_calc_stats_from_data_with_external_stats(self) -> None:
+        metric = ExternalEvalConfig("ExternalEval", n_annotators=2).to_metric()
+        true_data = [1, 0]
+        pred_data = [1, 1]
+        stats = metric.calc_stats_from_data(
+            true_data,
+            pred_data,
+            ExternalEvalConfig(
+                "ExternalEval", n_annotators=1, external_stats=[[1], [0]]
+            ),
+        )
+        self.assertEqual(len(stats), 2)
+        self.assertEqual(stats.num_statistics(), 1)
+        np.testing.assert_array_equal(stats.get_data(), np.array([[1], [0]]))
+
+    def test_calc_stats_from_data_without_external_stats(self) -> None:
+        metric = ExternalEvalConfig("ExternalEval", n_annotators=2).to_metric()
+        true_data = [1, 0]
+        pred_data = [1, 1]
+        stats = metric.calc_stats_from_data(
+            true_data,
+            pred_data,
+            ExternalEvalConfig("ExternalEval", n_annotators=1),
+        )
+        self.assertEqual(len(stats), 2)
+        self.assertEqual(stats.num_statistics(), 1)
+        np.testing.assert_array_equal(
+            stats.get_data(), np.array([[UNANNOTATED_SYMBOL], [UNANNOTATED_SYMBOL]])
         )

--- a/explainaboard/metrics/external_eval_test.py
+++ b/explainaboard/metrics/external_eval_test.py
@@ -26,7 +26,9 @@ class ExternalEvalTest(unittest.TestCase):
         metric = ExternalEvalConfig("ExternalEval", n_annotators=2).to_metric()
         stats = metric.calc_stats_from_external(
             ExternalEvalConfig(
-                "ExternalEval", n_annotators=2, external_stats=[[1, 2], [3, 4]]
+                "ExternalEval",
+                n_annotators=2,
+                external_stats=np.array([[1, 2], [3, 4]]),
             )
         )
         self.assertEqual(len(stats), 2)
@@ -41,12 +43,12 @@ class ExternalEvalTest(unittest.TestCase):
             true_data,
             pred_data,
             ExternalEvalConfig(
-                "ExternalEval", n_annotators=1, external_stats=[[1], [0]]
+                "ExternalEval", n_annotators=1, external_stats=np.array([[1], [2]])
             ),
         )
         self.assertEqual(len(stats), 2)
         self.assertEqual(stats.num_statistics(), 1)
-        np.testing.assert_array_equal(stats.get_data(), np.array([[1], [0]]))
+        np.testing.assert_array_equal(stats.get_data(), np.array([[1], [2]]))
 
     def test_calc_stats_from_data_without_external_stats(self) -> None:
         metric = ExternalEvalConfig("ExternalEval", n_annotators=2).to_metric()

--- a/explainaboard/metrics/metric.py
+++ b/explainaboard/metrics/metric.py
@@ -56,8 +56,6 @@ class MetricConfig(dict):
     source_language: str | None = None
     target_language: str | None = None
     cls_name: str | None = None
-    # The external statistics for metrics
-    external_stats: np.ndarray | None = None
 
     def __post_init__(self):
         # Save the class name

--- a/integration_tests/summarization_test.py
+++ b/integration_tests/summarization_test.py
@@ -2,6 +2,7 @@ import os
 import unittest
 
 from integration_tests.utils import OPTIONAL_TEST_SUITES, test_artifacts_path
+import numpy as np
 
 from explainaboard import FileType, get_processor, Source, TaskType
 from explainaboard.loaders import get_loader_class
@@ -125,7 +126,7 @@ class SummarizationTest(unittest.TestCase):
                         aspect="fluency",
                         n_annotators=2,
                         categories=5,
-                        external_stats=[[2, 2], [1, 1], [3, 3]],
+                        external_stats=np.array([[2, 2], [1, 1], [3, 3]]),
                     )
                 ]
             },

--- a/integration_tests/summarization_test.py
+++ b/integration_tests/summarization_test.py
@@ -2,7 +2,6 @@ import os
 import unittest
 
 from integration_tests.utils import OPTIONAL_TEST_SUITES, test_artifacts_path
-import numpy as np
 
 from explainaboard import FileType, get_processor, Source, TaskType
 from explainaboard.loaders import get_loader_class
@@ -126,7 +125,7 @@ class SummarizationTest(unittest.TestCase):
                         aspect="fluency",
                         n_annotators=2,
                         categories=5,
-                        external_stats=np.array([[2, 2], [1, 1], [3, 3]]),
+                        external_stats=[[2, 2], [1, 1], [3, 3]],
                     )
                 ]
             },


### PR DESCRIPTION
As per the discussion in #428, this PR moves `external_stats` property from the `MetricConfig` class to the `ExternalEvalConfig` class. This is for separation of concerns: Derived classes from `MetricConfig` except `ExternalEvalConfig` don't need to know the property because they don't use that property. ~This PR also changes the type of the property from `numpy.ndarray` to `list[list[int]]` to make `ExternalEvalConfig` serializable.~