### PR TITLE
Refactor preprocessor.py

### DIFF
--- a/explainaboard/loaders/file_loader.py
+++ b/explainaboard/loaders/file_loader.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 import copy
 import csv
 import dataclasses
@@ -30,7 +31,6 @@ from explainaboard.analysis.feature import FeatureType
 from explainaboard.constants import Source
 from explainaboard.serialization.serializers import PrimitiveSerializer
 from explainaboard.utils.load_resources import get_customized_features
-from explainaboard.utils.preprocessor import Preprocessor
 from explainaboard.utils.typing_utils import narrow
 
 DType = Union[Type[int], Type[float], Type[str], Type[dict], Type[list]]
@@ -61,7 +61,7 @@ class FileLoaderField:
     target_name: int | str
     dtype: Optional[DType] = None
     strip_before_parsing: Optional[bool] = None
-    parser: Optional[Preprocessor] = None
+    parser: Optional[Callable[[str], str]] = None
 
     # Special constants used in field mapping
     SOURCE_LANGUAGE: ClassVar[str] = '__SOURCE_LANGUAGE__'

--- a/explainaboard/loaders/kg_link_tail_prediction.py
+++ b/explainaboard/loaders/kg_link_tail_prediction.py
@@ -15,7 +15,8 @@ from explainaboard.loaders.file_loader import (
 from explainaboard.loaders.loader import Loader
 from explainaboard.loaders.loader_registry import register_loader
 from explainaboard.utils import cache_api
-from explainaboard.utils.preprocessor import KGMapPreprocessor
+from explainaboard.utils.preprocessor import MapPreprocessor
+from explainaboard.utils.typing_utils import narrow
 
 
 @register_loader(TaskType.kg_link_tail_prediction)
@@ -52,9 +53,13 @@ class KgLinkTailPredictionLoader(Loader):
             'explainaboard/task_data/kg_link_tail_prediction/entity2wikidata.json',
         )
         with open(file_path, 'r') as file:
-            entity_dic = json.loads(file.read())
+            entity_dic = json.load(file)
 
-        map_preprocessor = KGMapPreprocessor(resources={"dictionary": entity_dic})
+        map_preprocessor = MapPreprocessor(
+            dictionary={
+                narrow(str, k): narrow(str, v["label"]) for k, v in entity_dic.items()
+            }
+        )
 
         target_field_names = [
             "true_head",

--- a/explainaboard/metrics/extractive_qa.py
+++ b/explainaboard/metrics/extractive_qa.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import abc
 from collections import Counter
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Optional, Union
 
@@ -16,7 +17,7 @@ from explainaboard.metrics.metric import (
     SimpleMetricStats,
 )
 from explainaboard.serialization import common_registry
-from explainaboard.utils.preprocessor import ExtractiveQAPreprocessor, Preprocessor
+from explainaboard.utils.preprocessor import ExtractiveQAPreprocessor
 from explainaboard.utils.typing_utils import unwrap_or
 
 
@@ -48,7 +49,7 @@ class ExtractiveQAMetric(Metric):
 
     @abc.abstractmethod
     def sample_level_metric(
-        self, ground_truth: str, prediction: str, preprocessor: Preprocessor
+        self, ground_truth: str, prediction: str, preprocessor: Callable[[str], str]
     ) -> float:
         """Calculate the metric  for a single sample.
 
@@ -77,7 +78,7 @@ class ExactMatchQA(ExtractiveQAMetric):
     """Calculate a score for extractive QA based on exact match."""
 
     def sample_level_metric(
-        self, ground_truth: str, prediction: str, preprocessor: Preprocessor
+        self, ground_truth: str, prediction: str, preprocessor: Callable[[str], str]
     ) -> float:
         """See ExtractiveQAMetric.sample_level_metric."""
         return 1.0 if preprocessor(prediction) == preprocessor(ground_truth) else 0.0
@@ -97,7 +98,7 @@ class F1ScoreQA(ExtractiveQAMetric):
     """Calculate a score for extractive QA based on F1 score."""
 
     def sample_level_metric(
-        self, ground_truth: str, prediction: str, preprocessor: Preprocessor
+        self, ground_truth: str, prediction: str, preprocessor: Callable[[str], str]
     ):
         """See ExtractiveQAMetric.sample_level_metric."""
         prediction_tokens = preprocessor(prediction).split()

--- a/explainaboard/metrics/qa_table_text_hybrid.py
+++ b/explainaboard/metrics/qa_table_text_hybrid.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import abc
+from collections.abc import Callable
 from dataclasses import dataclass
 import itertools
 from typing import Optional
@@ -17,7 +18,7 @@ from explainaboard.metrics.metric import (
     SimpleMetricStats,
 )
 from explainaboard.serialization import common_registry
-from explainaboard.utils.preprocessor import ExtractiveQAPreprocessor, Preprocessor
+from explainaboard.utils.preprocessor import ExtractiveQAPreprocessor
 from explainaboard.utils.typing_utils import unwrap_or
 
 
@@ -74,7 +75,7 @@ class QATatMetric(Metric):
 
     @abc.abstractmethod
     def sample_level_metric(
-        self, ground_truth: str, prediction: str, preprocessor: Preprocessor
+        self, ground_truth: str, prediction: str, preprocessor: Callable[[str], str]
     ) -> float:
         """Calculate a score given a ground truth answer string and a prediction."""
         ...
@@ -98,7 +99,7 @@ class ExactMatchQATat(QATatMetric):
         return True
 
     def sample_level_metric(
-        self, ground_truth: str, prediction: str, preprocessor: Preprocessor
+        self, ground_truth: str, prediction: str, preprocessor: Callable[[str], str]
     ) -> float:
         """See QATatMetric.sample_level_metric."""
         ground_truths = eval_util._answer_to_bags(ground_truth)
@@ -125,7 +126,7 @@ class F1ScoreQATat(QATatMetric):
         return True
 
     def sample_level_metric(
-        self, ground_truth: str, prediction: str, preprocessor: Preprocessor
+        self, ground_truth: str, prediction: str, preprocessor: Callable[[str], str]
     ):
         """See QATatMetric.sample_level_metric."""
         ground_truths = eval_util._answer_to_bags(ground_truth)

--- a/explainaboard/utils/preprocessor_test.py
+++ b/explainaboard/utils/preprocessor_test.py
@@ -1,32 +1,27 @@
+"""Tests for explainaboard.utils.preprocessor."""
+
 import unittest
 
 from explainaboard.utils.preprocessor import ExtractiveQAPreprocessor, MapPreprocessor
 
 
-class ExampleCodeTest(unittest.TestCase):
-    """
-    This tests preprocessor class
-    """
-
-    def test_mlqa_preprocessor(self):
+class ExtractiveQAPreprocessorTest(unittest.TestCase):
+    def test_non_mixed_segmentation_languages(self):
         en_preprocessor = ExtractiveQAPreprocessor(language='en')
         text = "This is a boring movie."
         text_processed = en_preprocessor(text)
         self.assertEqual(text_processed, "this is boring movie")
 
+    def test_mixed_segmentation_languages(self):
         zh_preprocessor = ExtractiveQAPreprocessor(language='zh')
         text = "这一部电影看着很无聊"
         text_processed = zh_preprocessor(text)
         self.assertEqual(text_processed, "这 一 部 电 影 看 着 很 无 聊")
 
-    def test_map_preprocessor(self):
+
+class MapPreprocessorTest(unittest.TestCase):
+    def test_call(self):
         dictionary = {"aaaa": "a", "bbbb": "b"}
-        my_preprocessor = MapPreprocessor(resources={"dictionary": dictionary})
-
-        text = "aaaa"
-        res = my_preprocessor(text)
-        self.assertEqual(res, "a")
-
-        text = "ab"
-        res = my_preprocessor(text)
-        self.assertEqual(res, "ab")
+        preprocessor = MapPreprocessor(dictionary=dictionary)
+        self.assertEqual(preprocessor("aaaa"), "a")
+        self.assertEqual(preprocessor("ab"), "ab")

--- a/explainaboard/utils/preprocessor_test.py
+++ b/explainaboard/utils/preprocessor_test.py
@@ -24,4 +24,4 @@ class MapPreprocessorTest(unittest.TestCase):
         dictionary = {"aaaa": "a", "bbbb": "b"}
         preprocessor = MapPreprocessor(dictionary=dictionary)
         self.assertEqual(preprocessor("aaaa"), "a")
-        self.assertEqual(preprocessor("ab"), "ab")
+        self.assertEqual(preprocessor("xbbbb"), "xbbbb")

--- a/explainaboard/utils/tokenizer.py
+++ b/explainaboard/utils/tokenizer.py
@@ -47,7 +47,7 @@ def get_default_tokenizer(lang: str | None) -> Tokenizer:
 
 @final
 @dataclass(frozen=True)
-class TokenSeq(Sequence[str]):
+class TokenSeq:
     """Dataclass representing a list of tokens and its original positions."""
 
     strs: list[str]

--- a/explainaboard/utils/tokenizer.py
+++ b/explainaboard/utils/tokenizer.py
@@ -9,7 +9,7 @@ from functools import lru_cache
 import re
 import string
 import sys
-from typing import final
+from typing import final, overload
 import unicodedata
 
 from sacrebleu.tokenizers import BaseTokenizer
@@ -47,7 +47,7 @@ def get_default_tokenizer(lang: str | None) -> Tokenizer:
 
 @final
 @dataclass(frozen=True)
-class TokenSeq(Sequence):
+class TokenSeq(Sequence[str]):
     """Dataclass representing a list of tokens and its original positions."""
 
     strs: list[str]
@@ -57,6 +57,14 @@ class TokenSeq(Sequence):
         """Perform checks of validity."""
         if len(self.strs) != len(self.positions):
             raise ValueError("strs and positions must be the same length.")
+
+    @overload
+    def __getitem__(self, index: int) -> str:  # noqa: D105: suppress bug
+        ...
+
+    @overload
+    def __getitem__(self, index: slice) -> Sequence[str]:  # noqa: D105: suppress bug
+        ...
 
     def __getitem__(self, item: int | slice) -> str | Sequence[str]:
         """Get an item or slice from the sequence."""


### PR DESCRIPTION
This change refactors `explainaboard/utils/preprocessor.py`. Specifically, this removes `Preprocrssor` class and all subclasses are reformed to behave as `Callable[[str], str]`.