### PR TITLE
Change the version of pypa/gh-action-pypi-publish from master to release/v1

### DIFF
--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -26,7 +26,7 @@ jobs:
         run: >-
           python setup.py sdist bdist_wheel --universal
       - name: Publish distribution 📦 to PyPI
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
           skip_existing: false


### PR DESCRIPTION
PyPI publish GitHub Action made the [master branch version sunset](https://github.com/pypa/gh-action-pypi-publish#-master-branch-sunset-) 2 months ago. This PR uses the released version `release/v1` instead.