### PR TITLE
Remove unused EXTERNAL_METRICS

### DIFF
--- a/explainaboard/metrics/external_eval.py
+++ b/explainaboard/metrics/external_eval.py
@@ -17,11 +17,6 @@ from explainaboard.metrics.registry import metric_config_registry
 from explainaboard.utils.agreement import fleiss_kappa
 from explainaboard.utils.typing_utils import unwrap
 
-EXTERNAL_METRICS = [
-    "LikertScore_fluency",
-    "LikertScore_coherence",
-    "LikertScore_factuality",
-]
 UNANNOTATED_SYMBOL = -1
 
 


### PR DESCRIPTION
`EXTERNAL_METRICS` was introduced in #355, but the variable is no longer used in the codebase. This PR removes the unused list.