### PR TITLE
Rename TextClassificationProcessor to TabularClassificationProcessor

### DIFF
--- a/explainaboard/processors/tabular_classification.py
+++ b/explainaboard/processors/tabular_classification.py
@@ -22,7 +22,7 @@ from explainaboard.processors.processor_registry import register_processor
 
 
 @register_processor(TaskType.tabular_classification)
-class TextClassificationProcessor(Processor):
+class TabularClassificationProcessor(Processor):
     """A processor for the tabular classification task."""
 
     @classmethod

--- a/explainaboard/processors/tabular_classification_test.py
+++ b/explainaboard/processors/tabular_classification_test.py
@@ -6,12 +6,14 @@ import unittest
 
 from explainaboard import TaskType
 from explainaboard.processors.processor_registry import get_processor
-from explainaboard.processors.tabular_classification import TextClassificationProcessor
+from explainaboard.processors.tabular_classification import (
+    TabularClassificationProcessor,
+)
 
 
-class TextClassificationProcessorTest(unittest.TestCase):
+class TabularClassificationProcessorTest(unittest.TestCase):
     def test_get_processor(self) -> None:
         self.assertIsInstance(
             get_processor(TaskType.tabular_classification.value),
-            TextClassificationProcessor,
+            TabularClassificationProcessor,
         )


### PR DESCRIPTION
`TextClassificationProcessor` is not unique to the codebase. The same class name exists in `explainaboard/processors/tabular_classification.py` and `explainaboard/processors/text_classification.py`. This PR renames the class name in `explainaboard/processors/tabular_classification.py` to `TabularClassificationProcessor` to make  `TextClassificationProcessor` unique to the codebase.