### PR TITLE
Remove prop_samples from calc_confidence_interval

### DIFF
--- a/explainaboard/metrics/metric.py
+++ b/explainaboard/metrics/metric.py
@@ -364,11 +364,11 @@ class Metric:
             )
         # Do bootstrapping otherwise
         else:
-            n_elems = len(stats)
+            sample_size = len(stats)
             all_indices = np.array(range(len(stats)))
             rng = np.random.default_rng()
             all_indices = rng.choice(
-                all_indices, size=(n_samples, n_elems), replace=True
+                all_indices, size=(n_samples, sample_size), replace=True
             )
             filt_stats = stats.filter(all_indices)
             agg_stats = self.aggregate_stats(filt_stats)

--- a/explainaboard/metrics/metric.py
+++ b/explainaboard/metrics/metric.py
@@ -365,7 +365,7 @@ class Metric:
         # Do bootstrapping otherwise
         else:
             sample_size = len(stats)
-            all_indices = np.array(range(len(stats)))
+            all_indices = np.array(range(sample_size))
             rng = np.random.default_rng()
             all_indices = rng.choice(
                 all_indices, size=(num_iterations, sample_size), replace=True

--- a/explainaboard/metrics/metric.py
+++ b/explainaboard/metrics/metric.py
@@ -321,7 +321,7 @@ class Metric:
         self,
         stats: MetricStats,
         confidence_alpha: float,
-        n_samples: int = 1000,
+        num_iterations: int = 1000,
         config: Optional[MetricConfig] = None,
     ) -> tuple[float, float] | None:
         """Calculate the confidence interval of a statistics function.
@@ -329,7 +329,7 @@ class Metric:
         Args:
             stats: sufficient statistics as calculated by calc_stats_from_data
             confidence_alpha: the inverse confidence level of the confidence interval
-            n_samples: the number of bootstrapping samples
+            num_iterations: the number of iterations to perform resampling
             config: a configuration to over-ride the default for this object
 
         Returns:
@@ -368,14 +368,14 @@ class Metric:
             all_indices = np.array(range(len(stats)))
             rng = np.random.default_rng()
             all_indices = rng.choice(
-                all_indices, size=(n_samples, sample_size), replace=True
+                all_indices, size=(num_iterations, sample_size), replace=True
             )
             filt_stats = stats.filter(all_indices)
             agg_stats = self.aggregate_stats(filt_stats)
             samp_results = self.calc_metric_from_aggregate(agg_stats, config)
             samp_results.sort()
-            low = int(n_samples * confidence_alpha / 2.0)
-            high = int(n_samples * (1.0 - confidence_alpha / 2.0))
+            low = int(num_iterations * confidence_alpha / 2.0)
+            high = int(num_iterations * (1.0 - confidence_alpha / 2.0))
             return float(samp_results[low]), float(samp_results[high])
 
     def evaluate_from_stats(

--- a/explainaboard/metrics/metric.py
+++ b/explainaboard/metrics/metric.py
@@ -322,7 +322,6 @@ class Metric:
         stats: MetricStats,
         confidence_alpha: float,
         n_samples: int = 1000,
-        prop_samples: float = 0.5,
         config: Optional[MetricConfig] = None,
     ) -> tuple[float, float] | None:
         """Calculate the confidence interval of a statistics function.
@@ -331,7 +330,6 @@ class Metric:
             stats: sufficient statistics as calculated by calc_stats_from_data
             confidence_alpha: the inverse confidence level of the confidence interval
             n_samples: the number of bootstrapping samples
-            prop_samples: the proportion of samples to sample each time
             config: a configuration to over-ride the default for this object
 
         Returns:
@@ -366,7 +364,7 @@ class Metric:
             )
         # Do bootstrapping otherwise
         else:
-            n_elems = max(int(prop_samples * len(stats)), 1)
+            n_elems = len(stats)
             all_indices = np.array(range(len(stats)))
             rng = np.random.default_rng()
             all_indices = rng.choice(


### PR DESCRIPTION
The sampling part of the procedure of *Bootstrapping* can be summarized at high level if I understand it correctly:
1. Resample each sample in the given data.
2. Repeat Step 1 several times

where the number of random samples generated in Step 1 should be same as the number of samples in the data. 
(The similar description is found in [scipy.stats.bootstrap](https://docs.scipy.org/doc/scipy/reference/generated/scipy.stats.bootstrap.html#scipy-stats-bootstrap))

However, it seems `calc_confidence_interval` implements differently, which raises a concern for the correctness of the algorithm. I could be wrong, but it seems better to prefer the correctness over the efficiency of resampling given that computed values with this library could be used in someone's research. With this in mind, this PR removes `prop_samples` from `calc_confidence_interval`.