### PR TITLE
Use same versions of actions as ci.yml

### DIFF
--- a/.github/workflows/publish-to-test-pypi.yml
+++ b/.github/workflows/publish-to-test-pypi.yml
@@ -10,9 +10,9 @@ jobs:
     name: Build and publish Python 🐍 distributions 📦 to PyPI
     runs-on: ubuntu-18.04
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v3
       - name: Set up Python 3.9
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v3
         with:
           python-version: 3.9
       - name: Install pypa/build


### PR DESCRIPTION
This PR updates version of actions in `publish-to-test-pypi.yml` so that the workflow uses same version of actions used in `ci.yml`. It is better to use a single version to reduce maintenance costs and avoid accidental troubles caused by two different version of the same actions.