### PR TITLE
Clarified length mismatch message

### DIFF
--- a/explainaboard/loaders/loader.py
+++ b/explainaboard/loaders/loader.py
@@ -187,8 +187,9 @@ class Loader:
             dataset_loaded_data.metadata.merge(output_loaded_data.metadata)
             if len(dataset_loaded_data) != len(output_loaded_data):
                 raise ValueError(
-                    "dataset and output are of different length"
-                    + f"({len(dataset_loaded_data)} != {len(output_loaded_data)})"
+                    "the number of examples in the system output "
+                    f"({len(output_loaded_data)}) does not match the number of "
+                    f"examples in the dataset ({len(dataset_loaded_data)})"
                 )
             data_list: list[dict] = output_loaded_data.samples
             for i, output in enumerate(data_list):


### PR DESCRIPTION
A common error for users is that they try to analyze a file that is of different length than expected. This makes the error message displayed in this case a bit more explicit.