### PR TITLE
add more concrete documents for dataset formats when performing analyses

### DIFF
--- a/docs/concepts_about_system_analysis.md
+++ b/docs/concepts_about_system_analysis.md
@@ -1,0 +1,53 @@
+# Concepts about System Analysis
+In this docs, we will explain some important concepts that
+you need to know before performing system analyses using Explainaboard.
+
+## What a "dataset" and "system output" is
+To perform an analysis of your results, usually, two types of files should be prepared: `dataset`
+and `system output` 
+
+### `Dataset`
+`Dataset` usually consists of test samples together with true labels (or references in text generation
+tasks).
+For example, in text classification, the `dataset` could be organized in a tsv format:
+```text
+I love this movie   positive
+The movie is too long   negative
+...
+``` 
+
+### `System output`
+`System output` is frequently composed of predicted labels (or hypotheses, e.g., system-generated text),
+but sometimes `system output` will also contain test samples, such as `CoNLL` format in sequence labeling tasks.
+For example, in text classification, the `system output` could be organized in a text format:
+```text
+positive
+negative
+...
+```
+
+
+
+## How the dataset can be gotten from two sources, either "datalab" or "custom"
+The `dataset` typically could be obtained from two sources (so far): one is supported by [Datalab](https://aclanthology.org/2022.acl-demo.18.pdf) (Xiao et al 2022) and the
+other is custom.
+* if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
+you, fortunately, don't need to prepare the dataset. Instead, you just need to get the dataset name for later use.
+For example, the following command can be used to perform system analysis on `sst2` dataset (supported by datalab)
+```shell script
+explainaboard --task text-classification --dataset sst2 --system-outputs ./data/system_outputs/sst2/sst2-lstm-output.txt
+```
+If the dataset hasn't been supported by datalab, we then need to specify a file path:
+```shell script
+explainaboard --task text-classification --custom-dataset-paths ./data/system_outputs/sst2/sst2-dataset.tsv --system-outputs ./data/system_outputs/sst2/sst2-lstm-output.txt
+```
+
+* if your datasets haven't been supported by datalab but you want them supported, you can follow this 
+[doc](https://github.com/ExpressAI/DataLab/blob/main/docs/SDK/add_new_datasets_into_sdk.md) to add them.
+
+
+
+
+## How different formats (e.g. json, tsv, etc.) are supported
+In ExplainaBoard, users are allowed to prepare custom datasets with different formats, such as
+`json`, `tsv` etc. We will detail this in each task's description.

--- a/docs/concepts_about_system_analysis.md
+++ b/docs/concepts_about_system_analysis.md
@@ -1,15 +1,15 @@
 # Concepts about System Analysis
-In this docs, we will explain some important concepts that
+In these docs, we will explain some important concepts that
 you need to know before performing system analyses using Explainaboard.
 
-## What a "dataset" and "system output" is
-To perform an analysis of your results, usually, two types of files should be prepared: `dataset`
-and `system output` 
+## What are a "dataset" and a "system output"?
+To perform an analysis of your results, usually, two types of files should be prepared: "dataset"
+and "system output" 
 
 ### `Dataset`
-`Dataset` usually consists of test samples together with true labels (or references in text generation
-tasks).
-For example, in text classification, the `dataset` could be organized in a tsv format:
+A "dataset" usually consists of test inputs together with true outputs (e.g. gold-standard labels for classification tasks 
+or reference outputs for text generation tasks).
+For example, in text classification, a `dataset` organized in tsv format may look like this:
 ```text
 I love this movie   positive
 The movie is too long   negative
@@ -28,16 +28,23 @@ negative
 
 
 
-## How the dataset can be gotten from two sources, either "datalab" or "custom"
-The `dataset` typically could be obtained from two sources (so far): one is supported by [Datalab](https://aclanthology.org/2022.acl-demo.18.pdf) (Xiao et al 2022) and the
+## "Datalab datasets" and "custom datasets"
+ExplainaBoard currently supports two sources for datasets: one is through [Datalab](https://aclanthology.org/2022.acl-demo.18.pdf) (Xiao et al 2022) and the
 other is custom.
 * if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
-you, fortunately, don't need to prepare the dataset. Instead, you just need to get the dataset name for later use.
+we recommend that you load it through DataLab. This is for several reasons:
+ (1) you don't have to prepare the data yourself, 
+ (2) you can be sure that your accuracy numbers will be comparable with those calculated 
+ by other people using ExplainaBoard, and
+ (3) DataLab datasets support analysis with features calculated over the training set,
+  which can be informative.
+
 For example, the following command can be used to perform system analysis on `sst2` dataset (supported by datalab)
 ```shell script
 explainaboard --task text-classification --dataset sst2 --system-outputs ./data/system_outputs/sst2/sst2-lstm-output.txt
 ```
-If the dataset hasn't been supported by datalab, we then need to specify a file path:
+If the dataset hasn't been supported by datalab, we then need to prepare the dataset in a format supported by ExplainaBoard
+ (this varies from task-to-task, see the task-specific documentation) and specify a file path:
 ```shell script
 explainaboard --task text-classification --custom-dataset-paths ./data/system_outputs/sst2/sst2-dataset.tsv --system-outputs ./data/system_outputs/sst2/sst2-lstm-output.txt
 ```

--- a/docs/task_argument_pair_extraction.md
+++ b/docs/task_argument_pair_extraction.md
@@ -1,27 +1,21 @@
 # Analyzing the Argument Pair Extraction (APE) Task
 
+Before diving into the detail of this doc, you're strongly recommended to know [some
+important concepts about system analyses](concepts_about_system_analysis.md).
+
 In this file we describe how to analyze APE models.
 We will give an example using the  [ape](https://github.com/ExpressAI/DataLab/blob/main/datasets/ape/ape.py) dataset, but other datasets
 can be analyzed in a similar way.
 
 ## Data Preparation
 
-To perform analysis of your results, usually two types of files should be pre-trained, which we will
-detailed below.
+ 
 
 ### Format of `Dataset` File
-`Dataset` file usually consists of test samples together with true labels (or references in text generation
-tasks). 
-In this task, the following specific formats are supported 
+ 
 
-* (1) `datalab`
-    * if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
-    you fortunately don't need to prepare the dataset. 
-    Instead, you just need to remember the dataset name for later use.
-    * if your datasets haven't been supported by datalab but you want it supported, you can follow this 
-    [doc](https://github.com/ExpressAI/DataLab/blob/main/docs/SDK/add_new_datasets_into_sdk.md) to add them.
-
-    * you can examine the specific format organized in datalab by following commands:
+* (1) `datalab`: if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
+    you fortunately don't need to prepare the dataset. For example, you can examine the specific format organized in datalab by following commands:
     ```python
     from datalabs import load_dataset
     dataset = load_dataset("ape")
@@ -30,11 +24,6 @@ In this task, the following specific formats are supported
     ```
 
 ### Format of `System Output` File
-
-`System output` file usually only composed of predicted labels (or hypothesis, e.g., system-generated text),
-but sometimes `system output` will also contains test samples, such as `CoNLL` format in sequence labeling tasks.
-In this task, your system outputs should be as follows:
-
 
 In order to perform analysis of your results, they should be in the following conll format:
 

--- a/docs/task_argument_pair_extraction.md
+++ b/docs/task_argument_pair_extraction.md
@@ -6,6 +6,36 @@ can be analyzed in a similar way.
 
 ## Data Preparation
 
+To perform analysis of your results, usually two types of files should be pre-trained, which we will
+detailed below.
+
+### Format of `Dataset` File
+`Dataset` file usually consists of test samples together with true labels (or references in text generation
+tasks). 
+In this task, the following specific formats are supported 
+
+* (1) `datalab`
+    * if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
+    you fortunately don't need to prepare the dataset. 
+    Instead, you just need to remember the dataset name for later use.
+    * if your datasets haven't been supported by datalab but you want it supported, you can follow this 
+    [doc](https://github.com/ExpressAI/DataLab/blob/main/docs/SDK/add_new_datasets_into_sdk.md) to add them.
+
+    * you can examine the specific format organized in datalab by following commands:
+    ```python
+    from datalabs import load_dataset
+    dataset = load_dataset("ape")
+    print(dataset["test"][0])
+
+    ```
+
+### Format of `System Output` File
+
+`System output` file usually only composed of predicted labels (or hypothesis, e.g., system-generated text),
+but sometimes `system output` will also contains test samples, such as `CoNLL` format in sequence labeling tasks.
+In this task, your system outputs should be as follows:
+
+
 In order to perform analysis of your results, they should be in the following conll format:
 
 ```

--- a/docs/task_aspect_based_sentiment_classification.md
+++ b/docs/task_aspect_based_sentiment_classification.md
@@ -6,8 +6,46 @@ can be analyzed in a similar way.
 
 ## Data Preparation
 
-In order to perform analysis of your results, they should be in the following
-text format with one predicted label per line.
+To perform analysis of your results, usually two types of files should be pre-trained, which we will
+detailed below.
+
+### Format of `Dataset` File
+`Dataset` file usually consists of test samples together with true labels (or references in text generation
+tasks). 
+In this task, the following specific formats are supported 
+(the first two are also called custom datasets)
+
+* (1) `tsv` (without column names at the first row), see one [example](https://github.com/neulab/ExplainaBoard/blob/main/data/system_outputs/absa/absa-dataset.tsv)
+```python
+Boot time	 Boot time  is super fast, around anywhere from 35 seconds to 1 minute.	positive
+Windows 8	Did not enjoy the new  Windows 8  and  touchscreen functions .	negative
+...
+```
+where the first 1st, 2nd, 3rd column represent aspect text, sentence and true label respectively.
+
+
+* (2) `json` (basically, it's a list of dictionaries with three keys: `aspect`, `text` and `true_label`)
+```json
+[
+  {"aspect":"Boot time", "text": "Boot time  is super fast, around anywhere from 35 seconds to 1 minute.", "true_label": "positive"},
+  ...
+]
+```
+
+* (3) `datalab`
+    * if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
+    you fortunately don't need to prepare the dataset. 
+    Instead, you just need to remember the dataset name for later use.
+    * if your datasets haven't been supported by datalab but you want it supported, you can follow this 
+    [doc](https://github.com/ExpressAI/DataLab/blob/main/docs/SDK/add_new_datasets_into_sdk.md) to add them.
+
+
+### Format of `System Output` File
+
+`System output` file usually only composed of predicted labels (or hypothesis, e.g., system-generated text),
+but sometimes `system output` will also contains test samples, such as `CoNLL` format in sequence labeling tasks.
+In this task, your system outputs should be as follows:
+
 
 ```
 predicted_label

--- a/docs/task_aspect_based_sentiment_classification.md
+++ b/docs/task_aspect_based_sentiment_classification.md
@@ -1,19 +1,19 @@
 # Analyzing Aspect-based Sentiment Classification
 
+Before diving into the detail of this doc, you're strongly recommended to know [some
+important concepts about system analyses](concepts_about_system_analysis.md).
+
+
 In this file we describe how to analyze aspect-based sentiment classification models.
 We will give an example using the `aspect-based-sentiment-classification` [laptop](https://github.com/neulab/ExplainaBoard/blob/main/data/system_outputs/absa/test-aspect.tsv) dataset, but other datasets
 can be analyzed in a similar way.
 
 ## Data Preparation
 
-To perform analysis of your results, usually two types of files should be pre-trained, which we will
-detailed below.
+ 
 
 ### Format of `Dataset` File
-`Dataset` file usually consists of test samples together with true labels (or references in text generation
-tasks). 
-In this task, the following specific formats are supported 
-(the first two are also called custom datasets)
+
 
 * (1) `tsv` (without column names at the first row), see one [example](https://github.com/neulab/ExplainaBoard/blob/main/data/system_outputs/absa/absa-dataset.tsv)
 ```python
@@ -32,18 +32,11 @@ where the first 1st, 2nd, 3rd column represent aspect text, sentence and true la
 ]
 ```
 
-* (3) `datalab`
-    * if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
+* (3) `datalab`: if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
     you fortunately don't need to prepare the dataset. 
-    Instead, you just need to remember the dataset name for later use.
-    * if your datasets haven't been supported by datalab but you want it supported, you can follow this 
-    [doc](https://github.com/ExpressAI/DataLab/blob/main/docs/SDK/add_new_datasets_into_sdk.md) to add them.
 
 
 ### Format of `System Output` File
-
-`System output` file usually only composed of predicted labels (or hypothesis, e.g., system-generated text),
-but sometimes `system output` will also contains test samples, such as `CoNLL` format in sequence labeling tasks.
 In this task, your system outputs should be as follows:
 
 

--- a/docs/task_aspect_based_sentiment_classification.md
+++ b/docs/task_aspect_based_sentiment_classification.md
@@ -15,7 +15,11 @@ can be analyzed in a similar way.
 ### Format of `Dataset` File
 
 
-* (1) `tsv` (without column names at the first row), see one [example](https://github.com/neulab/ExplainaBoard/blob/main/data/system_outputs/absa/absa-dataset.tsv)
+
+* (1) `datalab`: if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
+    you fortunately don't need to prepare the dataset. 
+
+* (2) `tsv` (without column names at the first row), see one [example](https://github.com/neulab/ExplainaBoard/blob/main/data/system_outputs/absa/absa-dataset.tsv)
 ```python
 Boot time	 Boot time  is super fast, around anywhere from 35 seconds to 1 minute.	positive
 Windows 8	Did not enjoy the new  Windows 8  and  touchscreen functions .	negative
@@ -24,7 +28,7 @@ Windows 8	Did not enjoy the new  Windows 8  and  touchscreen functions .	negativ
 where the first 1st, 2nd, 3rd column represent aspect text, sentence and true label respectively.
 
 
-* (2) `json` (basically, it's a list of dictionaries with three keys: `aspect`, `text` and `true_label`)
+* (3) `json` (basically, it's a list of dictionaries with three keys: `aspect`, `text` and `true_label`)
 ```json
 [
   {"aspect":"Boot time", "text": "Boot time  is super fast, around anywhere from 35 seconds to 1 minute.", "true_label": "positive"},
@@ -32,8 +36,6 @@ where the first 1st, 2nd, 3rd column represent aspect text, sentence and true la
 ]
 ```
 
-* (3) `datalab`: if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
-    you fortunately don't need to prepare the dataset. 
 
 
 ### Format of `System Output` File

--- a/docs/task_conditional_generation.md
+++ b/docs/task_conditional_generation.md
@@ -1,5 +1,9 @@
 # Analyzing Conditional Text Generation Tasks
 
+Before diving into the detail of this doc, you're strongly recommended to know [some
+important concepts about system analyses](concepts_about_system_analysis.md).
+
+
 Conditional text generation is a class of tasks where you generate text based on some conditioning context.
 This can include a wide variety of tasks, such as:
 
@@ -13,14 +17,9 @@ This can include a wide variety of tasks, such as:
 
 ## Data Preparation
 
-To perform analysis of your results, usually two types of files should be pre-trained, which we will
-detailed below.
-
+ 
 ### Format of `Dataset` File
-`Dataset` file usually consists of test samples together with true labels (or references in text generation
-tasks). 
-In this task, the following specific formats are supported 
-(the first two are also called custom datasets)
+
 
 * (1) `tsv` (without column names at the first row), see one [example](https://github.com/neulab/ExplainaBoard/blob/main/data/system_outputs/cnndm/cnndm_mini-dataset.tsv)
 ```python
@@ -37,18 +36,11 @@ where the first column represents source text and the 2nd column denotes gold re
 ]
 ```
 
-* (3) `datalab`
-    * if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
+* (3) `datalab`: if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
     you fortunately don't need to prepare the dataset. 
-    Instead, you just need to remember the dataset name for later use.
-    * if your datasets haven't been supported by datalab but you want it supported, you can follow this 
-    [doc](https://github.com/ExpressAI/DataLab/blob/main/docs/SDK/add_new_datasets_into_sdk.md) to add them.
 
 
 ### Format of `System Output` File
-
-`System output` file usually only composed of predicted labels (or hypothesis, e.g., system-generated text),
-but sometimes `system output` will also contains test samples, such as `CoNLL` format in sequence labeling tasks.
 In this task, your system outputs should be as follows:
 
 

--- a/docs/task_conditional_generation.md
+++ b/docs/task_conditional_generation.md
@@ -21,14 +21,17 @@ This can include a wide variety of tasks, such as:
 ### Format of `Dataset` File
 
 
-* (1) `tsv` (without column names at the first row), see one [example](https://github.com/neulab/ExplainaBoard/blob/main/data/system_outputs/cnndm/cnndm_mini-dataset.tsv)
+* (1) `datalab`: if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
+    you fortunately don't need to prepare the dataset. 
+
+* (2) `tsv` (without column names at the first row), see one [example](https://github.com/neulab/ExplainaBoard/blob/main/data/system_outputs/cnndm/cnndm_mini-dataset.tsv)
 ```python
 This is a good movie    这是一部好电影
 ...
 ```
 where the first column represents source text and the 2nd column denotes gold reference.
 
-* (2) `json` (basically, it's a list of dictionaries with two keys: `source` and `reference`)
+* (3) `json` (basically, it's a list of dictionaries with two keys: `source` and `reference`)
 ```json
 [
   {"source": "This is a good movie", "reference": "这是一部好电影"},
@@ -36,8 +39,7 @@ where the first column represents source text and the 2nd column denotes gold re
 ]
 ```
 
-* (3) `datalab`: if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
-    you fortunately don't need to prepare the dataset. 
+
 
 
 ### Format of `System Output` File

--- a/docs/task_conditional_generation.md
+++ b/docs/task_conditional_generation.md
@@ -13,8 +13,44 @@ This can include a wide variety of tasks, such as:
 
 ## Data Preparation
 
-In order to perform analysis of your results, they should be in the following
-text format:
+To perform analysis of your results, usually two types of files should be pre-trained, which we will
+detailed below.
+
+### Format of `Dataset` File
+`Dataset` file usually consists of test samples together with true labels (or references in text generation
+tasks). 
+In this task, the following specific formats are supported 
+(the first two are also called custom datasets)
+
+* (1) `tsv` (without column names at the first row), see one [example](https://github.com/neulab/ExplainaBoard/blob/main/data/system_outputs/cnndm/cnndm_mini-dataset.tsv)
+```python
+This is a good movie    这是一部好电影
+...
+```
+where the first column represents source text and the 2nd column denotes gold reference.
+
+* (2) `json` (basically, it's a list of dictionaries with two keys: `source` and `reference`)
+```json
+[
+  {"source": "This is a good movie", "reference": "这是一部好电影"},
+  ...
+]
+```
+
+* (3) `datalab`
+    * if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
+    you fortunately don't need to prepare the dataset. 
+    Instead, you just need to remember the dataset name for later use.
+    * if your datasets haven't been supported by datalab but you want it supported, you can follow this 
+    [doc](https://github.com/ExpressAI/DataLab/blob/main/docs/SDK/add_new_datasets_into_sdk.md) to add them.
+
+
+### Format of `System Output` File
+
+`System output` file usually only composed of predicted labels (or hypothesis, e.g., system-generated text),
+but sometimes `system output` will also contains test samples, such as `CoNLL` format in sequence labeling tasks.
+In this task, your system outputs should be as follows:
+
 
 ```
 predicted_output_text

--- a/docs/task_extractive_qa.md
+++ b/docs/task_extractive_qa.md
@@ -15,9 +15,10 @@ In this file we describe how to analyze models trained on extractive QA datasets
 
 ### Format of `Dataset` File
 
+* (1) `datalab`: if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
+    you fortunately don't need to prepare the dataset. 
 
-
-* (1) `json` (basically, it's a list of dictionaries with three keys: `context`, `question`, and `answers`)
+* (2) `json` (basically, it's a list of dictionaries with three keys: `context`, `question`, and `answers`)
 ```json
 [
   {"context": "Super Bowl 50 was an American footb", "question": "Which NFL team represented the AFC at Super Bowl 50?", 'answers': {'text': ['Denver Broncos', 'Denver Broncos', 'Denver Broncos'], 'answer_start': [177, 177, 177]}},
@@ -25,8 +26,7 @@ In this file we describe how to analyze models trained on extractive QA datasets
 ]
 ```
 
-* (2) `datalab`: if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
-    you fortunately don't need to prepare the dataset. 
+
 
 ### Format of `System Output` File
 In order to perform analysis of your results, they should be in the following

--- a/docs/task_extractive_qa.md
+++ b/docs/task_extractive_qa.md
@@ -1,5 +1,9 @@
 # Analyzing Extractive QA Task
 
+Before diving into the detail of this doc, you're strongly recommended to know [some
+important concepts about system analyses](concepts_about_system_analysis.md).
+
+
 
 In this file we describe how to analyze models trained on extractive QA datasets, for example
 [`squad`](http://datalab.nlpedia.ai/#/normal_dataset/6163a29beb9872f33252b01b/dataset_samples).
@@ -7,14 +11,10 @@ In this file we describe how to analyze models trained on extractive QA datasets
 
 ## Data Preparation
 
-To perform analysis of your results, usually two types of files should be pre-trained, which we will
-detailed below.
+ 
 
 ### Format of `Dataset` File
-`Dataset` file usually consists of test samples together with true labels (or references in text generation
-tasks). 
-In this task, the following specific formats are supported 
- 
+
 
 
 * (1) `json` (basically, it's a list of dictionaries with three keys: `context`, `question`, and `answers`)
@@ -25,18 +25,10 @@ In this task, the following specific formats are supported
 ]
 ```
 
-* (2) `datalab`
-    * if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
+* (2) `datalab`: if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
     you fortunately don't need to prepare the dataset. 
-    Instead, you just need to remember the dataset name for later use.
-    * if your datasets haven't been supported by datalab but you want it supported, you can follow this 
-    [doc](https://github.com/ExpressAI/DataLab/blob/main/docs/SDK/add_new_datasets_into_sdk.md) to add them.
-
 
 ### Format of `System Output` File
-
-`System output` file usually only composed of predicted labels (or hypothesis, e.g., system-generated text),
-but sometimes `system output` will also contains test samples, such as `CoNLL` format in sequence labeling tasks.
 In order to perform analysis of your results, they should be in the following
 JSON format:
 

--- a/docs/task_extractive_qa.md
+++ b/docs/task_extractive_qa.md
@@ -7,6 +7,36 @@ In this file we describe how to analyze models trained on extractive QA datasets
 
 ## Data Preparation
 
+To perform analysis of your results, usually two types of files should be pre-trained, which we will
+detailed below.
+
+### Format of `Dataset` File
+`Dataset` file usually consists of test samples together with true labels (or references in text generation
+tasks). 
+In this task, the following specific formats are supported 
+ 
+
+
+* (1) `json` (basically, it's a list of dictionaries with three keys: `context`, `question`, and `answers`)
+```json
+[
+  {"context": "Super Bowl 50 was an American footb", "question": "Which NFL team represented the AFC at Super Bowl 50?", 'answers': {'text': ['Denver Broncos', 'Denver Broncos', 'Denver Broncos'], 'answer_start': [177, 177, 177]}},
+  ...
+]
+```
+
+* (2) `datalab`
+    * if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
+    you fortunately don't need to prepare the dataset. 
+    Instead, you just need to remember the dataset name for later use.
+    * if your datasets haven't been supported by datalab but you want it supported, you can follow this 
+    [doc](https://github.com/ExpressAI/DataLab/blob/main/docs/SDK/add_new_datasets_into_sdk.md) to add them.
+
+
+### Format of `System Output` File
+
+`System output` file usually only composed of predicted labels (or hypothesis, e.g., system-generated text),
+but sometimes `system output` will also contains test samples, such as `CoNLL` format in sequence labeling tasks.
 In order to perform analysis of your results, they should be in the following
 JSON format:
 

--- a/docs/task_grammatical_error_correction.md
+++ b/docs/task_grammatical_error_correction.md
@@ -1,5 +1,9 @@
 # Analyzing Grammatical Error Correction
 
+Before diving into the detail of this doc, you're strongly recommended to know [some
+important concepts about system analyses](concepts_about_system_analysis.md).
+
+
 Grammatical error correction is the task of correcting different kinds of errors in text, such as spelling errors. If you're interested in how datasets for this task look like, you can
 perform the following command after installing [`DataLab`](https://github.com/ExpressAI/DataLab#installation)
 ```python
@@ -15,26 +19,15 @@ In what follows, we will describe how to analyze grammatical error correction sy
 
 ## Data Preparation
 
-To perform analysis of your results, usually two types of files should be pre-trained, which we will
-detailed below.
 
 ### Format of `Dataset` File
-`Dataset` file usually consists of test samples together with true labels (or references in text generation
-tasks). 
-In this task, the following specific formats are supported 
+
  
-* (1) `datalab`
-    * if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
+* (1) `datalab`: if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
     you fortunately don't need to prepare the dataset. 
-    Instead, you just need to remember the dataset name for later use.
-    * if your datasets haven't been supported by datalab but you want it supported, you can follow this 
-    [doc](https://github.com/ExpressAI/DataLab/blob/main/docs/SDK/add_new_datasets_into_sdk.md) to add them.
 
 
 ### Format of `System Output` File
-
-`System output` file usually only composed of predicted labels (or hypothesis, e.g., system-generated text),
-but sometimes `system output` will also contains test samples, such as `CoNLL` format in sequence labeling tasks.
 In order to perform an analysis of your results, your system outputs should be arranged into following
 format:
 

--- a/docs/task_grammatical_error_correction.md
+++ b/docs/task_grammatical_error_correction.md
@@ -15,6 +15,26 @@ In what follows, we will describe how to analyze grammatical error correction sy
 
 ## Data Preparation
 
+To perform analysis of your results, usually two types of files should be pre-trained, which we will
+detailed below.
+
+### Format of `Dataset` File
+`Dataset` file usually consists of test samples together with true labels (or references in text generation
+tasks). 
+In this task, the following specific formats are supported 
+ 
+* (1) `datalab`
+    * if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
+    you fortunately don't need to prepare the dataset. 
+    Instead, you just need to remember the dataset name for later use.
+    * if your datasets haven't been supported by datalab but you want it supported, you can follow this 
+    [doc](https://github.com/ExpressAI/DataLab/blob/main/docs/SDK/add_new_datasets_into_sdk.md) to add them.
+
+
+### Format of `System Output` File
+
+`System output` file usually only composed of predicted labels (or hypothesis, e.g., system-generated text),
+but sometimes `system output` will also contains test samples, such as `CoNLL` format in sequence labeling tasks.
 In order to perform an analysis of your results, your system outputs should be arranged into following
 format:
 

--- a/docs/task_kg_link_tail_prediction.md
+++ b/docs/task_kg_link_tail_prediction.md
@@ -22,8 +22,39 @@ In this file we describe how to analyze models trained to predict the tail entit
 
 
 ### Data Preparation
-In order to perform analysis of your results, they should be in the following
-JSON format:
+
+To perform analysis of your results, usually two types of files should be pre-trained, which we will
+detailed below.
+
+#### Format of `Dataset` File
+`Dataset` file usually consists of test samples together with true labels (or references in text generation
+tasks). 
+In this task, the following specific formats are supported 
+(the first one is also called the custom dataset)
+
+
+* (1) `json` (basically, it's a list of dictionaries with two keys: `gold_head`,
+        `gold_predicate`, and `gold_tail`)
+```json
+[
+  {"gold_head": "abc", "gold_predicate": "dummy relation", "gold_tail":"cde"},
+  ...
+]
+```
+
+* (2) `datalab`
+    * if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
+    you fortunately don't need to prepare the dataset. 
+    Instead, you just need to remember the dataset name for later use.
+    * if your datasets haven't been supported by datalab but you want it supported, you can follow this 
+    [doc](https://github.com/ExpressAI/DataLab/blob/main/docs/SDK/add_new_datasets_into_sdk.md) to add them.
+
+
+#### Format of `System Output` File
+
+`System output` file usually only composed of predicted labels (or hypothesis, e.g., system-generated text),
+but sometimes `system output` will also contains test samples, such as `CoNLL` format in sequence labeling tasks.
+In this task, your system outputs should be as follows:
 
 ```json
 [

--- a/docs/task_kg_link_tail_prediction.md
+++ b/docs/task_kg_link_tail_prediction.md
@@ -30,8 +30,10 @@ In this file we describe how to analyze models trained to predict the tail entit
 
 #### Format of `Dataset` File
 
+* (1) `datalab`: if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
+    you fortunately don't need to prepare the dataset. 
 
-* (1) `json` (basically, it's a list of dictionaries with two keys: `gold_head`,
+* (2) `json` (basically, it's a list of dictionaries with two keys: `gold_head`,
         `gold_predicate`, and `gold_tail`)
 ```json
 [
@@ -40,8 +42,7 @@ In this file we describe how to analyze models trained to predict the tail entit
 ]
 ```
 
-* (2) `datalab`: if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
-    you fortunately don't need to prepare the dataset. 
+
 
 
 #### Format of `System Output` File

--- a/docs/task_kg_link_tail_prediction.md
+++ b/docs/task_kg_link_tail_prediction.md
@@ -1,6 +1,9 @@
 # Analyzing Knowledge Graph Link Tail Prediction Task
 
 
+Before diving into the detail of this doc, you're strongly recommended to know [some
+important concepts about system analyses](concepts_about_system_analysis.md).
+
 In this file we describe how to analyze models trained to predict the tail entity on knowledge graph link prediction tasks, for example
 [`fb15k-237`](https://www.microsoft.com/en-us/download/details.aspx?id=52312).
 
@@ -23,14 +26,9 @@ In this file we describe how to analyze models trained to predict the tail entit
 
 ### Data Preparation
 
-To perform analysis of your results, usually two types of files should be pre-trained, which we will
-detailed below.
+
 
 #### Format of `Dataset` File
-`Dataset` file usually consists of test samples together with true labels (or references in text generation
-tasks). 
-In this task, the following specific formats are supported 
-(the first one is also called the custom dataset)
 
 
 * (1) `json` (basically, it's a list of dictionaries with two keys: `gold_head`,
@@ -42,18 +40,12 @@ In this task, the following specific formats are supported
 ]
 ```
 
-* (2) `datalab`
-    * if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
+* (2) `datalab`: if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
     you fortunately don't need to prepare the dataset. 
-    Instead, you just need to remember the dataset name for later use.
-    * if your datasets haven't been supported by datalab but you want it supported, you can follow this 
-    [doc](https://github.com/ExpressAI/DataLab/blob/main/docs/SDK/add_new_datasets_into_sdk.md) to add them.
 
 
 #### Format of `System Output` File
 
-`System output` file usually only composed of predicted labels (or hypothesis, e.g., system-generated text),
-but sometimes `system output` will also contains test samples, such as `CoNLL` format in sequence labeling tasks.
 In this task, your system outputs should be as follows:
 
 ```json

--- a/docs/task_qa_multiple_choice.md
+++ b/docs/task_qa_multiple_choice.md
@@ -13,7 +13,10 @@ can be analyzed in a similar way.
 
 ### Format of `Dataset` File
 
-* (1) `json` (basically, it's a list of dictionaries with two keys: `context`
+* (1) `datalab`: if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
+    you fortunately don't need to prepare the dataset. 
+
+* (2) `json` (basically, it's a list of dictionaries with two keys: `context`
                , `options`, `question`, and `answers`)
 ```json
 [
@@ -23,8 +26,7 @@ can be analyzed in a similar way.
 ]
 ```
 
-* (2) `datalab`: if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
-    you fortunately don't need to prepare the dataset. 
+
 ### Format of `System Output` File
 
 

--- a/docs/task_qa_multiple_choice.md
+++ b/docs/task_qa_multiple_choice.md
@@ -1,22 +1,19 @@
 # Analyzing Multiple Choices QA
 
+Before diving into the detail of this doc, you're strongly recommended to know [some
+important concepts about system analyses](concepts_about_system_analysis.md).
+
 In this file we describe how to analyze multiple-choice QA models.
 We will give an example using the  [fig_qa](http://datalab.nlpedia.ai/normal_dataset/62139f3dc5fa557614d36df2/dataset_metadata) dataset, but other datasets
 can be analyzed in a similar way.
 
 ## Data Preparation
 
-To perform analysis of your results, usually two types of files should be pre-trained, which we will
-detailed below.
+ 
 
 ### Format of `Dataset` File
-`Dataset` file usually consists of test samples together with true labels (or references in text generation
-tasks). 
-In this task, the following specific formats are supported 
-(the first one is also called the custom dataset)
 
-
-* (2) `json` (basically, it's a list of dictionaries with two keys: `context`
+* (1) `json` (basically, it's a list of dictionaries with two keys: `context`
                , `options`, `question`, and `answers`)
 ```json
 [
@@ -26,20 +23,9 @@ In this task, the following specific formats are supported
 ]
 ```
 
-* (3) `datalab`
-    * if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
+* (2) `datalab`: if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
     you fortunately don't need to prepare the dataset. 
-    Instead, you just need to remember the dataset name for later use.
-    * if your datasets haven't been supported by datalab but you want it supported, you can follow this 
-    [doc](https://github.com/ExpressAI/DataLab/blob/main/docs/SDK/add_new_datasets_into_sdk.md) to add them.
-
-
 ### Format of `System Output` File
-
-`System output` file usually only composed of predicted labels (or hypothesis, e.g., system-generated text),
-but sometimes `system output` will also contains test samples, such as `CoNLL` format in sequence labeling tasks.
-In this task, your system outputs should be as follows:
-
 
 
 In order to perform analysis of your results, they should be in the following json format:

--- a/docs/task_qa_multiple_choice.md
+++ b/docs/task_qa_multiple_choice.md
@@ -6,6 +6,42 @@ can be analyzed in a similar way.
 
 ## Data Preparation
 
+To perform analysis of your results, usually two types of files should be pre-trained, which we will
+detailed below.
+
+### Format of `Dataset` File
+`Dataset` file usually consists of test samples together with true labels (or references in text generation
+tasks). 
+In this task, the following specific formats are supported 
+(the first one is also called the custom dataset)
+
+
+* (2) `json` (basically, it's a list of dictionaries with two keys: `context`
+               , `options`, `question`, and `answers`)
+```json
+[
+  {'context': 'The girl had the flightiness of a sparrow', 'question': '', 'answers': {'text': 'The girl was very fickle.', 'option_index': 0}, 'options': ['The girl was very fickle.', 'The girl was very stable.']},
+  {'context': 'The girl had the flightiness of a rock', 'question': '', 'answers': {'text': 'The girl was very stable.', 'option_index': 1}, 'options': ['The girl was very fickle.', 'The girl was very stable.']}
+  ...
+]
+```
+
+* (3) `datalab`
+    * if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
+    you fortunately don't need to prepare the dataset. 
+    Instead, you just need to remember the dataset name for later use.
+    * if your datasets haven't been supported by datalab but you want it supported, you can follow this 
+    [doc](https://github.com/ExpressAI/DataLab/blob/main/docs/SDK/add_new_datasets_into_sdk.md) to add them.
+
+
+### Format of `System Output` File
+
+`System output` file usually only composed of predicted labels (or hypothesis, e.g., system-generated text),
+but sometimes `system output` will also contains test samples, such as `CoNLL` format in sequence labeling tasks.
+In this task, your system outputs should be as follows:
+
+
+
 In order to perform analysis of your results, they should be in the following json format:
 
 ```json

--- a/docs/task_qa_open_domain.md
+++ b/docs/task_qa_open_domain.md
@@ -6,7 +6,38 @@ can be analyzed in a similar way.
 
 ## Data Preparation
 
-In order to perform analysis of your results, they should be in the following json format:
+To perform analysis of your results, usually two types of files should be pre-trained, which we will
+detailed below.
+
+### Format of `Dataset` File
+`Dataset` file usually consists of test samples together with true labels (or references in text generation
+tasks). 
+In this task, the following specific formats are supported 
+
+
+* (1) `json` (basically, it's a list of dictionaries with two keys: `question` and `answers`)
+```json
+[
+  {'question': 'who got the first nobel prize in physics', 'answers': ['Wilhelm Conrad Röntgen']},
+  {'question': 'when is the next deadpool movie being released', 'answers': ['May 18 , 2018']},
+  ...
+]
+```
+
+* (2) `datalab`
+    * if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
+    you fortunately don't need to prepare the dataset. 
+    Instead, you just need to remember the dataset name for later use.
+    * if your datasets haven't been supported by datalab but you want it supported, you can follow this 
+    [doc](https://github.com/ExpressAI/DataLab/blob/main/docs/SDK/add_new_datasets_into_sdk.md) to add them.
+
+
+### Format of `System Output` File
+
+`System output` file usually only composed of predicted labels (or hypothesis, e.g., system-generated text),
+but sometimes `system output` will also contains test samples, such as `CoNLL` format in sequence labeling tasks.
+In this task, your system outputs should be as follows:
+
 
 ```text
 william henry bragg

--- a/docs/task_qa_open_domain.md
+++ b/docs/task_qa_open_domain.md
@@ -1,19 +1,17 @@
 # Analyzing Open-domain QA
 
+Before diving into the detail of this doc, you're strongly recommended to know [some
+important concepts about system analyses](concepts_about_system_analysis.md).
+
 In this file we describe how to analyze open-domain QA models.
 We will give an example using the  [natural_questions_comp_gen](https://github.com/ExpressAI/DataLab/blob/main/datasets/natural_questions_comp_gen/natural_questions_comp_gen.py) dataset, but other datasets
 can be analyzed in a similar way.
 
 ## Data Preparation
 
-To perform analysis of your results, usually two types of files should be pre-trained, which we will
-detailed below.
+ 
 
 ### Format of `Dataset` File
-`Dataset` file usually consists of test samples together with true labels (or references in text generation
-tasks). 
-In this task, the following specific formats are supported 
-
 
 * (1) `json` (basically, it's a list of dictionaries with two keys: `question` and `answers`)
 ```json
@@ -24,20 +22,12 @@ In this task, the following specific formats are supported
 ]
 ```
 
-* (2) `datalab`
-    * if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
+* (2) `datalab`: if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
     you fortunately don't need to prepare the dataset. 
-    Instead, you just need to remember the dataset name for later use.
-    * if your datasets haven't been supported by datalab but you want it supported, you can follow this 
-    [doc](https://github.com/ExpressAI/DataLab/blob/main/docs/SDK/add_new_datasets_into_sdk.md) to add them.
-
 
 ### Format of `System Output` File
 
-`System output` file usually only composed of predicted labels (or hypothesis, e.g., system-generated text),
-but sometimes `system output` will also contains test samples, such as `CoNLL` format in sequence labeling tasks.
 In this task, your system outputs should be as follows:
-
 
 ```text
 william henry bragg

--- a/docs/task_qa_open_domain.md
+++ b/docs/task_qa_open_domain.md
@@ -13,7 +13,10 @@ can be analyzed in a similar way.
 
 ### Format of `Dataset` File
 
-* (1) `json` (basically, it's a list of dictionaries with two keys: `question` and `answers`)
+* (1) `datalab`: if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
+    you fortunately don't need to prepare the dataset. 
+
+* (2) `json` (basically, it's a list of dictionaries with two keys: `question` and `answers`)
 ```json
 [
   {'question': 'who got the first nobel prize in physics', 'answers': ['Wilhelm Conrad Röntgen']},
@@ -22,8 +25,7 @@ can be analyzed in a similar way.
 ]
 ```
 
-* (2) `datalab`: if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
-    you fortunately don't need to prepare the dataset. 
+
 
 ### Format of `System Output` File
 

--- a/docs/task_qa_table_text_hybrid.md
+++ b/docs/task_qa_table_text_hybrid.md
@@ -1,31 +1,25 @@
 # Analyzing QA over Hybrid Tabular/Textual Content
 
+Before diving into the detail of this doc, you're strongly recommended to know [some
+important concepts about system analyses](concepts_about_system_analysis.md).
+
+
+
 In this file we describe how to analyze QA models trained on datasets 
 with a hybrid of tabular and textual context.
 
 
 ## Data Preparation
 
-To perform analysis of your results, usually two types of files should be pre-trained, which we will
-detailed below.
-
+ 
 ### Format of `Dataset` File
-`Dataset` file usually consists of test samples together with true labels (or references in text generation
-tasks). 
 In this task, only the `datalab` format is supported so far:
 
-* (1) `datalab`
-    * if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
+* (1) `datalab`: if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
     you fortunately don't need to prepare the dataset. 
-    Instead, you just need to remember the dataset name for later use.
-    * if your datasets haven't been supported by datalab but you want it supported, you can follow this 
-    [doc](https://github.com/ExpressAI/DataLab/blob/main/docs/SDK/add_new_datasets_into_sdk.md) to add them.
-
 
 ### Format of `System Output` File
 
-`System output` file usually only composed of predicted labels (or hypothesis, e.g., system-generated text),
-but sometimes `system output` will also contains test samples, such as `CoNLL` format in sequence labeling tasks.
 In this task, your system outputs should be:
 
 ```json

--- a/docs/task_qa_table_text_hybrid.md
+++ b/docs/task_qa_table_text_hybrid.md
@@ -6,7 +6,27 @@ with a hybrid of tabular and textual context.
 
 ## Data Preparation
 
-In order to perform analysis of your results, they should be in the following json format:
+To perform analysis of your results, usually two types of files should be pre-trained, which we will
+detailed below.
+
+### Format of `Dataset` File
+`Dataset` file usually consists of test samples together with true labels (or references in text generation
+tasks). 
+In this task, only the `datalab` format is supported so far:
+
+* (1) `datalab`
+    * if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
+    you fortunately don't need to prepare the dataset. 
+    Instead, you just need to remember the dataset name for later use.
+    * if your datasets haven't been supported by datalab but you want it supported, you can follow this 
+    [doc](https://github.com/ExpressAI/DataLab/blob/main/docs/SDK/add_new_datasets_into_sdk.md) to add them.
+
+
+### Format of `System Output` File
+
+`System output` file usually only composed of predicted labels (or hypothesis, e.g., system-generated text),
+but sometimes `system output` will also contains test samples, such as `CoNLL` format in sequence labeling tasks.
+In this task, your system outputs should be:
 
 ```json
 [

--- a/docs/task_text_classification.md
+++ b/docs/task_text_classification.md
@@ -1,18 +1,16 @@
 # Analyzing Text Classification
 
+
+Before diving into the detail of this doc, you're strongly recommended to know [some
+important concepts about system analyses](concepts_about_system_analysis.md).
+
 In this file we describe how to analyze text classification models.
 We will give an example using the `text-classification` [sst2](https://github.com/ExpressAI/ExplainaBoard/tree/main/data/datasets/sst2) dataset, but other datasets
 can be analyzed in a similar way.
 
 ## Data Preparation
-To perform analysis of your results, usually two types of files should be pre-trained, which we will
-detailed below.
-
+ 
 ### Format of `Dataset` File
-`Dataset` file usually consists of test samples together with true labels (or references in text generation
-tasks). 
-In this task, the following specific formats are supported 
-(the first two are also called custom datasets)
 
 * (1) `tsv` (without column names at the first row), see one [example](https://github.com/neulab/ExplainaBoard/blob/main/data/system_outputs/sst2/sst2-dataset.tsv)
 ```python
@@ -29,18 +27,13 @@ The movie is too long   negative
 ]
 ```
 
-* (3) `datalab`
-    * if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
+* (3) `datalab`: if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
     you fortunately don't need to prepare the dataset. 
-    Instead, you just need to remember the dataset name for later use.
-    * if your datasets haven't been supported by datalab but you want it supported, you can follow this 
-    [doc](https://github.com/ExpressAI/DataLab/blob/main/docs/SDK/add_new_datasets_into_sdk.md) to add them.
+  
 
 
 ### Format of `System Output` File
 
-`System output` file usually only composed of predicted labels (or hypothesis, e.g., system-generated text),
-but sometimes `system output` will also contains test samples, such as `CoNLL` format in sequence labeling tasks.
 In this task, your system outputs should be as follows:
 
 ```

--- a/docs/task_text_classification.md
+++ b/docs/task_text_classification.md
@@ -5,9 +5,43 @@ We will give an example using the `text-classification` [sst2](https://github.co
 can be analyzed in a similar way.
 
 ## Data Preparation
+To perform analysis of your results, usually two types of files should be pre-trained, which we will
+detailed below.
 
-In order to perform analysis of your results, your system outputs should be one
-predicted label per line:
+### Format of `Dataset` File
+`Dataset` file usually consists of test samples together with true labels (or references in text generation
+tasks). 
+In this task, the following specific formats are supported 
+(the first two are also called custom datasets)
+
+* (1) `tsv` (without column names at the first row), see one [example](https://github.com/neulab/ExplainaBoard/blob/main/data/system_outputs/sst2/sst2-dataset.tsv)
+```python
+I love this movie   positive
+The movie is too long   negative
+...
+```
+* (2) `json` (basically, it's a list of dictionaries with two keys: `text` and `true_label`)
+```json
+[
+  {"text": "I love this movie", "true_label": "positive"},
+  {"text": "The movie is too long", "true_label": "negative"}
+  ...
+]
+```
+
+* (3) `datalab`
+    * if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
+    you fortunately don't need to prepare the dataset. 
+    Instead, you just need to remember the dataset name for later use.
+    * if your datasets haven't been supported by datalab but you want it supported, you can follow this 
+    [doc](https://github.com/ExpressAI/DataLab/blob/main/docs/SDK/add_new_datasets_into_sdk.md) to add them.
+
+
+### Format of `System Output` File
+
+`System output` file usually only composed of predicted labels (or hypothesis, e.g., system-generated text),
+but sometimes `system output` will also contains test samples, such as `CoNLL` format in sequence labeling tasks.
+In this task, your system outputs should be as follows:
 
 ```
 predicted_label

--- a/docs/task_text_classification.md
+++ b/docs/task_text_classification.md
@@ -12,13 +12,16 @@ can be analyzed in a similar way.
  
 ### Format of `Dataset` File
 
-* (1) `tsv` (without column names at the first row), see one [example](https://github.com/neulab/ExplainaBoard/blob/main/data/system_outputs/sst2/sst2-dataset.tsv)
+* (1) `datalab`: if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
+    you fortunately don't need to prepare the dataset. 
+  
+* (2) `tsv` (without column names at the first row), see one [example](https://github.com/neulab/ExplainaBoard/blob/main/data/system_outputs/sst2/sst2-dataset.tsv)
 ```python
 I love this movie   positive
 The movie is too long   negative
 ...
 ```
-* (2) `json` (basically, it's a list of dictionaries with two keys: `text` and `true_label`)
+* (3) `json` (basically, it's a list of dictionaries with two keys: `text` and `true_label`)
 ```json
 [
   {"text": "I love this movie", "true_label": "positive"},
@@ -27,9 +30,7 @@ The movie is too long   negative
 ]
 ```
 
-* (3) `datalab`: if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
-    you fortunately don't need to prepare the dataset. 
-  
+
 
 
 ### Format of `System Output` File

--- a/docs/task_text_pair_classification.md
+++ b/docs/task_text_pair_classification.md
@@ -8,8 +8,40 @@ We will give an example using the `nature-language-inference`
 
 ## Data Preparation
 
-In order to perform analysis of your results, your system outputs should be one
-predicted label per line:
+### Format of `Dataset` File
+`Dataset` file usually consists of test samples together with true labels (or references in text generation
+tasks). 
+In this task, the following specific formats are supported 
+(the first two are also called custom datasets)
+
+* (1) `tsv` (without column names at the first row), see one [example](https://github.com/neulab/ExplainaBoard/blob/main/data/system_outputs/snli/snli-dataset.tsv)
+```python
+A man playing an electric guitar on stage.   A man playing banjo on the floor.  contradiction
+A man playing an electric guitar on stage.   A man is performing for cash.  neutral
+...
+```
+* (2) `json` (basically, it's a list of dictionaries with three keys: `text1`, `text2` and `true_label`)
+```json
+[
+  {"text1": "A man playing an electric guitar on stage.", "text2": "A man playing banjo on the floor.", "true_label": "contradiction"},
+  {"text1": "A man playing an electric guitar on stage.", "text2": "A man is performing for cash.", "true_label": "neutral"},
+  ...
+]
+```
+
+* (3) `datalab`
+    * if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
+    you fortunately don't need to prepare the dataset. 
+    Instead, you just need to remember the dataset name for later use.
+    * if your datasets haven't been supported by datalab but you want it supported, you can follow this 
+    [doc](https://github.com/ExpressAI/DataLab/blob/main/docs/SDK/add_new_datasets_into_sdk.md) to add them.
+
+
+### Format of `System Output` File
+
+`System output` file usually only composed of predicted labels (or hypothesis, e.g., system-generated text),
+but sometimes `system output` will also contains test samples, such as `CoNLL` format in sequence labeling tasks.
+In this task, your system outputs should be one predicted label per line:
 
 ```
 predicted_label

--- a/docs/task_text_pair_classification.md
+++ b/docs/task_text_pair_classification.md
@@ -1,5 +1,8 @@
 # Analyzing Text Pair Classification
 
+Before diving into the detail of this doc, you're strongly recommended to know [some
+important concepts about system analyses](concepts_about_system_analysis.md).
+
 
 In this file we describe how to analyze text pair classification models,
 such as natural language inference (NLI), paraphrase identification etc.
@@ -9,10 +12,6 @@ We will give an example using the `nature-language-inference`
 ## Data Preparation
 
 ### Format of `Dataset` File
-`Dataset` file usually consists of test samples together with true labels (or references in text generation
-tasks). 
-In this task, the following specific formats are supported 
-(the first two are also called custom datasets)
 
 * (1) `tsv` (without column names at the first row), see one [example](https://github.com/neulab/ExplainaBoard/blob/main/data/system_outputs/snli/snli-dataset.tsv)
 ```python
@@ -29,18 +28,11 @@ A man playing an electric guitar on stage.   A man is performing for cash.  neut
 ]
 ```
 
-* (3) `datalab`
-    * if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
+* (3) `datalab`: if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
     you fortunately don't need to prepare the dataset. 
-    Instead, you just need to remember the dataset name for later use.
-    * if your datasets haven't been supported by datalab but you want it supported, you can follow this 
-    [doc](https://github.com/ExpressAI/DataLab/blob/main/docs/SDK/add_new_datasets_into_sdk.md) to add them.
-
 
 ### Format of `System Output` File
 
-`System output` file usually only composed of predicted labels (or hypothesis, e.g., system-generated text),
-but sometimes `system output` will also contains test samples, such as `CoNLL` format in sequence labeling tasks.
 In this task, your system outputs should be one predicted label per line:
 
 ```

--- a/docs/task_text_pair_classification.md
+++ b/docs/task_text_pair_classification.md
@@ -13,13 +13,16 @@ We will give an example using the `nature-language-inference`
 
 ### Format of `Dataset` File
 
-* (1) `tsv` (without column names at the first row), see one [example](https://github.com/neulab/ExplainaBoard/blob/main/data/system_outputs/snli/snli-dataset.tsv)
+* (1) `datalab`: if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
+    you fortunately don't need to prepare the dataset. 
+
+* (2) `tsv` (without column names at the first row), see one [example](https://github.com/neulab/ExplainaBoard/blob/main/data/system_outputs/snli/snli-dataset.tsv)
 ```python
 A man playing an electric guitar on stage.   A man playing banjo on the floor.  contradiction
 A man playing an electric guitar on stage.   A man is performing for cash.  neutral
 ...
 ```
-* (2) `json` (basically, it's a list of dictionaries with three keys: `text1`, `text2` and `true_label`)
+* (3) `json` (basically, it's a list of dictionaries with three keys: `text1`, `text2` and `true_label`)
 ```json
 [
   {"text1": "A man playing an electric guitar on stage.", "text2": "A man playing banjo on the floor.", "true_label": "contradiction"},
@@ -28,8 +31,7 @@ A man playing an electric guitar on stage.   A man is performing for cash.  neut
 ]
 ```
 
-* (3) `datalab`: if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
-    you fortunately don't need to prepare the dataset. 
+
 
 ### Format of `System Output` File
 


### PR DESCRIPTION
Currently, we don't describe how custom datasets should be organized in the doc that describes each task's analysis setup. This prevents new users from using the custom datasets.

Relevant issues: 
* https://github.com/neulab/ExplainaBoard/issues/465
* https://github.com/neulab/explainaboard_web/issues/300