### PR TITLE
Rename GrammaticalErrorCorrection to GrammaticalErrorCorrectionProcessor

### DIFF
--- a/explainaboard/processors/grammatical_error_correction.py
+++ b/explainaboard/processors/grammatical_error_correction.py
@@ -18,7 +18,7 @@ from explainaboard.processors.processor_registry import register_processor
 
 
 @register_processor(TaskType.grammatical_error_correction)
-class GrammaticalErrorCorrection(Processor):
+class GrammaticalErrorCorrectionProcessor(Processor):
     """A processor for the grammatical error correction task."""
 
     @classmethod

--- a/explainaboard/processors/grammatical_error_correction_test.py
+++ b/explainaboard/processors/grammatical_error_correction_test.py
@@ -6,14 +6,14 @@ import unittest
 
 from explainaboard import TaskType
 from explainaboard.processors.grammatical_error_correction import (
-    GrammaticalErrorCorrection,
+    GrammaticalErrorCorrectionProcessor,
 )
 from explainaboard.processors.processor_registry import get_processor
 
 
-class GrammaticalErrorCorrectionTest(unittest.TestCase):
+class GrammaticalErrorCorrectionProcessorTest(unittest.TestCase):
     def test_get_processor(self) -> None:
         self.assertIsInstance(
             get_processor(TaskType.grammatical_error_correction.value),
-            GrammaticalErrorCorrection,
+            GrammaticalErrorCorrectionProcessor,
         )


### PR DESCRIPTION
The processor class for grammatical error correction task, `GrammaticalErrorCorrection` is the only processor which doesn't end with a suffix "Processor". This PR renames the class name to `GrammaticalErrorCorrectionProcessor` to make the naming of processor consistent in the codebase.