### PR TITLE
Disambiguate "conf"

### DIFF
--- a/data/reports/report_kg.json
+++ b/data/reports/report_kg.json
@@ -8,7 +8,7 @@
   "target_language": null,
   "reload_stat": true,
   "is_print_case": true,
-  "conf_value": 0.05,
+  "confidence_level": 0.05,
   "system_details": null,
   "metric_configs": [
     {

--- a/data/reports/report_kg.json
+++ b/data/reports/report_kg.json
@@ -8,7 +8,7 @@
   "target_language": null,
   "reload_stat": true,
   "is_print_case": true,
-  "confidence_level": 0.05,
+  "confidence_alpha": 0.05,
   "system_details": null,
   "metric_configs": [
     {

--- a/explainaboard/analysis/analyses.py
+++ b/explainaboard/analysis/analyses.py
@@ -65,7 +65,7 @@ class Analysis:
         cases: list[AnalysisCase],
         metrics: list[Metric],
         stats: list[MetricStats],
-        confidence_level: float,
+        confidence_alpha: float,
     ) -> AnalysisResult:
         """
         A super-class for analyses, which take in examples and analyze their features in
@@ -75,7 +75,7 @@ class Analysis:
           These could be examples, spans, tokens, etc.
         :param metrics: The metrics used to evaluate the cases.
         :param stats: The statistics calculated by each metric.
-        :param confidence_level: In the case that any significance analysis is
+        :param confidence_alpha: In the case that any significance analysis is
             performed, the inverse confidence level.
         """
         raise NotImplementedError
@@ -211,7 +211,7 @@ class BucketAnalysis(Analysis):
         cases: list[AnalysisCase],
         metrics: list[Metric],
         stats: list[MetricStats],
-        confidence_level: float,
+        confidence_alpha: float,
     ) -> AnalysisResult:
         # Preparation for bucketing
         bucket_func: Callable[..., list[AnalysisCaseCollection]] = getattr(
@@ -247,7 +247,7 @@ class BucketAnalysis(Analysis):
                 bucket_stats = metric_stat.filter(bucket_collection.samples)
                 metric_result = metric_func.evaluate_from_stats(
                     bucket_stats,
-                    confidence_level=confidence_level,
+                    confidence_alpha=confidence_alpha,
                 )
 
                 conf_low, conf_high = (
@@ -346,7 +346,7 @@ class ComboCountAnalysis(Analysis):
         cases: list[AnalysisCase],
         metrics: list[Metric],
         stats: list[MetricStats],
-        confidence_level: float,
+        confidence_alpha: float,
     ) -> AnalysisResult:
         for x in self.features:
             if x not in cases[0].features:

--- a/explainaboard/analysis/analyses.py
+++ b/explainaboard/analysis/analyses.py
@@ -65,7 +65,7 @@ class Analysis:
         cases: list[AnalysisCase],
         metrics: list[Metric],
         stats: list[MetricStats],
-        conf_value: float,
+        confidence_level: float,
     ) -> AnalysisResult:
         """
         A super-class for analyses, which take in examples and analyze their features in
@@ -75,8 +75,8 @@ class Analysis:
           These could be examples, spans, tokens, etc.
         :param metrics: The metrics used to evaluate the cases.
         :param stats: The statistics calculated by each metric.
-        :param conf_value: In the case that any significance analysis is performed, the
-          confidence level.
+        :param confidence_level: In the case that any significance analysis is
+            performed, the inverse confidence level.
         """
         raise NotImplementedError
 
@@ -211,7 +211,7 @@ class BucketAnalysis(Analysis):
         cases: list[AnalysisCase],
         metrics: list[Metric],
         stats: list[MetricStats],
-        conf_value: float,
+        confidence_level: float,
     ) -> AnalysisResult:
         # Preparation for bucketing
         bucket_func: Callable[..., list[AnalysisCaseCollection]] = getattr(
@@ -247,12 +247,12 @@ class BucketAnalysis(Analysis):
                 bucket_stats = metric_stat.filter(bucket_collection.samples)
                 metric_result = metric_func.evaluate_from_stats(
                     bucket_stats,
-                    conf_value=conf_value,
+                    confidence_level=confidence_level,
                 )
 
                 conf_low, conf_high = (
-                    metric_result.conf_interval
-                    if metric_result.conf_interval
+                    metric_result.confidence_interval
+                    if metric_result.confidence_interval
                     else (None, None)
                 )
 
@@ -346,7 +346,7 @@ class ComboCountAnalysis(Analysis):
         cases: list[AnalysisCase],
         metrics: list[Metric],
         stats: list[MetricStats],
-        conf_value: float,
+        confidence_level: float,
     ) -> AnalysisResult:
         for x in self.features:
             if x not in cases[0].features:

--- a/explainaboard/explainaboard_main.py
+++ b/explainaboard/explainaboard_main.py
@@ -259,10 +259,21 @@ def create_parser():
 
     parser.add_argument(
         '--conf-value',
+        dest="confidence_level",
+        type=float,
+        required=False,
+        help="Deprecated. use --confidence-level instead.",
+    )
+
+    parser.add_argument(
+        '--confidence-level',
         type=float,
         required=False,
         default=0.05,
-        help="the p-value with which to calculate the confidence interval",
+        help=(
+            "the *inverse* confidence level of confidence intervals. If you need to "
+            "set the confidence level to 0.95, set this value to 0.05."
+        ),
     )
 
     parser.add_argument(
@@ -454,7 +465,7 @@ def main():
             "source_language": source_language,
             "target_language": target_language,
             "reload_stat": reload_stat,
-            "conf_value": args.conf_value,
+            "confidence_level": args.confidence_level,
             "system_details": system_details,
             "custom_features": system_datasets[0].metadata.custom_features,
             "custom_analyses": system_datasets[0].metadata.custom_analyses,

--- a/explainaboard/explainaboard_main.py
+++ b/explainaboard/explainaboard_main.py
@@ -259,14 +259,14 @@ def create_parser():
 
     parser.add_argument(
         '--conf-value',
-        dest="confidence_level",
+        dest="confidence_alpha",
         type=float,
         required=False,
-        help="Deprecated. use --confidence-level instead.",
+        help="Deprecated. use --confidence-alpha instead.",
     )
 
     parser.add_argument(
-        '--confidence-level',
+        '--confidence-alpha',
         type=float,
         required=False,
         default=0.05,
@@ -465,7 +465,7 @@ def main():
             "source_language": source_language,
             "target_language": target_language,
             "reload_stat": reload_stat,
-            "confidence_level": args.confidence_level,
+            "confidence_alpha": args.confidence_alpha,
             "system_details": system_details,
             "custom_features": system_datasets[0].metadata.custom_features,
             "custom_analyses": system_datasets[0].metadata.custom_analyses,

--- a/explainaboard/info.py
+++ b/explainaboard/info.py
@@ -72,7 +72,7 @@ class SysOutputInfo:
     source_language: str | None = None
     target_language: str | None = None
     reload_stat: bool = True
-    conf_value: float = 0.05
+    confidence_level: float = 0.05
     system_details: Optional[dict] = None
     source_tokenizer: Optional[Tokenizer] = None
     target_tokenizer: Optional[Tokenizer] = None

--- a/explainaboard/info.py
+++ b/explainaboard/info.py
@@ -72,7 +72,7 @@ class SysOutputInfo:
     source_language: str | None = None
     target_language: str | None = None
     reload_stat: bool = True
-    confidence_level: float = 0.05
+    confidence_alpha: float = 0.05
     system_details: Optional[dict] = None
     source_tokenizer: Optional[Tokenizer] = None
     target_tokenizer: Optional[Tokenizer] = None

--- a/explainaboard/metrics/external_eval.py
+++ b/explainaboard/metrics/external_eval.py
@@ -136,12 +136,12 @@ class ExternalEval(Metric):
     def evaluate_from_stats(
         self,
         stats: MetricStats,
-        confidence_level: Optional[float] = None,
+        confidence_alpha: Optional[float] = None,
         config: Optional[MetricConfig] = None,
     ) -> MetricResult:
         """Return an evaluation result over stats.
         :param stats: pre-computed metric stats
-        :param confidence_level: if set to not None, must be a number between 0 and 1,
+        :param confidence_alpha: if set to not None, must be a number between 0 and 1,
             indicating the inverse confidence level of the confidence interval
         :param config: a configuration to over-ride the default for this object
         :return: a resulting metric value
@@ -151,14 +151,14 @@ class ExternalEval(Metric):
         agreement = self.calc_agreement(stats)
         value = self.calc_metric_from_aggregate(agg_stats, config)
         confidence_interval = (
-            self.calc_confidence_interval(stats, confidence_level)
-            if confidence_level
+            self.calc_confidence_interval(stats, confidence_alpha)
+            if confidence_alpha
             else None
         )
         return MetricResult(
             config,
             float(value),
             confidence_interval,
-            confidence_level,
+            confidence_alpha,
             ExternalEvalResult(agreement),
         )

--- a/explainaboard/metrics/external_eval.py
+++ b/explainaboard/metrics/external_eval.py
@@ -136,13 +136,13 @@ class ExternalEval(Metric):
     def evaluate_from_stats(
         self,
         stats: MetricStats,
-        conf_value: Optional[float] = None,
+        confidence_level: Optional[float] = None,
         config: Optional[MetricConfig] = None,
     ) -> MetricResult:
         """Return an evaluation result over stats.
         :param stats: pre-computed metric stats
-        :param conf_value: if set to not None, must be a number between 0 and 1,
-            indicating the p-value of confidence intervals
+        :param confidence_level: if set to not None, must be a number between 0 and 1,
+            indicating the inverse confidence level of the confidence interval
         :param config: a configuration to over-ride the default for this object
         :return: a resulting metric value
         """
@@ -150,13 +150,15 @@ class ExternalEval(Metric):
         agg_stats = self.aggregate_stats(stats)
         agreement = self.calc_agreement(stats)
         value = self.calc_metric_from_aggregate(agg_stats, config)
-        conf_interval = (
-            self.calc_confidence_interval(stats, conf_value) if conf_value else None
+        confidence_interval = (
+            self.calc_confidence_interval(stats, confidence_level)
+            if confidence_level
+            else None
         )
         return MetricResult(
             config,
             float(value),
-            conf_interval,
-            conf_value,
+            confidence_interval,
+            confidence_level,
             ExternalEvalResult(agreement),
         )

--- a/explainaboard/metrics/metric.py
+++ b/explainaboard/metrics/metric.py
@@ -26,9 +26,9 @@ class MetricResult:
     # Metric value
     value: float
     # Confidence interval of the metric values
-    conf_interval: Optional[tuple[float, float]] = None
-    # The p-value of the confidence interval
-    conf_value: Optional[float] = None
+    confidence_interval: Optional[tuple[float, float]] = None
+    # The inverse confidence level of the confidence interval
+    confidence_level: Optional[float] = None
     # Extra data for
     auxiliary_result: AuxiliaryMetricResult | None = None
 
@@ -37,10 +37,10 @@ class MetricResult:
             'config': self.config.__dict__,
             'value': self.value,
         }
-        if self.conf_interval is not None:
-            ret['conf_interval'] = self.conf_interval
-        if self.conf_value is not None:
-            ret['conf_value'] = self.conf_value
+        if self.confidence_interval is not None:
+            ret['confidence_interval'] = self.confidence_interval
+        if self.confidence_level is not None:
+            ret['confidence_level'] = self.confidence_level
         return ret
 
 
@@ -302,20 +302,20 @@ class Metric:
     def calc_confidence_interval(
         self,
         stats: MetricStats,
-        conf_value: float,
+        confidence_level: float,
         n_samples: int = 1000,
         prop_samples: float = 0.5,
         config: Optional[MetricConfig] = None,
     ) -> tuple[float, float] | None:
         """
         :param stats: sufficient statistics as calculated by calc_stats_from_data
-        :param conf_value: the p-value of the interval
+        :param confidence_level: the inverse confidence level of the confidence interval
         :param n_samples: the number of bootstrapping samples
         :param prop_samples: the proportion of samples to sample each time
         :param config: a configuration to over-ride the default for this object
         """
-        if conf_value <= 0.0 or conf_value >= 1.0:
-            raise ValueError(f'Bad confidence value {conf_value}')
+        if confidence_level <= 0.0 or confidence_level >= 1.0:
+            raise ValueError(f'Bad confidence value {confidence_level}')
 
         stats_data = stats.get_batch_data() if stats.is_batched() else stats.get_data()
         num_stats = stats.num_statistics()
@@ -336,7 +336,7 @@ class Metric:
             if my_std == 0.0:
                 return (float(my_mean), float(my_mean))
             return stats_t.interval(
-                alpha=conf_value,
+                alpha=confidence_level,
                 df=stats_data.shape[-2] - 1,
                 loc=my_mean,
                 scale=my_std,
@@ -353,45 +353,49 @@ class Metric:
             agg_stats = self.aggregate_stats(filt_stats)
             samp_results = self.calc_metric_from_aggregate(agg_stats, config)
             samp_results.sort()
-            low = int(n_samples * conf_value / 2.0)
-            high = int(n_samples * (1.0 - conf_value / 2.0))
+            low = int(n_samples * confidence_level / 2.0)
+            high = int(n_samples * (1.0 - confidence_level / 2.0))
             return float(samp_results[low]), float(samp_results[high])
 
     def evaluate_from_stats(
         self,
         stats: MetricStats,
-        conf_value: Optional[float] = None,
+        confidence_level: Optional[float] = None,
         config: Optional[MetricConfig] = None,
     ) -> MetricResult:
         """Return an evaluation result over stats.
         :param stats: pre-computed metric stats
-        :param conf_value: if set to not None, must be a number between 0 and 1,
-            indicating the p-value of confidence intervals
+        :param confidence_level: if set to not None, must be a number between 0 and 1,
+            indicating the inverse confidence level of confidence intervals
         :param config: a configuration to over-ride the default for this object
         :return: a resulting metric value
         """
         actual_config = unwrap_or(config, self.config)
         agg_stats = self.aggregate_stats(stats)
         value = self.calc_metric_from_aggregate(agg_stats, actual_config)
-        conf_interval = (
-            self.calc_confidence_interval(stats, conf_value) if conf_value else None
+        confidence_interval = (
+            self.calc_confidence_interval(stats, confidence_level)
+            if confidence_level
+            else None
         )
-        return MetricResult(actual_config, float(value), conf_interval, conf_value)
+        return MetricResult(
+            actual_config, float(value), confidence_interval, confidence_level
+        )
 
     def evaluate(
         self,
         true_data: list,
         pred_data: list,
-        conf_value: Optional[float] = None,
+        confidence_level: Optional[float] = None,
         config: Optional[MetricConfig] = None,
     ) -> MetricResult:
         """Return an evaluation result over true data and predicted data.
         :param true_data: gold-standard data
         :param pred_data: predicted data
-        :param conf_value: if set to not None, must be a number between 0 and 1,
-            indicating the p-value of confidence intervals
+        :param confidence_level: if set to not None, must be a number between 0 and 1,
+            indicating the inverse confidence level of confidence intervals
         :param config: a configuration to over-ride the default for this object
         :return: a resulting metric value
         """
         stats = self.calc_stats_from_data(true_data, pred_data, config)
-        return self.evaluate_from_stats(stats, conf_value, config)
+        return self.evaluate_from_stats(stats, confidence_level, config)

--- a/explainaboard/processors/processor.py
+++ b/explainaboard/processors/processor.py
@@ -261,7 +261,7 @@ class Processor(metaclass=abc.ABCMeta):
                         cases=analysis_cases[level_id],
                         metrics=metrics[level_id],
                         stats=metric_stats[level_id],
-                        confidence_level=sys_info.confidence_level,
+                        confidence_alpha=sys_info.confidence_alpha,
                     )
                 )
             except Exception as ex:
@@ -333,7 +333,7 @@ class Processor(metaclass=abc.ABCMeta):
             ):
                 metric_result = metric_cfg.to_metric().evaluate_from_stats(
                     metric_stat,
-                    confidence_level=sys_info.confidence_level,
+                    confidence_alpha=sys_info.confidence_alpha,
                 )
 
                 confidence_low, confidence_high = (

--- a/explainaboard/processors/processor.py
+++ b/explainaboard/processors/processor.py
@@ -261,7 +261,7 @@ class Processor(metaclass=abc.ABCMeta):
                         cases=analysis_cases[level_id],
                         metrics=metrics[level_id],
                         stats=metric_stats[level_id],
-                        conf_value=sys_info.conf_value,
+                        confidence_level=sys_info.confidence_level,
                     )
                 )
             except Exception as ex:
@@ -333,20 +333,20 @@ class Processor(metaclass=abc.ABCMeta):
             ):
                 metric_result = metric_cfg.to_metric().evaluate_from_stats(
                     metric_stat,
-                    conf_value=sys_info.conf_value,
+                    confidence_level=sys_info.confidence_level,
                 )
 
-                conf_low, conf_high = (
-                    metric_result.conf_interval
-                    if metric_result.conf_interval
+                confidence_low, confidence_high = (
+                    metric_result.confidence_interval
+                    if metric_result.confidence_interval
                     else (None, None)
                 )
 
                 overall_performance = Performance(
                     metric_name=metric_cfg.name,
                     value=metric_result.value,
-                    confidence_score_low=conf_low,
-                    confidence_score_high=conf_high,
+                    confidence_score_low=confidence_low,
+                    confidence_score_high=confidence_high,
                 )
                 my_results.append(overall_performance)
             overall_results.append(my_results)

--- a/explainaboard/visualizers/draw_charts.py
+++ b/explainaboard/visualizers/draw_charts.py
@@ -84,17 +84,19 @@ def plot_combo_counts(
                 f'plot_combo_counts currently only supports feature combinations of '
                 f'size 2, but got {feature_names}'
             )
-        conf_matrix = np.zeros([len(x) for x in feature_maps])
+        confusion_matrix = np.zeros([len(x) for x in feature_maps])
         for feats, count in unwrap(combo_result.combo_counts):
-            conf_matrix[feature_maps[0][feats[0]], feature_maps[1][feats[1]]] = count
+            confusion_matrix[
+                feature_maps[0][feats[0]], feature_maps[1][feats[1]]
+            ] = count
         fig, ax = plt.subplots(figsize=(7.5, 7.5))
-        ax.matshow(conf_matrix, cmap=plt.cm.Blues, alpha=0.3)
-        for i in range(conf_matrix.shape[0]):
-            for j in range(conf_matrix.shape[1]):
+        ax.matshow(confusion_matrix, cmap=plt.cm.Blues, alpha=0.3)
+        for i in range(confusion_matrix.shape[0]):
+            for j in range(confusion_matrix.shape[1]):
                 ax.text(
                     x=j,
                     y=i,
-                    s=conf_matrix[i, j],
+                    s=confusion_matrix[i, j],
                     va='center',
                     ha='center',
                     size='xx-large',

--- a/integration_tests/artifacts/reports/test-ar_6960.json
+++ b/integration_tests/artifacts/reports/test-ar_6960.json
@@ -9,7 +9,7 @@
     "reload_stat": true,
     "is_print_case": true,
     "language": "ar",
-    "conf_value": 0.05,
+    "confidence_level": 0.05,
     "features": {
         "text": {
             "dtype": "string",

--- a/integration_tests/artifacts/reports/test-ar_6960.json
+++ b/integration_tests/artifacts/reports/test-ar_6960.json
@@ -9,7 +9,7 @@
     "reload_stat": true,
     "is_print_case": true,
     "language": "ar",
-    "confidence_level": 0.05,
+    "confidence_alpha": 0.05,
     "features": {
         "text": {
             "dtype": "string",

--- a/integration_tests/artifacts/reports/test-de_7213.json
+++ b/integration_tests/artifacts/reports/test-de_7213.json
@@ -9,7 +9,7 @@
     "reload_stat": true,
     "is_print_case": true,
     "language": "de",
-    "conf_value": 0.05,
+    "confidence_level": 0.05,
     "features": {
         "text": {
             "dtype": "string",

--- a/integration_tests/artifacts/reports/test-de_7213.json
+++ b/integration_tests/artifacts/reports/test-de_7213.json
@@ -9,7 +9,7 @@
     "reload_stat": true,
     "is_print_case": true,
     "language": "de",
-    "confidence_level": 0.05,
+    "confidence_alpha": 0.05,
     "features": {
         "text": {
             "dtype": "string",

--- a/integration_tests/artifacts/reports/test-de_9330.json
+++ b/integration_tests/artifacts/reports/test-de_9330.json
@@ -9,7 +9,7 @@
     "reload_stat": true,
     "is_print_case": true,
     "language": "de",
-    "conf_value": 0.05,
+    "confidence_level": 0.05,
     "features": {
         "text": {
             "dtype": "string",

--- a/integration_tests/artifacts/reports/test-de_9330.json
+++ b/integration_tests/artifacts/reports/test-de_9330.json
@@ -9,7 +9,7 @@
     "reload_stat": true,
     "is_print_case": true,
     "language": "de",
-    "confidence_level": 0.05,
+    "confidence_alpha": 0.05,
     "features": {
         "text": {
             "dtype": "string",

--- a/integration_tests/artifacts/reports/test-de_9335.json
+++ b/integration_tests/artifacts/reports/test-de_9335.json
@@ -9,7 +9,7 @@
     "reload_stat": true,
     "is_print_case": true,
     "language": "de",
-    "conf_value": 0.05,
+    "confidence_level": 0.05,
     "features": {
         "text": {
             "dtype": "string",

--- a/integration_tests/artifacts/reports/test-de_9335.json
+++ b/integration_tests/artifacts/reports/test-de_9335.json
@@ -9,7 +9,7 @@
     "reload_stat": true,
     "is_print_case": true,
     "language": "de",
-    "confidence_level": 0.05,
+    "confidence_alpha": 0.05,
     "features": {
         "text": {
             "dtype": "string",

--- a/integration_tests/artifacts/reports/test-en_7676.json
+++ b/integration_tests/artifacts/reports/test-en_7676.json
@@ -9,7 +9,7 @@
     "reload_stat": true,
     "is_print_case": true,
     "language": "en",
-    "conf_value": 0.05,
+    "confidence_level": 0.05,
     "features": {
         "text": {
             "dtype": "string",

--- a/integration_tests/artifacts/reports/test-en_7676.json
+++ b/integration_tests/artifacts/reports/test-en_7676.json
@@ -9,7 +9,7 @@
     "reload_stat": true,
     "is_print_case": true,
     "language": "en",
-    "confidence_level": 0.05,
+    "confidence_alpha": 0.05,
     "features": {
         "text": {
             "dtype": "string",

--- a/integration_tests/artifacts/reports/test-en_7872.json
+++ b/integration_tests/artifacts/reports/test-en_7872.json
@@ -9,7 +9,7 @@
     "reload_stat": true,
     "is_print_case": true,
     "language": "en",
-    "conf_value": 0.05,
+    "confidence_level": 0.05,
     "features": {
         "text": {
             "dtype": "string",

--- a/integration_tests/artifacts/reports/test-en_7872.json
+++ b/integration_tests/artifacts/reports/test-en_7872.json
@@ -9,7 +9,7 @@
     "reload_stat": true,
     "is_print_case": true,
     "language": "en",
-    "confidence_level": 0.05,
+    "confidence_alpha": 0.05,
     "features": {
         "text": {
             "dtype": "string",

--- a/integration_tests/artifacts/reports/test-en_8113.json
+++ b/integration_tests/artifacts/reports/test-en_8113.json
@@ -10,7 +10,7 @@
     "reload_stat": true,
     "is_print_case": true,
     "language": "en",
-    "conf_value": 0.05,
+    "confidence_level": 0.05,
     "features": {
         "title": {
             "dtype": "string",

--- a/integration_tests/artifacts/reports/test-en_8113.json
+++ b/integration_tests/artifacts/reports/test-en_8113.json
@@ -10,7 +10,7 @@
     "reload_stat": true,
     "is_print_case": true,
     "language": "en",
-    "confidence_level": 0.05,
+    "confidence_alpha": 0.05,
     "features": {
         "title": {
             "dtype": "string",

--- a/integration_tests/artifacts/reports/test-en_8235.json
+++ b/integration_tests/artifacts/reports/test-en_8235.json
@@ -10,7 +10,7 @@
     "reload_stat": true,
     "is_print_case": true,
     "language": "en",
-    "conf_value": 0.05,
+    "confidence_level": 0.05,
     "features": {
         "title": {
             "dtype": "string",

--- a/integration_tests/artifacts/reports/test-en_8235.json
+++ b/integration_tests/artifacts/reports/test-en_8235.json
@@ -10,7 +10,7 @@
     "reload_stat": true,
     "is_print_case": true,
     "language": "en",
-    "confidence_level": 0.05,
+    "confidence_alpha": 0.05,
     "features": {
         "title": {
             "dtype": "string",

--- a/integration_tests/artifacts/reports/test-en_9152.json
+++ b/integration_tests/artifacts/reports/test-en_9152.json
@@ -9,7 +9,7 @@
     "reload_stat": true,
     "is_print_case": true,
     "language": "en",
-    "conf_value": 0.05,
+    "confidence_level": 0.05,
     "features": {
         "text": {
             "dtype": "string",

--- a/integration_tests/artifacts/reports/test-en_9152.json
+++ b/integration_tests/artifacts/reports/test-en_9152.json
@@ -9,7 +9,7 @@
     "reload_stat": true,
     "is_print_case": true,
     "language": "en",
-    "confidence_level": 0.05,
+    "confidence_alpha": 0.05,
     "features": {
         "text": {
             "dtype": "string",

--- a/integration_tests/artifacts/reports/test-en_9200.json
+++ b/integration_tests/artifacts/reports/test-en_9200.json
@@ -9,7 +9,7 @@
     "reload_stat": true,
     "is_print_case": true,
     "language": "en",
-    "conf_value": 0.05,
+    "confidence_level": 0.05,
     "features": {
         "text": {
             "dtype": "string",

--- a/integration_tests/artifacts/reports/test-en_9200.json
+++ b/integration_tests/artifacts/reports/test-en_9200.json
@@ -9,7 +9,7 @@
     "reload_stat": true,
     "is_print_case": true,
     "language": "en",
-    "confidence_level": 0.05,
+    "confidence_alpha": 0.05,
     "features": {
         "text": {
             "dtype": "string",

--- a/integration_tests/artifacts/reports/test-es_7377.json
+++ b/integration_tests/artifacts/reports/test-es_7377.json
@@ -9,7 +9,7 @@
     "reload_stat": true,
     "is_print_case": true,
     "language": "es",
-    "confidence_level": 0.05,
+    "confidence_alpha": 0.05,
     "features": {
         "text": {
             "dtype": "string",

--- a/integration_tests/artifacts/reports/test-es_7377.json
+++ b/integration_tests/artifacts/reports/test-es_7377.json
@@ -9,7 +9,7 @@
     "reload_stat": true,
     "is_print_case": true,
     "language": "es",
-    "conf_value": 0.05,
+    "confidence_level": 0.05,
     "features": {
         "text": {
             "dtype": "string",

--- a/integration_tests/artifacts/reports/test-es_7678.json
+++ b/integration_tests/artifacts/reports/test-es_7678.json
@@ -9,7 +9,7 @@
     "reload_stat": true,
     "is_print_case": true,
     "language": "es",
-    "confidence_level": 0.05,
+    "confidence_alpha": 0.05,
     "features": {
         "text": {
             "dtype": "string",

--- a/integration_tests/artifacts/reports/test-es_7678.json
+++ b/integration_tests/artifacts/reports/test-es_7678.json
@@ -9,7 +9,7 @@
     "reload_stat": true,
     "is_print_case": true,
     "language": "es",
-    "conf_value": 0.05,
+    "confidence_level": 0.05,
     "features": {
         "text": {
             "dtype": "string",

--- a/integration_tests/artifacts/reports/test-es_7687.json
+++ b/integration_tests/artifacts/reports/test-es_7687.json
@@ -10,7 +10,7 @@
     "reload_stat": true,
     "is_print_case": true,
     "language": "es",
-    "confidence_level": 0.05,
+    "confidence_alpha": 0.05,
     "features": {
         "title": {
             "dtype": "string",

--- a/integration_tests/artifacts/reports/test-es_7687.json
+++ b/integration_tests/artifacts/reports/test-es_7687.json
@@ -10,7 +10,7 @@
     "reload_stat": true,
     "is_print_case": true,
     "language": "es",
-    "conf_value": 0.05,
+    "confidence_level": 0.05,
     "features": {
         "title": {
             "dtype": "string",

--- a/integration_tests/artifacts/reports/test-es_7698.json
+++ b/integration_tests/artifacts/reports/test-es_7698.json
@@ -10,7 +10,7 @@
     "reload_stat": true,
     "is_print_case": true,
     "language": "es",
-    "confidence_level": 0.05,
+    "confidence_alpha": 0.05,
     "features": {
         "title": {
             "dtype": "string",

--- a/integration_tests/artifacts/reports/test-es_7698.json
+++ b/integration_tests/artifacts/reports/test-es_7698.json
@@ -10,7 +10,7 @@
     "reload_stat": true,
     "is_print_case": true,
     "language": "es",
-    "conf_value": 0.05,
+    "confidence_level": 0.05,
     "features": {
         "title": {
             "dtype": "string",

--- a/integration_tests/artifacts/reports/test-es_9340.json
+++ b/integration_tests/artifacts/reports/test-es_9340.json
@@ -9,7 +9,7 @@
     "reload_stat": true,
     "is_print_case": true,
     "language": "es",
-    "confidence_level": 0.05,
+    "confidence_alpha": 0.05,
     "features": {
         "text": {
             "dtype": "string",

--- a/integration_tests/artifacts/reports/test-es_9340.json
+++ b/integration_tests/artifacts/reports/test-es_9340.json
@@ -9,7 +9,7 @@
     "reload_stat": true,
     "is_print_case": true,
     "language": "es",
-    "conf_value": 0.05,
+    "confidence_level": 0.05,
     "features": {
         "text": {
             "dtype": "string",

--- a/integration_tests/artifacts/reports/test-es_9342.json
+++ b/integration_tests/artifacts/reports/test-es_9342.json
@@ -9,7 +9,7 @@
     "reload_stat": true,
     "is_print_case": true,
     "language": "es",
-    "confidence_level": 0.05,
+    "confidence_alpha": 0.05,
     "features": {
         "text": {
             "dtype": "string",

--- a/integration_tests/artifacts/reports/test-es_9342.json
+++ b/integration_tests/artifacts/reports/test-es_9342.json
@@ -9,7 +9,7 @@
     "reload_stat": true,
     "is_print_case": true,
     "language": "es",
-    "conf_value": 0.05,
+    "confidence_level": 0.05,
     "features": {
         "text": {
             "dtype": "string",

--- a/integration_tests/artifacts/reports/test-fr_9262.json
+++ b/integration_tests/artifacts/reports/test-fr_9262.json
@@ -9,7 +9,7 @@
     "reload_stat": true,
     "is_print_case": true,
     "language": "fr",
-    "confidence_level": 0.05,
+    "confidence_alpha": 0.05,
     "features": {
         "text": {
             "dtype": "string",

--- a/integration_tests/artifacts/reports/test-fr_9262.json
+++ b/integration_tests/artifacts/reports/test-fr_9262.json
@@ -9,7 +9,7 @@
     "reload_stat": true,
     "is_print_case": true,
     "language": "fr",
-    "conf_value": 0.05,
+    "confidence_level": 0.05,
     "features": {
         "text": {
             "dtype": "string",

--- a/integration_tests/artifacts/reports/test-fr_9332.json
+++ b/integration_tests/artifacts/reports/test-fr_9332.json
@@ -9,7 +9,7 @@
     "reload_stat": true,
     "is_print_case": true,
     "language": "fr",
-    "confidence_level": 0.05,
+    "confidence_alpha": 0.05,
     "features": {
         "text": {
             "dtype": "string",

--- a/integration_tests/artifacts/reports/test-fr_9332.json
+++ b/integration_tests/artifacts/reports/test-fr_9332.json
@@ -9,7 +9,7 @@
     "reload_stat": true,
     "is_print_case": true,
     "language": "fr",
-    "conf_value": 0.05,
+    "confidence_level": 0.05,
     "features": {
         "text": {
             "dtype": "string",

--- a/integration_tests/artifacts/reports/test-ja_9137.json
+++ b/integration_tests/artifacts/reports/test-ja_9137.json
@@ -9,7 +9,7 @@
     "reload_stat": true,
     "is_print_case": true,
     "language": "ja",
-    "conf_value": 0.05,
+    "confidence_level": 0.05,
     "features": {
         "text": {
             "dtype": "string",

--- a/integration_tests/artifacts/reports/test-ja_9137.json
+++ b/integration_tests/artifacts/reports/test-ja_9137.json
@@ -9,7 +9,7 @@
     "reload_stat": true,
     "is_print_case": true,
     "language": "ja",
-    "confidence_level": 0.05,
+    "confidence_alpha": 0.05,
     "features": {
         "text": {
             "dtype": "string",

--- a/integration_tests/artifacts/reports/test-ja_9150.json
+++ b/integration_tests/artifacts/reports/test-ja_9150.json
@@ -9,7 +9,7 @@
     "reload_stat": true,
     "is_print_case": true,
     "language": "ja",
-    "conf_value": 0.05,
+    "confidence_level": 0.05,
     "features": {
         "text": {
             "dtype": "string",

--- a/integration_tests/artifacts/reports/test-ja_9150.json
+++ b/integration_tests/artifacts/reports/test-ja_9150.json
@@ -9,7 +9,7 @@
     "reload_stat": true,
     "is_print_case": true,
     "language": "ja",
-    "confidence_level": 0.05,
+    "confidence_alpha": 0.05,
     "features": {
         "text": {
             "dtype": "string",

--- a/integration_tests/artifacts/reports/test-zh_7117.json
+++ b/integration_tests/artifacts/reports/test-zh_7117.json
@@ -9,7 +9,7 @@
     "reload_stat": true,
     "is_print_case": true,
     "language": "zh",
-    "conf_value": 0.05,
+    "confidence_level": 0.05,
     "features": {
         "text": {
             "dtype": "string",

--- a/integration_tests/artifacts/reports/test-zh_7117.json
+++ b/integration_tests/artifacts/reports/test-zh_7117.json
@@ -9,7 +9,7 @@
     "reload_stat": true,
     "is_print_case": true,
     "language": "zh",
-    "confidence_level": 0.05,
+    "confidence_alpha": 0.05,
     "features": {
         "text": {
             "dtype": "string",

--- a/integration_tests/artifacts/reports/test-zh_7311.json
+++ b/integration_tests/artifacts/reports/test-zh_7311.json
@@ -9,7 +9,7 @@
     "reload_stat": true,
     "is_print_case": true,
     "language": "zh",
-    "conf_value": 0.05,
+    "confidence_level": 0.05,
     "features": {
         "text": {
             "dtype": "string",

--- a/integration_tests/artifacts/reports/test-zh_7311.json
+++ b/integration_tests/artifacts/reports/test-zh_7311.json
@@ -9,7 +9,7 @@
     "reload_stat": true,
     "is_print_case": true,
     "language": "zh",
-    "confidence_level": 0.05,
+    "confidence_alpha": 0.05,
     "features": {
         "text": {
             "dtype": "string",

--- a/integration_tests/artifacts/reports/test-zh_7396.json
+++ b/integration_tests/artifacts/reports/test-zh_7396.json
@@ -10,7 +10,7 @@
     "reload_stat": true,
     "is_print_case": true,
     "language": "zh",
-    "confidence_level": 0.05,
+    "confidence_alpha": 0.05,
     "features": {
         "title": {
             "dtype": "string",

--- a/integration_tests/artifacts/reports/test-zh_7396.json
+++ b/integration_tests/artifacts/reports/test-zh_7396.json
@@ -10,7 +10,7 @@
     "reload_stat": true,
     "is_print_case": true,
     "language": "zh",
-    "conf_value": 0.05,
+    "confidence_level": 0.05,
     "features": {
         "title": {
             "dtype": "string",

--- a/integration_tests/artifacts/reports/test-zh_7443.json
+++ b/integration_tests/artifacts/reports/test-zh_7443.json
@@ -10,7 +10,7 @@
     "reload_stat": true,
     "is_print_case": true,
     "language": "zh",
-    "confidence_level": 0.05,
+    "confidence_alpha": 0.05,
     "features": {
         "title": {
             "dtype": "string",

--- a/integration_tests/artifacts/reports/test-zh_7443.json
+++ b/integration_tests/artifacts/reports/test-zh_7443.json
@@ -10,7 +10,7 @@
     "reload_stat": true,
     "is_print_case": true,
     "language": "zh",
-    "conf_value": 0.05,
+    "confidence_level": 0.05,
     "features": {
         "title": {
             "dtype": "string",

--- a/integration_tests/artifacts/reports/test-zh_8680.json
+++ b/integration_tests/artifacts/reports/test-zh_8680.json
@@ -9,7 +9,7 @@
     "reload_stat": true,
     "is_print_case": true,
     "language": "zh",
-    "conf_value": 0.05,
+    "confidence_level": 0.05,
     "features": {
         "text": {
             "dtype": "string",

--- a/integration_tests/artifacts/reports/test-zh_8680.json
+++ b/integration_tests/artifacts/reports/test-zh_8680.json
@@ -9,7 +9,7 @@
     "reload_stat": true,
     "is_print_case": true,
     "language": "zh",
-    "confidence_level": 0.05,
+    "confidence_alpha": 0.05,
     "features": {
         "text": {
             "dtype": "string",

--- a/integration_tests/artifacts/reports/test-zh_8705.json
+++ b/integration_tests/artifacts/reports/test-zh_8705.json
@@ -9,7 +9,7 @@
     "reload_stat": true,
     "is_print_case": true,
     "language": "zh",
-    "conf_value": 0.05,
+    "confidence_level": 0.05,
     "features": {
         "text": {
             "dtype": "string",

--- a/integration_tests/artifacts/reports/test-zh_8705.json
+++ b/integration_tests/artifacts/reports/test-zh_8705.json
@@ -9,7 +9,7 @@
     "reload_stat": true,
     "is_print_case": true,
     "language": "zh",
-    "confidence_level": 0.05,
+    "confidence_alpha": 0.05,
     "features": {
         "text": {
             "dtype": "string",

--- a/integration_tests/machine_translation_test.py
+++ b/integration_tests/machine_translation_test.py
@@ -107,8 +107,8 @@ class MachineTranslationTest(unittest.TestCase):
         sys_info = processor.process(
             dataclasses.asdict(data.metadata), data.samples, skip_failed_analyses=True
         )
-        analysis_map = {x.name: x for x in sys_info.results.analyses if x is not None}
-        self.assertTrue('num_capital_letters' in analysis_map)
+        analysis_names = [x.name for x in sys_info.results.analyses if x is not None]
+        self.assertIn('num_capital_letters', analysis_names)
 
 
 if __name__ == '__main__':

--- a/integration_tests/metric_test.py
+++ b/integration_tests/metric_test.py
@@ -24,7 +24,7 @@ class MetricTest(unittest.TestCase):
         ).to_metric()
         true = ['a', 'b', 'a', 'b', 'a', 'b']
         pred = ['a', 'b', 'a', 'b', 'b', 'a']
-        result = metric.evaluate(true, pred, confidence_level=0.05)
+        result = metric.evaluate(true, pred, confidence_alpha=0.05)
         self.assertAlmostEqual(result.value, 2.0 / 3.0)
 
     def test_correct_score(self):
@@ -33,7 +33,7 @@ class MetricTest(unittest.TestCase):
         ).to_metric()
         true = ['a', 'b', 'a', 'b', 'a', 'b']
         pred = ['a', 'b', 'a', 'b', 'b', 'a']
-        result = metric.evaluate(true, pred, confidence_level=0.05)
+        result = metric.evaluate(true, pred, confidence_alpha=0.05)
         self.assertAlmostEqual(result.value, 4)
 
     def test_seq_correct_score(self):
@@ -80,7 +80,7 @@ class MetricTest(unittest.TestCase):
         pred = ['a', 'b', 'a', 'b', 'b', 'a', 'c', 'a']
 
         sklearn_f1 = f1_score(true, pred, average='micro')
-        result = metric.evaluate(true, pred, confidence_level=0.05)
+        result = metric.evaluate(true, pred, confidence_alpha=0.05)
         self.assertAlmostEqual(result.value, sklearn_f1)
 
     def test_f1_macro(self):
@@ -90,14 +90,14 @@ class MetricTest(unittest.TestCase):
         true = ['a', 'b', 'a', 'b', 'a', 'a', 'c', 'c']
         pred = ['a', 'b', 'a', 'b', 'b', 'a', 'c', 'a']
         sklearn_f1 = f1_score(true, pred, average='macro')
-        result = metric.evaluate(true, pred, confidence_level=None)
+        result = metric.evaluate(true, pred, confidence_alpha=None)
         self.assertAlmostEqual(result.value, sklearn_f1)
 
     def test_hits(self):
         metric = explainaboard.metrics.ranking.HitsConfig(name='Hits').to_metric()
         true = ['a', 'b', 'a', 'b', 'a', 'b']
         pred = [['a', 'b'], ['c', 'd'], ['c', 'a'], ['a', 'c'], ['b', 'a'], ['a', 'b']]
-        result = metric.evaluate(true, pred, confidence_level=0.05)
+        result = metric.evaluate(true, pred, confidence_alpha=0.05)
         self.assertAlmostEqual(result.value, 4.0 / 6.0)
 
     def test_mrr(self):
@@ -106,7 +106,7 @@ class MetricTest(unittest.TestCase):
         ).to_metric()
         true = ['a', 'b', 'a', 'b', 'a', 'b']
         pred = [['a', 'b'], ['c', 'd'], ['c', 'a'], ['a', 'c'], ['b', 'a'], ['a', 'b']]
-        result = metric.evaluate(true, pred, confidence_level=0.05)
+        result = metric.evaluate(true, pred, confidence_alpha=0.05)
         self.assertAlmostEqual(result.value, 2.5 / 6.0)
 
     def test_ner_f1(self):
@@ -123,13 +123,13 @@ class MetricTest(unittest.TestCase):
         metric = explainaboard.metrics.f1_score.SeqF1ScoreConfig(
             name='MicroF1', average='micro', tag_schema='bio'
         ).to_metric()
-        result = metric.evaluate(true, pred, confidence_level=None)
+        result = metric.evaluate(true, pred, confidence_alpha=None)
         self.assertAlmostEqual(result.value, 2.0 / 3.0)
 
         metric = explainaboard.metrics.f1_score.SeqF1ScoreConfig(
             name='MacroF1', average='macro', tag_schema='bio'
         ).to_metric()
-        result = metric.evaluate(true, pred, confidence_level=None)
+        result = metric.evaluate(true, pred, confidence_alpha=None)
         self.assertAlmostEqual(result.value, 3.0 / 4.0)
 
     def _get_eaas_request(

--- a/integration_tests/metric_test.py
+++ b/integration_tests/metric_test.py
@@ -24,7 +24,7 @@ class MetricTest(unittest.TestCase):
         ).to_metric()
         true = ['a', 'b', 'a', 'b', 'a', 'b']
         pred = ['a', 'b', 'a', 'b', 'b', 'a']
-        result = metric.evaluate(true, pred, conf_value=0.05)
+        result = metric.evaluate(true, pred, confidence_level=0.05)
         self.assertAlmostEqual(result.value, 2.0 / 3.0)
 
     def test_correct_score(self):
@@ -33,7 +33,7 @@ class MetricTest(unittest.TestCase):
         ).to_metric()
         true = ['a', 'b', 'a', 'b', 'a', 'b']
         pred = ['a', 'b', 'a', 'b', 'b', 'a']
-        result = metric.evaluate(true, pred, conf_value=0.05)
+        result = metric.evaluate(true, pred, confidence_level=0.05)
         self.assertAlmostEqual(result.value, 4)
 
     def test_seq_correct_score(self):
@@ -80,7 +80,7 @@ class MetricTest(unittest.TestCase):
         pred = ['a', 'b', 'a', 'b', 'b', 'a', 'c', 'a']
 
         sklearn_f1 = f1_score(true, pred, average='micro')
-        result = metric.evaluate(true, pred, conf_value=0.05)
+        result = metric.evaluate(true, pred, confidence_level=0.05)
         self.assertAlmostEqual(result.value, sklearn_f1)
 
     def test_f1_macro(self):
@@ -90,14 +90,14 @@ class MetricTest(unittest.TestCase):
         true = ['a', 'b', 'a', 'b', 'a', 'a', 'c', 'c']
         pred = ['a', 'b', 'a', 'b', 'b', 'a', 'c', 'a']
         sklearn_f1 = f1_score(true, pred, average='macro')
-        result = metric.evaluate(true, pred, conf_value=None)
+        result = metric.evaluate(true, pred, confidence_level=None)
         self.assertAlmostEqual(result.value, sklearn_f1)
 
     def test_hits(self):
         metric = explainaboard.metrics.ranking.HitsConfig(name='Hits').to_metric()
         true = ['a', 'b', 'a', 'b', 'a', 'b']
         pred = [['a', 'b'], ['c', 'd'], ['c', 'a'], ['a', 'c'], ['b', 'a'], ['a', 'b']]
-        result = metric.evaluate(true, pred, conf_value=0.05)
+        result = metric.evaluate(true, pred, confidence_level=0.05)
         self.assertAlmostEqual(result.value, 4.0 / 6.0)
 
     def test_mrr(self):
@@ -106,7 +106,7 @@ class MetricTest(unittest.TestCase):
         ).to_metric()
         true = ['a', 'b', 'a', 'b', 'a', 'b']
         pred = [['a', 'b'], ['c', 'd'], ['c', 'a'], ['a', 'c'], ['b', 'a'], ['a', 'b']]
-        result = metric.evaluate(true, pred, conf_value=0.05)
+        result = metric.evaluate(true, pred, confidence_level=0.05)
         self.assertAlmostEqual(result.value, 2.5 / 6.0)
 
     def test_ner_f1(self):
@@ -123,13 +123,13 @@ class MetricTest(unittest.TestCase):
         metric = explainaboard.metrics.f1_score.SeqF1ScoreConfig(
             name='MicroF1', average='micro', tag_schema='bio'
         ).to_metric()
-        result = metric.evaluate(true, pred, conf_value=None)
+        result = metric.evaluate(true, pred, confidence_level=None)
         self.assertAlmostEqual(result.value, 2.0 / 3.0)
 
         metric = explainaboard.metrics.f1_score.SeqF1ScoreConfig(
             name='MacroF1', average='macro', tag_schema='bio'
         ).to_metric()
-        result = metric.evaluate(true, pred, conf_value=None)
+        result = metric.evaluate(true, pred, confidence_level=None)
         self.assertAlmostEqual(result.value, 3.0 / 4.0)
 
     def _get_eaas_request(

--- a/integration_tests/nlg_meta_eval_test.py
+++ b/integration_tests/nlg_meta_eval_test.py
@@ -16,7 +16,7 @@ class NLGMetaEvalTest(unittest.TestCase):
         metadata = {
             "task_name": TaskType.nlg_meta_evaluation.value,
             "metric_names": ["SysPearsonCorr"],
-            "confidence_level": None,
+            "confidence_alpha": None,
         }
         loader = get_loader_class(TaskType.nlg_meta_evaluation)(
             self.tsv_dataset,

--- a/integration_tests/nlg_meta_eval_test.py
+++ b/integration_tests/nlg_meta_eval_test.py
@@ -16,7 +16,7 @@ class NLGMetaEvalTest(unittest.TestCase):
         metadata = {
             "task_name": TaskType.nlg_meta_evaluation.value,
             "metric_names": ["SysPearsonCorr"],
-            "conf_value": None,
+            "confidence_level": None,
         }
         loader = get_loader_class(TaskType.nlg_meta_evaluation)(
             self.tsv_dataset,


### PR DESCRIPTION
This pull request attempts to remove ambiguation around "conf" in the repository. This abbreviation is used for different meanings: confidence, confusion, and config. Using full name is preferred to avoid user-side confusion.

This pull request also changes the name of arguments `conf_value` to `confidence_alpha`, and fix descriptions to avoid "p-value" wording. In principle, the confidence level (or confidence coefficient) is a constant $(1-\alpha)$ defined before any analysis, while p-value is a result produced by some statistical test. They are pointing to different concepts.