### PR TITLE
Bump mypy version to 0.981

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/python/black.git
-    rev: 22.3.0 
+    rev: 22.3.0
     hooks:
       - id: black
         files: '\.py$'
@@ -35,7 +35,7 @@ repos:
       - id: upgrade-type-hints
         files: '\.py$'
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: 'v0.942'
+    rev: 'v0.981'
     hooks:
       - id: mypy
         additional_dependencies:

--- a/explainaboard/analysis/analyses.py
+++ b/explainaboard/analysis/analyses.py
@@ -19,8 +19,7 @@ from explainaboard.serialization.serializers import PrimitiveSerializer
 from explainaboard.utils.typing_utils import narrow, unwrap, unwrap_generator
 
 
-# See https://github.com/python/mypy/issues/5374
-@dataclass  # type: ignore
+@dataclass
 class AnalysisResult(metaclass=abc.ABCMeta):
     """A base class specifying the result of an analysis.
 

--- a/explainaboard/metrics/metric.py
+++ b/explainaboard/metrics/metric.py
@@ -55,10 +55,7 @@ class MetricResult:
         return ret
 
 
-# TODO(tetsuok): Remove the following type-ignore annotation when we update
-# mypy version to 0.980 or newer.
-# See https://github.com/python/mypy/issues/5374 for details.
-@dataclass  # type:ignore
+@dataclass
 class MetricConfig(SerializableDataclass, metaclass=abc.ABCMeta):
     """The configuration for a metric.
 


### PR DESCRIPTION
This PR bumps mypy version to 0.981. This is to remove "ignore" comments to silence mypy. 

* The version includes a fix for python/mypy#5374. This PR removes the comments to silence mypy due to the issue.
* The version has a fix for python/mypy#731. The fix is enabled when running mypy with `--enable-recursive-aliases` ([link to blog post](http://mypy-lang.blogspot.com/2022/09/mypy-0981-released.html)), but this PR doesn't enable the fix, deferring to a separate PR. This is because using the option causes different 91 errors. It seems better to tackle enabling the option in a separate PR.
* The version doesn't have a fix for python/mypy#4717, unfortunately. mypy still complains when the comments were removed.