### PR TITLE
Add typing information around Metric

### DIFF
--- a/explainaboard/metrics/accuracy.py
+++ b/explainaboard/metrics/accuracy.py
@@ -21,7 +21,7 @@ from explainaboard.metrics.registry import metric_config_registry
 class AccuracyConfig(MetricConfig):
     """Configuration for the Accuracy metric."""
 
-    def to_metric(self):
+    def to_metric(self) -> Metric:
         """See MetricConfig.to_metric."""
         return Accuracy(self)
 
@@ -51,7 +51,7 @@ class Accuracy(Metric):
 class CorrectCountConfig(MetricConfig):
     """Configuration for CorrectCount."""
 
-    def to_metric(self):
+    def to_metric(self) -> Metric:
         """See MetricConfig.to_metric."""
         return CorrectCount(self)
 
@@ -90,7 +90,7 @@ class CorrectCount(Accuracy):
 class SeqCorrectCountConfig(MetricConfig):
     """Configuration for SeqCorrectCount."""
 
-    def to_metric(self):
+    def to_metric(self) -> Metric:
         """See MetricConfig.to_metric."""
         return SeqCorrectCount(self)
 

--- a/explainaboard/metrics/continuous.py
+++ b/explainaboard/metrics/continuous.py
@@ -21,7 +21,7 @@ from explainaboard.metrics.registry import metric_config_registry
 class RootMeanSquaredErrorConfig(MetricConfig):
     """Configuration for RootMeanSquaredError."""
 
-    def to_metric(self):
+    def to_metric(self) -> Metric:
         """See MetricConfig.to_metric."""
         return RootMeanSquaredError(self)
 
@@ -53,7 +53,7 @@ class RootMeanSquaredError(Metric):
 class AbsoluteErrorConfig(MetricConfig):
     """Configuration for AbsoluteError."""
 
-    def to_metric(self):
+    def to_metric(self) -> Metric:
         """See MetricConfig.to_metric."""
         return AbsoluteError(self)
 

--- a/explainaboard/metrics/eaas.py
+++ b/explainaboard/metrics/eaas.py
@@ -86,7 +86,7 @@ class EaaSMetricStats(MetricStats):
 class EaaSMetricConfig(MetricConfig):
     """Configuration for EaaSMetric."""
 
-    def to_metric(self):
+    def to_metric(self) -> Metric:
         """See MetricConfig.to_metric."""
         return EaaSMetric(self)
 

--- a/explainaboard/metrics/external_eval.py
+++ b/explainaboard/metrics/external_eval.py
@@ -54,7 +54,7 @@ class ExternalEvalConfig(MetricConfig):
     # of test samples, the column size is equal to `n_annotators`.
     external_stats: np.ndarray | None = None
 
-    def to_metric(self):
+    def to_metric(self) -> Metric:
         """See MetricConfig.to_metric."""
         return ExternalEval(self)
 

--- a/explainaboard/metrics/external_eval_test.py
+++ b/explainaboard/metrics/external_eval_test.py
@@ -11,6 +11,7 @@ from explainaboard.metrics.external_eval import (
     ExternalEvalConfig,
     UNANNOTATED_SYMBOL,
 )
+from explainaboard.utils.typing_utils import narrow
 
 
 class ExternalEvalConfigTest(unittest.TestCase):
@@ -23,7 +24,10 @@ class ExternalEvalConfigTest(unittest.TestCase):
 
 class ExternalEvalTest(unittest.TestCase):
     def test_calc_stats_from_external(self) -> None:
-        metric = ExternalEvalConfig("ExternalEval", n_annotators=2).to_metric()
+        metric = narrow(
+            ExternalEval, ExternalEvalConfig("ExternalEval", n_annotators=2).to_metric()
+        )
+
         stats = metric.calc_stats_from_external(
             ExternalEvalConfig(
                 "ExternalEval",

--- a/explainaboard/metrics/extractive_qa.py
+++ b/explainaboard/metrics/extractive_qa.py
@@ -68,7 +68,7 @@ class ExtractiveQAMetric(Metric):
 class ExactMatchQAConfig(MetricConfig):
     """Configuration for ExactMatchQA."""
 
-    def to_metric(self):
+    def to_metric(self) -> Metric:
         """See MetricConfig.to_metric."""
         return ExactMatchQA(self)
 
@@ -88,7 +88,7 @@ class ExactMatchQA(ExtractiveQAMetric):
 class F1ScoreQAConfig(MetricConfig):
     """Configuration for F1ScoreQA."""
 
-    def to_metric(self):
+    def to_metric(self) -> Metric:
         """See MetricConfig.to_metric."""
         return F1ScoreQA(self)
 

--- a/explainaboard/metrics/f1_score.py
+++ b/explainaboard/metrics/f1_score.py
@@ -39,7 +39,7 @@ class F1ScoreConfig(MetricConfig):
     separate_match: bool = False
     ignore_classes: Optional[list] = None
 
-    def to_metric(self):
+    def to_metric(self) -> Metric:
         """See MetricConfig.to_metric."""
         return F1Score(self)
 
@@ -143,7 +143,7 @@ class F1Score(Metric):
 class APEF1ScoreConfig(MetricConfig):
     """Configuration for APEF1Score."""
 
-    def to_metric(self):
+    def to_metric(self) -> Metric:
         """See MetricConfig.to_metric."""
         return APEF1Score(self)
 
@@ -211,7 +211,7 @@ class SeqF1ScoreConfig(F1ScoreConfig):
 
     tag_schema: str = 'bio'
 
-    def to_metric(self):
+    def to_metric(self) -> Metric:
         """See MetricConfig.to_metric."""
         return SeqF1Score(self)
 

--- a/explainaboard/metrics/log_prob.py
+++ b/explainaboard/metrics/log_prob.py
@@ -28,7 +28,7 @@ class LogProbConfig(MetricConfig):
 
     ppl: bool = False
 
-    def to_metric(self):
+    def to_metric(self) -> Metric:
         """See MetricConfig.to_metric."""
         return LogProb(self)
 

--- a/explainaboard/metrics/metric.py
+++ b/explainaboard/metrics/metric.py
@@ -37,7 +37,7 @@ class MetricResult:
     confidence_alpha: Optional[float] = None
     auxiliary_result: AuxiliaryMetricResult | None = None
 
-    def to_dict(self):
+    def to_dict(self) -> dict[str, Any]:
         """Return the metric result as a serializable dictionary.
 
         Returns:
@@ -76,16 +76,16 @@ class MetricConfig(dict):
     cls_name: str | None = None
     external_stats: np.ndarray | None = None
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         """Set the class name for the metric config."""
         self.cls_name = type(self).__name__
 
-    def to_metric(self):
+    def to_metric(self) -> Metric:
         """See MetricConfig.to_metric."""
         raise NotImplementedError
 
     @classmethod
-    def dict_conv(cls, k, v):
+    def dict_conv(cls, k: str, v: Any) -> Any:
         """Conversion for serialization."""
         return v
 

--- a/explainaboard/metrics/nlg_meta_evaluation.py
+++ b/explainaboard/metrics/nlg_meta_evaluation.py
@@ -159,7 +159,7 @@ class KtauCorrelationConfig(CorrelationConfig):
 
     threshold: float = 25
 
-    def to_metric(self):
+    def to_metric(self) -> Metric:
         """See MetricConfig.to_metric."""
         return KtauCorrelation(self)
 
@@ -211,7 +211,7 @@ class KtauCorrelation(CorrelationMetric):
 class PearsonCorrelationConfig(CorrelationConfig):
     """A configuration for the PearsonCorrelation metric."""
 
-    def to_metric(self):
+    def to_metric(self) -> Metric:
         """See MetricConfig.to_metric."""
         return PearsonCorrelation(self)
 

--- a/explainaboard/metrics/qa_table_text_hybrid.py
+++ b/explainaboard/metrics/qa_table_text_hybrid.py
@@ -85,7 +85,7 @@ class QATatMetric(Metric):
 class ExactMatchQATatConfig(MetricConfig):
     """Configuration for ExactMatchQATat."""
 
-    def to_metric(self):
+    def to_metric(self) -> Metric:
         """See MetricConfig.to_metric."""
         return ExactMatchQATat(self)
 
@@ -112,7 +112,7 @@ class ExactMatchQATat(QATatMetric):
 class F1ScoreQATatConfig(MetricConfig):
     """Configuration for F1ScoreQATat."""
 
-    def to_metric(self):
+    def to_metric(self) -> Metric:
         """See MetricConfig.to_metric."""
         return F1ScoreQATat(self)
 

--- a/explainaboard/metrics/ranking.py
+++ b/explainaboard/metrics/ranking.py
@@ -18,7 +18,7 @@ from explainaboard.metrics.registry import metric_config_registry
 from explainaboard.utils.typing_utils import unwrap_or
 
 
-class RankingMetric(Metric):
+class RankingMetric(Metric, metaclass=abc.ABCMeta):
     """A metric for ranking."""
 
     @abc.abstractmethod
@@ -48,7 +48,7 @@ class HitsConfig(MetricConfig):
 
     hits_k: int = 5
 
-    def to_metric(self):
+    def to_metric(self) -> Metric:
         """See MetricConfig.to_metric."""
         return Hits(self)
 
@@ -88,7 +88,7 @@ class Hits(RankingMetric):
 class MeanReciprocalRankConfig(MetricConfig):
     """Configuration for MeanReciprocalRank."""
 
-    def to_metric(self):
+    def to_metric(self) -> Metric:
         """See MetricConfig.to_metric."""
         return MeanReciprocalRank(self)
 
@@ -128,7 +128,7 @@ class MeanReciprocalRank(RankingMetric):
 class MeanRankConfig(MetricConfig):
     """Configuration for MeanReciprocalRank."""
 
-    def to_metric(self):
+    def to_metric(self) -> Metric:
         """See MetricConfig.to_metric."""
         return MeanRank(self)
 


### PR DESCRIPTION
This pull request adds some missing type information around `Metric`. This change helps static analysis that is somewhat required for refactoring.