### PR TITLE
Introduce dict[str, Performance]

### DIFF
--- a/docs/example_scripts/test_kg.py
+++ b/docs/example_scripts/test_kg.py
@@ -31,9 +31,7 @@ sys_info.print_as_json(file=open("./report.json", 'w'))
 
 
 # get overall results of different metrics
-for metric_info in unwrap(sys_info.results.overall)[0]:
-
-    name = metric_info.metric_name
+for name, metric_info in sys_info.results.overall[0].items():
     value = metric_info.value
     confidence_score_low = metric_info.confidence_score_low
     confidence_score_high = metric_info.confidence_score_high
@@ -50,8 +48,7 @@ for metric_info in unwrap(sys_info.results.overall)[0]:
 for analyses in fine_grained_res:
     buckets = cast(BucketAnalysisResult, analyses)
     for bucket_info in buckets.bucket_performances:
-        for bucket_performance in bucket_info.performances:
-            metric_name = bucket_performance.metric_name
+        for metric_name, bucket_performance in bucket_info.performances.items():
             value = bucket_performance.value
             confidence_score_low = bucket_performance.confidence_score_low
             confidence_score_high = bucket_performance.confidence_score_high

--- a/docs/task_kg_link_tail_prediction.md
+++ b/docs/task_kg_link_tail_prediction.md
@@ -269,11 +269,9 @@ The options for the `"sort_by"` option are:
 2. `"performance_value"`: sort by bucket performance. Since each bucket has multiple metrics associated with it, use the `"sort_by_metric"` to choose which metric to sort on.
 3. `"n_bucket_samples"`, sort by the number of samples in each bucket.
 
-The `"sort_by_metric"` option is applicable when the `"sort_by"` option is set to `"performance_value"`. The options for the `"sort_by_metric"` option are:
-1. `"Hits"`, `"MeanRank"`, `"MeanReciprocalRank"`, etc: sort by a specific metric name. These names refer to the `metric_name` keyword in your metric definitions (i.e. what you pass into the `"metric_configs"` key in the `metadata` dictionary).
-2. `"first"` (default): sort by the value of the first BucketPerformance object which Explainaboard internally uses, whichever that may be. Not recommended to use this option; instead, specify the metric to sort on explicitly.
+The `"sort_by_metric"` option is applicable when the `"sort_by"` option is set to `"performance_value"`. The options for the `"sort_by_metric"` option are `"Hits"`, `"MR"`, `"MRR"`, etc: sort by a specific metric name. These names refer to the `metric_name` keyword in your metric definitions (i.e. what you pass into the `"metric_configs"` key in the `metadata` dictionary).
 
-The `"sort_by_metric"` option is applicable when the `"sort_by"` option is set to either `"performance_value"` or `"n_bucket_samples"`. The options for the `"sort_ascending"` option are:
+The `"sort_by_metric"` option is applicable when the `"sort_by"` option is set to `"performance_value"`. The options for the `"sort_ascending"` option are:
 1. `False` (default): sort high-to-low.
 2. `True`: sort low-to-high; useful for e.g. the `"MeanRank"` metric.
 

--- a/docs/task_kg_link_tail_prediction.md
+++ b/docs/task_kg_link_tail_prediction.md
@@ -257,7 +257,7 @@ metadata = {
     MeanRankConfig(name='MR'),
   ],
   "sort_by": "performance_value",
-  "sort_by_metric": "first",
+  "sort_by_metric": "Hits4"
 }
 
 processor = get_processor_class(TaskType.kg_link_tail_prediction)()

--- a/explainaboard/analysis/analyses.py
+++ b/explainaboard/analysis/analyses.py
@@ -163,20 +163,15 @@ class BucketAnalysisResult(AnalysisResult):
 
     def __post_init__(self):
         """Set the class name and validate."""
-        metric_names = [x.metric_name for x in self.bucket_performances[0].performances]
-        num_metrics = len(metric_names)
+        metric_names = self.bucket_performances[0].performances.keys()
+
         for bucket_perf in self.bucket_performances:
-            if len(bucket_perf.performances) != num_metrics:
+            if bucket_perf.performances.keys() != metric_names:
                 raise ValueError(
-                    "Inconsistent number of metrics. "
-                    f"Required: {num_metrics}, got: {len(bucket_perf.performances)}"
+                    "Inconsistent metrics. "
+                    f"Required: {set(metric_names)}, "
+                    f"got: {set(bucket_perf.performances.keys())}"
                 )
-            for metric_name, perf in zip(metric_names, bucket_perf.performances):
-                if perf.metric_name != metric_name:
-                    raise ValueError(
-                        "Inconsistent metric names. "
-                        f"Required: {metric_name}, got: {perf.metric_name}"
-                    )
 
         self.cls_name: str = self.__class__.__name__
 

--- a/explainaboard/analysis/analyses.py
+++ b/explainaboard/analysis/analyses.py
@@ -184,14 +184,14 @@ class BucketAnalysisResult(AnalysisResult):
         """See AnalysisResult.generate_report."""
         texts: list[str] = []
 
-        metric_names = [x.metric_name for x in self.bucket_performances[0].performances]
+        metric_names = sorted(k for k in self.bucket_performances[0].performances)
 
-        for i, metric_name in enumerate(metric_names):
+        for metric_name in metric_names:
             texts.append(f"the information of #{self.name}#")
             texts.append(f"bucket_name\t{metric_name}\t#samples")
 
             for bucket_perf in self.bucket_performances:
-                perf = bucket_perf.performances[i]
+                perf = bucket_perf.performances[metric_name]
 
                 if bucket_perf.bucket_interval is not None:
                     bucket_name = f"{unwrap(bucket_perf.bucket_interval)}"
@@ -269,12 +269,8 @@ class BucketAnalysis(Analysis):
             )
 
             n_samples = len(bucket_collection.samples)
-            bucket_performance = BucketPerformance(
-                n_samples=n_samples,
-                bucket_samples=subsampled_ids,
-                bucket_interval=bucket_collection.interval,
-                bucket_name=bucket_collection.name,
-            )
+
+            performances: dict[str, Performance] = {}
 
             for metric_func, metric_stat in zip(
                 unwrap_generator(metrics),
@@ -301,16 +297,21 @@ class BucketAnalysis(Analysis):
 
                     value = metric_result.value
 
-                performance = Performance(
-                    metric_name=metric_func.config.name,
+                performances[metric_func.config.name] = Performance(
                     value=value,
                     confidence_score_low=conf_low,
                     confidence_score_high=conf_high,
                 )
 
-                bucket_performance.performances.append(performance)
-
-            bucket_performances.append(bucket_performance)
+            bucket_performances.append(
+                BucketPerformance(
+                    n_samples=n_samples,
+                    bucket_samples=subsampled_ids,
+                    performances=performances,
+                    bucket_interval=bucket_collection.interval,
+                    bucket_name=bucket_collection.name,
+                )
+            )
 
         return BucketAnalysisResult(
             name=self.feature, level=self.level, bucket_performances=bucket_performances

--- a/explainaboard/analysis/analyses_test.py
+++ b/explainaboard/analysis/analyses_test.py
@@ -13,7 +13,7 @@ from explainaboard.analysis.performance import BucketPerformance, Performance
 
 class BucketAnalysisResultTest(unittest.TestCase):
     def test_inconsistent_num_metrics(self) -> None:
-        with self.assertRaisesRegex(ValueError, r"^Inconsistent number of metrics"):
+        with self.assertRaisesRegex(ValueError, r"^Inconsistent metrics"):
             BucketAnalysisResult(
                 name="foo",
                 level="bar",
@@ -21,25 +21,25 @@ class BucketAnalysisResultTest(unittest.TestCase):
                     BucketPerformance(
                         n_samples=5,
                         bucket_samples=[0, 1, 2, 3, 4],
-                        performances=[
-                            Performance(metric_name="metric1", value=0.5),
-                            Performance(metric_name="metric2", value=0.25),
-                        ],
+                        performances={
+                            "metric1": Performance(value=0.5),
+                            "metric2": Performance(value=0.25),
+                        },
                         bucket_name="baz",
                     ),
                     BucketPerformance(
                         n_samples=5,
                         bucket_samples=[5, 6, 7, 8, 9],
-                        performances=[
-                            Performance(metric_name="metric1", value=0.125),
-                        ],
+                        performances={
+                            "metric1": Performance(value=0.125),
+                        },
                         bucket_name="qux",
                     ),
                 ],
             )
 
     def test_inconsistent_metric_names(self) -> None:
-        with self.assertRaisesRegex(ValueError, r"^Inconsistent metric names"):
+        with self.assertRaisesRegex(ValueError, r"^Inconsistent metrics"):
             BucketAnalysisResult(
                 name="foo",
                 level="bar",
@@ -47,19 +47,19 @@ class BucketAnalysisResultTest(unittest.TestCase):
                     BucketPerformance(
                         n_samples=5,
                         bucket_samples=[0, 1, 2, 3, 4],
-                        performances=[
-                            Performance(metric_name="metric1", value=0.5),
-                            Performance(metric_name="metric2", value=0.25),
-                        ],
+                        performances={
+                            "metric1": Performance(value=0.5),
+                            "metric2": Performance(value=0.25),
+                        },
                         bucket_name="baz",
                     ),
                     BucketPerformance(
                         n_samples=5,
                         bucket_samples=[5, 6, 7, 8, 9],
-                        performances=[
-                            Performance(metric_name="metric1", value=0.125),
-                            Performance(metric_name="xxx", value=0.25),
-                        ],
+                        performances={
+                            "metric1": Performance(value=0.125),
+                            "xxx": Performance(value=0.25),
+                        },
                         bucket_name="qux",
                     ),
                 ],
@@ -73,19 +73,19 @@ class BucketAnalysisResultTest(unittest.TestCase):
                 BucketPerformance(
                     n_samples=5,
                     bucket_samples=[0, 1, 2, 3, 4],
-                    performances=[
-                        Performance(metric_name="metric1", value=0.5),
-                        Performance(metric_name="metric2", value=0.25),
-                    ],
+                    performances={
+                        "metric1": Performance(value=0.5),
+                        "metric2": Performance(value=0.25),
+                    },
                     bucket_interval=(1.0, 2.0),
                 ),
                 BucketPerformance(
                     n_samples=5,
                     bucket_samples=[5, 6, 7, 8, 9],
-                    performances=[
-                        Performance(metric_name="metric1", value=0.125),
-                        Performance(metric_name="metric2", value=0.0625),
-                    ],
+                    performances={
+                        "metric1": Performance(value=0.125),
+                        "metric2": Performance(value=0.0625),
+                    },
                     bucket_interval=(2.0, 3.0),
                 ),
             ],
@@ -113,19 +113,19 @@ class BucketAnalysisResultTest(unittest.TestCase):
                 BucketPerformance(
                     n_samples=5,
                     bucket_samples=[0, 1, 2, 3, 4],
-                    performances=[
-                        Performance(metric_name="metric1", value=0.5),
-                        Performance(metric_name="metric2", value=0.25),
-                    ],
+                    performances={
+                        "metric1": Performance(value=0.5),
+                        "metric2": Performance(value=0.25),
+                    },
                     bucket_name="baz",
                 ),
                 BucketPerformance(
                     n_samples=5,
                     bucket_samples=[5, 6, 7, 8, 9],
-                    performances=[
-                        Performance(metric_name="metric1", value=0.125),
-                        Performance(metric_name="metric2", value=0.0625),
-                    ],
+                    performances={
+                        "metric1": Performance(value=0.125),
+                        "metric2": Performance(value=0.0625),
+                    },
                     bucket_name="qux",
                 ),
             ],

--- a/explainaboard/analysis/performance.py
+++ b/explainaboard/analysis/performance.py
@@ -3,13 +3,13 @@
 from __future__ import annotations
 
 import dataclasses
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any
 
 from explainaboard.metrics.metric import AuxiliaryMetricResult
 
 
-@dataclass
+@dataclass(frozen=True)
 class BucketPerformance:
     """A class containing information about performance over buckets.
 
@@ -23,8 +23,8 @@ class BucketPerformance:
     """
 
     n_samples: int
-    bucket_samples: list[int] = field(default_factory=list)
-    performances: list[Performance] = field(default_factory=list)
+    bucket_samples: list[int]
+    performances: dict[str, Performance]
     bucket_interval: tuple[float, float] | None = None
     bucket_name: str | None = None
 
@@ -57,7 +57,7 @@ class BucketPerformance:
         )
 
 
-@dataclass
+@dataclass(frozen=True)
 class Performance:
     """A performance value along with other information.
 
@@ -69,7 +69,6 @@ class Performance:
         auxiliary_result: Other auxiliary information used by particular metrics
     """
 
-    metric_name: str
     value: float
     confidence_score_low: float | None = None
     confidence_score_high: float | None = None

--- a/explainaboard/analysis/performance.py
+++ b/explainaboard/analysis/performance.py
@@ -44,7 +44,7 @@ class BucketPerformance:
             The value corresponding to the key
         """
         if k == 'performances':
-            return [Performance.from_dict(v1) for v1 in v]
+            return {name: Performance.from_dict(v1) for name, v1 in v.items()}
         else:
             return v
 

--- a/explainaboard/analysis/result.py
+++ b/explainaboard/analysis/result.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import dataclasses
 from dataclasses import dataclass
-from typing import Optional
+from typing import Any, Optional
 
 from explainaboard.analysis.analyses import AnalysisResult
 from explainaboard.analysis.performance import Performance
@@ -20,14 +20,18 @@ class Result:
         analyses: The results of various analyses.
     """
 
-    overall: Optional[list[list[Performance]]] = None
+    overall: Optional[list[dict[str, Performance]]] = None
     analyses: Optional[list[AnalysisResult]] = None
 
     @classmethod
-    def dict_conv(cls, k: str, v: list[list[dict]] | None):
+    def dict_conv(cls, k: str, v: Any | None):
         """A utility function for deserialization."""
         if k == 'overall':
-            return [[Performance.from_dict(v2) for v2 in v1] for v1 in v] if v else None
+            return (
+                [{k: Performance.from_dict(v2) for k, v2 in v1.items()} for v1 in v]
+                if v
+                else None
+            )
         elif k == 'analyses':
             return [AnalysisResult.from_dict(v1) for v1 in v] if v else None
         else:

--- a/explainaboard/analysis/result.py
+++ b/explainaboard/analysis/result.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import dataclasses
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any
 
 from explainaboard.analysis.analyses import AnalysisResult
 from explainaboard.analysis.performance import Performance
@@ -20,20 +20,16 @@ class Result:
         analyses: The results of various analyses.
     """
 
-    overall: Optional[list[dict[str, Performance]]] = None
-    analyses: Optional[list[AnalysisResult]] = None
+    overall: list[dict[str, Performance]]
+    analyses: list[AnalysisResult]
 
     @classmethod
-    def dict_conv(cls, k: str, v: Any | None):
+    def dict_conv(cls, k: str, v: Any):
         """A utility function for deserialization."""
         if k == 'overall':
-            return (
-                [{k: Performance.from_dict(v2) for k, v2 in v1.items()} for v1 in v]
-                if v
-                else None
-            )
+            return [{k: Performance.from_dict(v2) for k, v2 in v1.items()} for v1 in v]
         elif k == 'analyses':
-            return [AnalysisResult.from_dict(v1) for v1 in v] if v else None
+            return [AnalysisResult.from_dict(v1) for v1 in v]
         else:
             raise NotImplementedError
 

--- a/explainaboard/explainaboard_main.py
+++ b/explainaboard/explainaboard_main.py
@@ -520,8 +520,8 @@ def main():
 
             logger.info('--- Overall Performance')
             for overall_level in report.results.overall:
-                for metric_stat in overall_level:
-                    logger.info(f'{metric_stat.metric_name}\t{metric_stat.value}')
+                for metric_name, metric_stat in overall_level.items():
+                    logger.info(f'{metric_name}\t{metric_stat.value}')
             logger.info('')
             logger.info('--- Fine-grained Analyses')
             for analysis in report.results.analyses:

--- a/explainaboard/info.py
+++ b/explainaboard/info.py
@@ -91,7 +91,7 @@ class SysOutputInfo:
     analyses: Optional[list[Analysis]] = None
 
     # set later
-    results: Result = field(default_factory=lambda: Result())
+    results: Result = field(default_factory=lambda: Result(overall=[], analyses=[]))
 
     def to_dict(self) -> dict:
         """Serialization function."""

--- a/explainaboard/meta_analyses/utils.py
+++ b/explainaboard/meta_analyses/utils.py
@@ -30,13 +30,13 @@ def report_to_sysout(report: SysOutputInfo) -> list[dict]:
 
             # loop through and record all the metrics that describe this bucket
             example_features: dict[str, Any] = {}
-            for perf in bucket.performances:
+            for metric_name, perf in bucket.performances.items():
 
                 example_features['feature_name'] = feature_buckets.name
                 example_features['bucket_interval'] = bucket.bucket_interval
                 example_features['bucket_name'] = bucket.bucket_name
                 example_features['bucket_size'] = bucket.n_samples
-                example_features[perf.metric_name] = perf.value
+                example_features[metric_name] = perf.value
                 # example_features[f'{perf.metric_name}_CI'] = \
                 # [perf.confidence_score_low, perf.confidence_score_high]
 

--- a/explainaboard/processors/processor.py
+++ b/explainaboard/processors/processor.py
@@ -515,7 +515,7 @@ class Processor(Serializable, metaclass=abc.ABCMeta):
         overall_results = self.get_overall_performance(
             sys_info, analysis_cases, metric_stats
         )
-        sys_info.results = Result(overall=overall_results, analyses=None)
+        sys_info.results = Result(overall=overall_results, analyses=[])
         return OverallStatistics(sys_info, analysis_cases, metric_stats)
 
     @final

--- a/explainaboard/visualizers/draw_charts.py
+++ b/explainaboard/visualizers/draw_charts.py
@@ -144,18 +144,17 @@ def plot_buckets(
         else render_interval_to_tick_label(unwrap(x.bucket_interval))
         for x in bucket_results[0].bucket_performances
     ]
-    bucket0_names = [
-        x.metric_name for x in bucket_results[0].bucket_performances[0].performances
-    ]
-    for metric_id, metric_name in enumerate(bucket0_names):
 
+    bucket0_names = sorted(bucket_results[0].bucket_performances[0].performances.keys())
+
+    for metric_name in bucket0_names:
+        # indices: [analysis_id][bucket_id]
         performances: list[list[Performance]] = [
-            [x.performances[metric_id] for x in y.bucket_performances]
+            [x.performances[metric_name] for x in y.bucket_performances]
             for y in bucket_results
         ]
         ys = [[x.value for x in y] for y in performances]
 
-        y_errs = None
         if performances[0][0].confidence_score_low is not None:
             y_errs = [
                 (
@@ -164,6 +163,8 @@ def plot_buckets(
                 )
                 for y in performances
             ]
+        else:
+            y_errs = None
 
         make_bar_chart(
             ys,
@@ -207,18 +208,24 @@ def draw_charts_from_reports(
     # --- Overall results
     num_levels = len(unwrap(report_info[0].analysis_levels))
     for level_id in range(num_levels):
-        overall_results: list[list[Performance]] = [
-            list(unwrap(x.results.overall)[level_id]) for x in report_info
+        overall_results: list[dict[str, Performance]] = [
+            x.results.overall[level_id] for x in report_info
         ]
-        overall_metric_names = [x.metric_name for x in overall_results[0]]
+        overall_metric_names = sorted((overall_results[0].keys()))
 
-        ys = [[x.value for x in y] for y in overall_results]
+        ys = [[y[name].value for name in overall_metric_names] for y in overall_results]
         y_errs = None
-        if overall_results[0][0].confidence_score_low is not None:
+        if overall_results[0][overall_metric_names[0]].confidence_score_low is not None:
             y_errs = [
                 (
-                    [x.value - unwrap(x.confidence_score_low) for x in y],
-                    [unwrap(x.confidence_score_high) - x.value for x in y],
+                    [
+                        y[name].value - unwrap(y[name].confidence_score_low)
+                        for name in overall_metric_names
+                    ],
+                    [
+                        unwrap(y[name].confidence_score_high) - y[name].value
+                        for name in overall_metric_names
+                    ],
                 )
                 for y in overall_results
             ]

--- a/explainaboard/visualizers/performance_gap.py
+++ b/explainaboard/visualizers/performance_gap.py
@@ -1,4 +1,6 @@
 """Measure the gap between two models."""
+from __future__ import annotations
+
 import copy
 
 from explainaboard.analysis.analyses import AnalysisResult, BucketAnalysisResult

--- a/explainaboard/visualizers/performance_gap.py
+++ b/explainaboard/visualizers/performance_gap.py
@@ -1,10 +1,25 @@
 """Measure the gap between two models."""
-
 import copy
 
-from explainaboard.analysis.analyses import BucketAnalysisResult
+from explainaboard.analysis.analyses import AnalysisResult, BucketAnalysisResult
+from explainaboard.analysis.performance import BucketPerformance, Performance
+from explainaboard.analysis.result import Result
 from explainaboard.info import SysOutputInfo
-from explainaboard.utils.typing_utils import unwrap
+
+
+def _diff_overall(
+    sys1: dict[str, Performance], sys2: dict[str, Performance]
+) -> dict[str, Performance]:
+    """Helper function to make a difference performance.
+
+    Args:
+        sys1: System1 overall performances.
+        sys2: System1 overall performances.
+
+    Returns:
+        dict of Perforamnces generated from sys1 and sys2.
+    """
+    return {k: Performance(sys1[k].value - sys2[k].value) for k in sys1}
 
 
 def get_pairwise_performance_gap(
@@ -19,34 +34,43 @@ def get_pairwise_performance_gap(
     Returns:
         A SystemOutputInfo object that has the difference between the performances.
     """
-    sys = copy.deepcopy(sys1)
+    overall = [
+        _diff_overall(o1, o2)
+        for o1, o2 in zip(sys1.results.overall, sys2.results.overall)
+    ]
 
-    orm, or1, or2 = (unwrap(x.results.overall) for x in (sys, sys1, sys2))
-    for orm_lev, or1_lev, or2_lev in zip(orm, or1, or2):
-        for orm_met, or1_met, or2_met in zip(orm_lev, or1_lev, or2_lev):
-            orm_met.value = float(or1_met.value) - float(or2_met.value)
-            orm_met.confidence_score_low = None
-            orm_met.confidence_score_high = None
+    analyses: list[AnalysisResult] = []
 
-    fgr, fgr1, fgr2 = (unwrap(x.results.analyses) for x in (sys, sys1, sys2))
-    for fgr_buks, fgr1_buks, fgr2_buks in zip(fgr, fgr1, fgr2):
-        if (
-            not isinstance(fgr_buks, BucketAnalysisResult)
-            or not isinstance(fgr1_buks, BucketAnalysisResult)
-            or not isinstance(fgr2_buks, BucketAnalysisResult)
-        ):
+    for analysis1, analysis2 in zip(sys1.results.analyses, sys2.results.analyses):
+        if not isinstance(analysis1, BucketAnalysisResult):
+            analyses.append(copy.deepcopy(analysis1))
             continue
-        for fgr_buk, fgr1_buk, fgr2_buk in zip(
-            fgr_buks.bucket_performances,
-            fgr1_buks.bucket_performances,
-            fgr2_buks.bucket_performances,
-        ):
-            for fgr_met, fgr1_met, fgr2_met in zip(
-                fgr_buk.performances, fgr1_buk.performances, fgr2_buk.performances
-            ):
-                fgr_met.value = fgr1_met.value - fgr2_met.value
-                # TODO(gneubig): these could be done via pairwise bootstraps
-                fgr_met.confidence_score_low = None
-                fgr_met.confidence_score_high = None
 
+        if not isinstance(analysis2, BucketAnalysisResult):
+            raise ValueError(
+                "Mismatched analyses: "
+                f"{type(analysis1).__name__} v.s. {type(analysis2).__name__}"
+            )
+
+        analyses.append(
+            BucketAnalysisResult(
+                name=analysis1.name,
+                level=analysis1.level,
+                bucket_performances=[
+                    BucketPerformance(
+                        n_samples=bp1.n_samples,
+                        bucket_samples=bp1.bucket_samples[:],
+                        performances=_diff_overall(bp1.performances, bp2.performances),
+                        bucket_interval=bp1.bucket_interval,
+                        bucket_name=bp1.bucket_name,
+                    )
+                    for bp1, bp2 in zip(
+                        analysis1.bucket_performances, analysis2.bucket_performances
+                    )
+                ],
+            )
+        )
+
+    sys = copy.deepcopy(sys1)
+    sys.results = Result(overall=overall, analyses=analyses)
     return sys

--- a/integration_tests/argument_pair_extraction_test.py
+++ b/integration_tests/argument_pair_extraction_test.py
@@ -32,13 +32,9 @@ class ArgumentPairExtractionTest(unittest.TestCase):
         sys_info = processor.process(metadata, data)
         self.assertIsNotNone(sys_info.results.analyses)
 
-        self.assertGreater(len(sys_info.results.overall), 0)
-        self.assertAlmostEqual(
-            sys_info.results.overall[0][0].value,
-            0.25625,
-            4,
-            "almost equal",
-        )
+        overall = sys_info.results.overall[0]
+        self.assertGreater(len(overall), 0)
+        self.assertAlmostEqual(overall["F1"].value, 0.25625, 4)
 
 
 if __name__ == '__main__':

--- a/integration_tests/extractive_qa_test.py
+++ b/integration_tests/extractive_qa_test.py
@@ -5,7 +5,6 @@ from integration_tests.utils import test_artifacts_path
 
 from explainaboard import FileType, get_processor_class, Source, TaskType
 from explainaboard.loaders.loader_registry import get_loader_class
-from explainaboard.utils.logging import get_logger
 
 
 class ExtractiveQATest(unittest.TestCase):
@@ -44,23 +43,10 @@ class ExtractiveQATest(unittest.TestCase):
         sys_info = processor.process(metadata, data)
 
         self.assertIsNotNone(sys_info.results.analyses)
-        self.assertGreater(len(sys_info.results.overall), 0)
-        get_logger('test').info(f'OVERALL={sys_info.results.overall}')
-        # should be 0.6974789915966386
-        overall_map = {x.metric_name: x for x in sys_info.results.overall[0]}
-        self.assertAlmostEqual(
-            overall_map["ExactMatch"].value,
-            0.6974789915966386,
-            2,
-            "almost equal",
-        )
-        # should be 0.8235975260931867
-        self.assertAlmostEqual(
-            overall_map["F1"].value,
-            0.8235975260931867,
-            2,
-            "almost equal",
-        )
+        overall = sys_info.results.overall[0]
+        self.assertGreater(len(overall), 0)
+        self.assertAlmostEqual(overall["ExactMatch"].value, 0.6974789915966386, 2)
+        self.assertAlmostEqual(overall["F1"].value, 0.8235975260931867, 2)
 
     def test_extractive_qa_zh(self):
         json_zh_dataset = os.path.join(self.artifact_path, "dataset-xquad-zh.json")
@@ -87,19 +73,7 @@ class ExtractiveQATest(unittest.TestCase):
         sys_info = processor.process(metadata, data)
 
         self.assertIsNotNone(sys_info.results.analyses)
-        self.assertGreater(len(sys_info.results.overall), 0)
-        # 0.6285714285714286
-        overall_map = {x.metric_name: x for x in sys_info.results.overall[0]}
-        self.assertAlmostEqual(
-            overall_map["ExactMatch"].value,
-            0.6285714285714286,
-            2,
-            "almost equal",
-        )
-        # 0.7559651817716333
-        self.assertAlmostEqual(
-            overall_map["F1"].value,
-            0.7559651817716333,
-            2,
-            "almost equal",
-        )
+        overall = sys_info.results.overall[0]
+        self.assertGreater(len(overall), 0)
+        self.assertAlmostEqual(overall["ExactMatch"].value, 0.6285714285714286, 2)
+        self.assertAlmostEqual(overall["F1"].value, 0.7559651817716333, 2)

--- a/integration_tests/grammar_error_correction_test.py
+++ b/integration_tests/grammar_error_correction_test.py
@@ -29,8 +29,7 @@ class GrammarErrorCorrectionTest(unittest.TestCase):
         }
         processor = get_processor_class(TaskType.grammatical_error_correction)()
         sys_info = processor.process(metadata, data)
-        overall_map = {x.metric_name: x for x in sys_info.results.overall[0]}
-        self.assertAlmostEqual(overall_map["SeqCorrectCount"].value, 8)
+        self.assertAlmostEqual(sys_info.results.overall[0]["SeqCorrectCount"].value, 8)
         self.assertIsNotNone(sys_info.results.analyses)
 
 

--- a/integration_tests/kg_link_tail_prediction_test.py
+++ b/integration_tests/kg_link_tail_prediction_test.py
@@ -124,8 +124,8 @@ class KgLinkTailPredictionTest(unittest.TestCase):
         if len(symmetry_performances) <= 1:  # can't sort if only 1 item
             return
         for i in range(len(symmetry_performances) - 1):
-            first_item = symmetry_performances[i].performances[0].value
-            second_item = symmetry_performances[i + 1].performances[0].value
+            first_item = symmetry_performances[i].performances["Hits4"].value
+            second_item = symmetry_performances[i + 1].performances["Hits4"].value
             self.assertGreater(first_item, second_item)
 
     def test_sort_buckets_by_key(self):

--- a/integration_tests/kg_link_tail_prediction_test.py
+++ b/integration_tests/kg_link_tail_prediction_test.py
@@ -108,7 +108,7 @@ class KgLinkTailPredictionTest(unittest.TestCase):
                 MeanRankConfig(name='MR'),
             ],
             "sort_by": "performance_value",
-            "sort_by_metric": "first",
+            "sort_by_metric": "Hits4",
         }
 
         processor = get_processor_class(TaskType.kg_link_tail_prediction)()

--- a/integration_tests/metric_test.py
+++ b/integration_tests/metric_test.py
@@ -247,17 +247,5 @@ class MetricTest(unittest.TestCase):
         self.assertIsNotNone(sys_info.results.analyses)
         overall = sys_info.results.overall[0]
         self.assertGreater(len(overall), 0)
-        overall_map = {x.metric_name: x for x in overall}
-        self.assertAlmostEqual(
-            overall_map["ExactMatch"].value,
-            0.6974789915966386,
-            2,
-            "almost equal",
-        )
-        # should be 0.8235975260931867
-        self.assertAlmostEqual(
-            overall_map["F1"].value,
-            0.8235975260931867,
-            2,
-            "almost equal",
-        )
+        self.assertAlmostEqual(overall["ExactMatch"].value, 0.6974789915966386, 2)
+        self.assertAlmostEqual(overall["F1"].value, 0.8235975260931867, 2)

--- a/integration_tests/ner_test.py
+++ b/integration_tests/ner_test.py
@@ -97,32 +97,21 @@ class NERTest(unittest.TestCase):
         # [0.007462686567164179,0.9565217391304348]
         second_bucket = span_econ_analysis.bucket_performances[1]
         second_bucket_interval = unwrap(second_bucket.bucket_interval)
-        self.assertAlmostEqual(
-            second_bucket_interval[0],
-            0.007462686567164179,
-            4,
-            "almost equal",
-        )
-        self.assertAlmostEqual(
-            second_bucket_interval[1],
-            0.8571428571428571,
-            4,
-            "almost equal",
-        )
+        self.assertAlmostEqual(second_bucket_interval[0], 0.007462686567164179, 4)
+        self.assertAlmostEqual(second_bucket_interval[1], 0.8571428571428571, 4)
         # 4. Unittest: test detailed bucket information: bucket samples
         self.assertEqual(second_bucket.n_samples, 1050)
 
         # 5. Unittest: test detailed bucket information: metric
-        self.assertEqual(second_bucket.performances[0].metric_name, "F1")
         self.assertAlmostEqual(
-            second_bucket.performances[0].value, 0.9121588089330025, 4, "almost equal"
+            second_bucket.performances["F1"].value, 0.9121588089330025, 4
         )
         # 6 Unittest: test detailed bucket information: confidence interval
         for bucket_vals in sys_info.results.analyses:
             if not isinstance(bucket_vals, BucketAnalysisResult):
                 continue
             for bucket in bucket_vals.bucket_performances:
-                for performance in bucket.performances:
+                for performance in bucket.performances.values():
                     if performance.confidence_score_low is not None:
                         self.assertGreaterEqual(
                             performance.value, performance.confidence_score_low

--- a/integration_tests/qa_table_text_hybrid_test.py
+++ b/integration_tests/qa_table_text_hybrid_test.py
@@ -33,10 +33,7 @@ class QATableTextHybridTest(unittest.TestCase):
 
         self.assertGreater(len(sys_info.results.overall), 0)
         self.assertAlmostEqual(
-            sys_info.results.overall[0][0].value,
-            0.746978,
-            3,
-            "almost equal",
+            sys_info.results.overall[0]["ExactMatchQATat"].value, 0.746978, 3
         )
 
 


### PR DESCRIPTION
Related to #491

This PR introduces following changes:

- Remove `metric_name` member from `Performance`.
- Change all `list[Performance]` to `dict[str, Performance]`, whose keys are metric names.
- Refactoring related to these changes.

Originally, `metric_name` is used as a primary key of the list, and often the list is converted to dict in the library. This change attempts to removes this burden.