### PR TITLE
Remove additional config argument from Metric

### DIFF
--- a/explainaboard/metrics/accuracy.py
+++ b/explainaboard/metrics/accuracy.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Optional
+from typing import Any
 
 import numpy as np
 
@@ -14,6 +14,7 @@ from explainaboard.metrics.metric import (
     SimpleMetricStats,
 )
 from explainaboard.serialization import common_registry
+from explainaboard.utils.typing_utils import narrow
 
 
 @dataclass
@@ -33,7 +34,7 @@ class Accuracy(Metric):
     """
 
     def calc_stats_from_data(
-        self, true_data: list, pred_data: list, config: Optional[MetricConfig] = None
+        self, true_data: list[Any], pred_data: list[Any]
     ) -> MetricStats:
         """See Metric.calc_stats_from_data."""
         return SimpleMetricStats(
@@ -64,7 +65,7 @@ class CorrectCount(Accuracy):
         return False
 
     def calc_stats_from_data(
-        self, true_data: list, pred_data: list, config: Optional[MetricConfig] = None
+        self, true_data: list[Any], pred_data: list[Any]
     ) -> MetricStats:
         """See Metric.calc_stats_from_data."""
         return SimpleMetricStats(
@@ -112,14 +113,14 @@ class SeqCorrectCount(CorrectCount):
         return flatten_edits
 
     def calc_stats_from_data(
-        self,
-        true_edits_ldl: list[dict[str, list]],
-        pred_edits_ldl: list[dict[str, list]],
-        config: Optional[MetricConfig] = None,
+        self, true_data: list[Any], pred_data: list[Any]
     ) -> MetricStats:
         """See Metric.calc_stats_from_data."""
         recall = []
-        for true_edits_dl, pred_edits_dl in zip(true_edits_ldl, pred_edits_ldl):
+        for true_edits_dl_untyped, pred_edits_dl_untyped in zip(true_data, pred_data):
+            true_edits_dl = narrow(dict, true_edits_dl_untyped)
+            pred_edits_dl = narrow(dict, pred_edits_dl_untyped)
+
             true_edits_ld = [
                 dict(zip(true_edits_dl, t)) for t in zip(*true_edits_dl.values())
             ]

--- a/explainaboard/metrics/continuous.py
+++ b/explainaboard/metrics/continuous.py
@@ -29,9 +29,7 @@ class RootMeanSquaredErrorConfig(MetricConfig):
 class RootMeanSquaredError(Metric):
     """Calculate the root mean squared error of continuous values."""
 
-    def calc_stats_from_data(
-        self, true_data: list, pred_data: list, config: Optional[MetricConfig] = None
-    ) -> MetricStats:
+    def calc_stats_from_data(self, true_data: list, pred_data) -> MetricStats:
         """See Metric.calc_stats_from_data."""
         error = np.array([(x - y) for x, y in zip(true_data, pred_data)])
         squared_error = error * error
@@ -63,9 +61,7 @@ class AbsoluteErrorConfig(MetricConfig):
 class AbsoluteError(Metric):
     """Calculate the absolute error of continuous values."""
 
-    def calc_stats_from_data(
-        self, true_data: list, pred_data: list, config: Optional[MetricConfig] = None
-    ) -> MetricStats:
+    def calc_stats_from_data(self, true_data: list, pred_data: list) -> MetricStats:
         """See Metric.calc_stats_from_data."""
         error = np.array([abs(x - y) for x, y in zip(true_data, pred_data)])
         return SimpleMetricStats(error)

--- a/explainaboard/metrics/eaas.py
+++ b/explainaboard/metrics/eaas.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import copy
 from dataclasses import dataclass
-from typing import Any, cast, final, Optional
+from typing import Any, cast, final
 
 from eaas.async_client import AsyncClient, AsyncRequest
 from eaas.config import Config
@@ -96,9 +96,7 @@ class EaaSMetric(Metric):
 
     _NOT_SIMPLE_METRICS = {'bleu', 'chrf', 'length_ratio', 'length'}
 
-    def _calc_metric_from_aggregate(
-        self, agg_stats: np.ndarray, config: Optional[MetricConfig] = None
-    ) -> np.ndarray:
+    def _calc_metric_from_aggregate(self, agg_stats: np.ndarray) -> np.ndarray:
         """See Metric.calc_metric_from_aggregate."""
         is_batched = agg_stats.ndim != 1
         if not is_batched:
@@ -135,9 +133,7 @@ class EaaSMetric(Metric):
         else:
             return np.mean(data, axis=-2)
 
-    def calc_stats_from_data(
-        self, true_data: list, pred_data: list, config: Optional[MetricConfig] = None
-    ) -> MetricStats:
+    def calc_stats_from_data(self, true_data: list, pred_data: list) -> MetricStats:
         """See Metric.calc_stats_from_data.
 
         Note that specifically for EaaSMetric, it's better to batch requests when

--- a/explainaboard/metrics/external_eval.py
+++ b/explainaboard/metrics/external_eval.py
@@ -171,7 +171,7 @@ class ExternalEval(Metric):
         agg_stats = self.aggregate_stats(stats)
 
         metric_values: dict[str, MetricValue] = {
-            "score": Score(float(self.calc_metric_from_aggregate(agg_stats, config))),
+            "score": Score(float(self.calc_metric_from_aggregate(agg_stats))),
             "agreement": Score(self.calc_agreement(stats)),
         }
         if confidence_alpha is not None:
@@ -181,4 +181,4 @@ class ExternalEval(Metric):
                     ci[0], ci[1], confidence_alpha
                 )
 
-        return MetricResult(config, metric_values)
+        return MetricResult(self.config, metric_values)

--- a/explainaboard/metrics/external_eval.py
+++ b/explainaboard/metrics/external_eval.py
@@ -17,7 +17,7 @@ from explainaboard.metrics.metric import (
 )
 from explainaboard.serialization import common_registry
 from explainaboard.utils.agreement import fleiss_kappa
-from explainaboard.utils.typing_utils import unwrap
+from explainaboard.utils.typing_utils import narrow
 
 UNANNOTATED_SYMBOL = -1
 
@@ -65,25 +65,11 @@ class ExternalEval(Metric):
     This tells whether the predicted output is in a set of true outputs.
     """
 
-    def _get_config(self, config: Optional[MetricConfig] = None) -> MetricConfig:
-        """Get the configuration or overwritten configuration.
-
-        Args:
-            config: Optional configuration to override the default configuration
-
-        Returns:
-            Either the default or overridden configuration
-        """
-        ret_config: MetricConfig = unwrap(config) if config is not None else self.config
-        return ret_config
-
     def is_simple_average(self, stats: MetricStats):
         """See Metric.is_simple_average."""
         return False
 
-    def calc_stats_from_external(
-        self, config: Optional[MetricConfig] = None
-    ) -> MetricStats:
+    def calc_stats_from_external(self) -> MetricStats:
         """Calculate statistics from external data.
 
         Args:
@@ -92,14 +78,11 @@ class ExternalEval(Metric):
         Returns:
             The calculated statistics.
         """
-        config = cast(ExternalEvalConfig, self._get_config(config))
-        return SimpleMetricStats(config.external_stats)
+        return SimpleMetricStats(narrow(ExternalEvalConfig, self.config).external_stats)
 
-    def calc_stats_from_data(
-        self, true_data: list, pred_data: list, config: Optional[MetricConfig] = None
-    ) -> MetricStats:
+    def calc_stats_from_data(self, true_data: list, pred_data: list) -> MetricStats:
         """See Metric.calc_stats_from_data."""
-        config = cast(ExternalEvalConfig, self._get_config(config))
+        config = narrow(ExternalEvalConfig, self.config)
 
         if config.external_stats is not None:
             n_sample, n_annotators = config.external_stats.shape
@@ -170,7 +153,6 @@ class ExternalEval(Metric):
         self,
         stats: MetricStats,
         confidence_alpha: Optional[float] = None,
-        config: Optional[MetricConfig] = None,
     ) -> MetricResult:
         """Return an evaluation result over stats.
 
@@ -183,17 +165,16 @@ class ExternalEval(Metric):
         Returns:
             a resulting metric value
         """
-        config = self._get_config(config)
         agg_stats = self.aggregate_stats(stats)
         agreement = self.calc_agreement(stats)
-        value = self.calc_metric_from_aggregate(agg_stats, config)
+        value = self.calc_metric_from_aggregate(agg_stats)
         confidence_interval = (
             self.calc_confidence_interval(stats, confidence_alpha)
             if confidence_alpha
             else None
         )
         return MetricResult(
-            config,
+            self.config,
             float(value),
             confidence_interval,
             confidence_alpha,

--- a/explainaboard/metrics/external_eval_test.py
+++ b/explainaboard/metrics/external_eval_test.py
@@ -11,7 +11,6 @@ from explainaboard.metrics.external_eval import (
     ExternalEvalConfig,
     UNANNOTATED_SYMBOL,
 )
-from explainaboard.utils.typing_utils import narrow
 
 
 class ExternalEvalConfigTest(unittest.TestCase):
@@ -65,45 +64,33 @@ class ExternalEvalConfigTest(unittest.TestCase):
 
 class ExternalEvalTest(unittest.TestCase):
     def test_calc_stats_from_external(self) -> None:
-        metric = narrow(
-            ExternalEval, ExternalEvalConfig("ExternalEval", n_annotators=2).to_metric()
+        config = ExternalEvalConfig(
+            "ExternalEval", n_annotators=2, external_stats=np.array([[1, 2], [3, 4]])
         )
-
-        stats = metric.calc_stats_from_external(
-            ExternalEvalConfig(
-                "ExternalEval",
-                n_annotators=2,
-                external_stats=np.array([[1, 2], [3, 4]]),
-            )
-        )
+        metric = ExternalEval(config)
+        stats = metric.calc_stats_from_external()
         self.assertEqual(len(stats), 2)
         self.assertEqual(stats.num_statistics(), 2)
         np.testing.assert_array_equal(stats.get_data(), np.array([[1, 2], [3, 4]]))
 
     def test_calc_stats_from_data_with_external_stats(self) -> None:
-        metric = ExternalEvalConfig("ExternalEval", n_annotators=2).to_metric()
+        config = ExternalEvalConfig(
+            "ExternalEval", n_annotators=1, external_stats=np.array([[1], [0]])
+        )
+        metric = ExternalEval(config)
         true_data = [1, 0]
         pred_data = [1, 1]
-        stats = metric.calc_stats_from_data(
-            true_data,
-            pred_data,
-            ExternalEvalConfig(
-                "ExternalEval", n_annotators=1, external_stats=np.array([[1], [0]])
-            ),
-        )
+        stats = metric.calc_stats_from_data(true_data, pred_data)
         self.assertEqual(len(stats), 2)
         self.assertEqual(stats.num_statistics(), 1)
         np.testing.assert_array_equal(stats.get_data(), np.array([[1], [0]]))
 
     def test_calc_stats_from_data_without_external_stats(self) -> None:
-        metric = ExternalEvalConfig("ExternalEval", n_annotators=2).to_metric()
+        config = ExternalEvalConfig("ExternalEval", n_annotators=1)
+        metric = ExternalEval(config)
         true_data = [1, 0]
         pred_data = [1, 1]
-        stats = metric.calc_stats_from_data(
-            true_data,
-            pred_data,
-            ExternalEvalConfig("ExternalEval", n_annotators=1),
-        )
+        stats = metric.calc_stats_from_data(true_data, pred_data)
         self.assertEqual(len(stats), 2)
         self.assertEqual(stats.num_statistics(), 1)
         np.testing.assert_array_equal(

--- a/explainaboard/metrics/extractive_qa.py
+++ b/explainaboard/metrics/extractive_qa.py
@@ -18,7 +18,6 @@ from explainaboard.metrics.metric import (
 )
 from explainaboard.serialization import common_registry
 from explainaboard.utils.preprocessor import ExtractiveQAPreprocessor
-from explainaboard.utils.typing_utils import unwrap_or
 
 
 class ExtractiveQAMetric(Metric):

--- a/explainaboard/metrics/extractive_qa.py
+++ b/explainaboard/metrics/extractive_qa.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import abc
 from collections import Counter
 from dataclasses import dataclass
-from typing import Optional, Union
+from typing import Union
 
 import numpy as np
 
@@ -17,7 +17,6 @@ from explainaboard.metrics.metric import (
 )
 from explainaboard.serialization import common_registry
 from explainaboard.utils.preprocessor import ExtractiveQAPreprocessor, Preprocessor
-from explainaboard.utils.typing_utils import unwrap_or
 
 
 class ExtractiveQAMetric(Metric):
@@ -31,12 +30,10 @@ class ExtractiveQAMetric(Metric):
         self,
         true_data: list[Union[str, list[str]]],
         pred_data: list[str],
-        config: Optional[MetricConfig] = None,
     ) -> MetricStats:
         """See Metric.calc_stats_from_data."""
         true_data = [[x] if isinstance(x, str) else x for x in true_data]
-        config = unwrap_or(config, self.config)
-        preprocessor = ExtractiveQAPreprocessor(language=config.source_language)
+        preprocessor = ExtractiveQAPreprocessor(language=self.config.source_language)
         return SimpleMetricStats(
             np.array(
                 [

--- a/explainaboard/metrics/f1_score.py
+++ b/explainaboard/metrics/f1_score.py
@@ -21,7 +21,7 @@ from explainaboard.utils.span_utils import (
     gen_argument_pairs,
     SpanOps,
 )
-from explainaboard.utils.typing_utils import unwrap_or
+from explainaboard.utils.typing_utils import narrow
 
 
 @dataclass
@@ -54,15 +54,12 @@ class F1Score(Metric):
         """See Metric.is_simple_average."""
         return False
 
-    def calc_stats_from_data(
-        self, true_data: list, pred_data: list, config: Optional[MetricConfig] = None
-    ) -> MetricStats:
+    def calc_stats_from_data(self, true_data: list, pred_data: list) -> MetricStats:
         """Return sufficient statistics necessary to compute f-score.
 
         Args:
           true_data: True outputs
           pred_data: Predicted outputs
-          config: Configuration, if overloading the default for this object
 
         Returns:
           Returns stats for each class (integer id c) in the following columns of
@@ -73,7 +70,7 @@ class F1Score(Metric):
           * c*stat_mult + 3: number of matches with the predicted output
           (when self.separate_match=True only)
         """
-        config = cast(F1ScoreConfig, unwrap_or(config, self.config))
+        config = narrow(F1ScoreConfig, self.config)
         stat_mult: int = 4 if config.separate_match else 3
 
         id_map: dict[str, int] = {}
@@ -100,15 +97,13 @@ class F1Score(Metric):
                         stats[i, tid * stat_mult + 3] += 1
         return SimpleMetricStats(stats)
 
-    def _calc_metric_from_aggregate(
-        self, agg_stats: np.ndarray, config: Optional[MetricConfig] = None
-    ) -> np.ndarray:
+    def _calc_metric_from_aggregate(self, agg_stats: np.ndarray) -> np.ndarray:
         """See Metric.calc_metric_from_aggregate."""
         is_batched = agg_stats.ndim != 1
         if not is_batched:
             agg_stats = agg_stats.reshape((1, agg_stats.shape[0]))
 
-        config = cast(F1ScoreConfig, unwrap_or(config, self.config))
+        config = cast(F1ScoreConfig, self.config)
         supported_averages = {'micro', 'macro'}
         stat_mult: int = 4 if config.separate_match else 3
         if config.average not in supported_averages:
@@ -169,10 +164,7 @@ class APEF1Score(Metric):
         return False
 
     def calc_stats_from_data(
-        self,
-        true_data: list[list[str]],
-        pred_data: list[list[str]],
-        config: Optional[MetricConfig] = None,
+        self, true_data: list[list[str]], pred_data: list[list[str]]
     ) -> MetricStats:
         """See Metric.calc_stats_from_data."""
         stats = []
@@ -186,9 +178,7 @@ class APEF1Score(Metric):
             )
         return SimpleMetricStats(np.array(stats))
 
-    def _calc_metric_from_aggregate(
-        self, agg_stats: np.ndarray, config: Optional[MetricConfig] = None
-    ) -> np.ndarray:
+    def _calc_metric_from_aggregate(self, agg_stats: np.ndarray) -> np.ndarray:
         """See Metric._calc_metric_from_aggregate."""
         is_batched = agg_stats.ndim == 2
         if not is_batched:
@@ -220,27 +210,22 @@ class SeqF1Score(F1Score):
         self,
         true_data: list[list[str]],
         pred_data: list[list[str]],
-        config: Optional[MetricConfig] = None,
     ) -> MetricStats:
         """Return sufficient statistics necessary to compute f-score.
 
         Args:
-          true_data: True outputs
-          pred_data: Predicted outputs
-          config: Configuration, if over-riding the default
-          true_data: list[list[str]]:
-          pred_data: list[list[str]]:
-          config: Optional[MetricConfig]:  (Default value = None)
+            true_data: True outputs
+            pred_data: Predicted outputs
 
         Returns:
-          Returns stats for each class (integer id c) in the following columns of
-          MetricStats
-          * c*stat_mult + 0: occurrences in the true output
-          * c*stat_mult + 1: occurrences in the predicted output
-          * c*stat_mult + 2: number of matches with the true output
+            Returns stats for each class (integer id c) in the following columns of
+            MetricStats
+            * c*stat_mult + 0: occurrences in the true output
+            * c*stat_mult + 1: occurrences in the predicted output
+            * c*stat_mult + 2: number of matches with the true output
         """
         # Get span ops
-        seq_config = cast(SeqF1ScoreConfig, config or self.config)
+        seq_config = narrow(SeqF1ScoreConfig, self.config)
         if seq_config.tag_schema == 'bio':
             span_ops: SpanOps = BIOSpanOps()
         elif seq_config.tag_schema == 'bmes':

--- a/explainaboard/metrics/log_prob.py
+++ b/explainaboard/metrics/log_prob.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import cast, Optional
 
 import numpy as np
 
@@ -14,7 +13,7 @@ from explainaboard.metrics.metric import (
     SimpleMetricStats,
 )
 from explainaboard.serialization import common_registry
-from explainaboard.utils.typing_utils import unwrap_or
+from explainaboard.utils.typing_utils import narrow
 
 
 @dataclass
@@ -40,9 +39,7 @@ class LogProb(Metric):
         """See Metric.is_simple_average."""
         return stats.num_statistics() == 1
 
-    def calc_stats_from_data(
-        self, true_data: list, pred_data: list, config: Optional[MetricConfig] = None
-    ) -> MetricStats:
+    def calc_stats_from_data(self, true_data: list, pred_data: list) -> MetricStats:
         """See Metric.calc_stats_from_data.
 
         Takes in a list of floats (token-level), or list of lists of floats (sentence
@@ -56,14 +53,12 @@ class LogProb(Metric):
             t = type(pred_data[0])
             raise ValueError(f'Invalid type of pred_data for calc_stats_from_data {t}')
 
-    def _calc_metric_from_aggregate(
-        self, agg_stats: np.ndarray, config: Optional[MetricConfig] = None
-    ) -> np.ndarray:
+    def _calc_metric_from_aggregate(self, agg_stats: np.ndarray) -> np.ndarray:
         """See Metric.calc_metric_from_aggregate."""
         is_batched = agg_stats.ndim != 1
         if not is_batched:
             agg_stats = agg_stats.reshape((1, agg_stats.shape[0]))
-        config = cast(LogProbConfig, unwrap_or(config, self.config))
+        config = narrow(LogProbConfig, self.config)
         val = (
             agg_stats[:, 0]
             if agg_stats.size == 1

--- a/explainaboard/metrics/metric.py
+++ b/explainaboard/metrics/metric.py
@@ -15,7 +15,7 @@ from explainaboard.serialization.types import (
     SerializableData,
     SerializableDataclass,
 )
-from explainaboard.utils.typing_utils import narrow, unwrap_or
+from explainaboard.utils.typing_utils import narrow
 
 
 @dataclass

--- a/explainaboard/metrics/qa_table_text_hybrid.py
+++ b/explainaboard/metrics/qa_table_text_hybrid.py
@@ -17,9 +17,7 @@ from explainaboard.metrics.metric import (
     SimpleMetricStats,
 )
 from explainaboard.serialization import common_registry
-
 from explainaboard.utils.preprocessor import ExtractiveQAPreprocessor
-from explainaboard.utils.typing_utils import unwrap_or
 
 
 class QATatMetric(Metric):

--- a/explainaboard/metrics/qa_table_text_hybrid.py
+++ b/explainaboard/metrics/qa_table_text_hybrid.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import abc
 from dataclasses import dataclass
 import itertools
-from typing import Optional
 
 import numpy as np
 
@@ -18,7 +17,6 @@ from explainaboard.metrics.metric import (
 )
 from explainaboard.serialization import common_registry
 from explainaboard.utils.preprocessor import ExtractiveQAPreprocessor, Preprocessor
-from explainaboard.utils.typing_utils import unwrap_or
 
 
 class QATatMetric(Metric):
@@ -33,12 +31,7 @@ class QATatMetric(Metric):
         """See Metric.is_simple_average."""
         return True
 
-    def calc_stats_from_data(
-        self,
-        true_data: list,
-        pred_data: list,
-        config: Optional[MetricConfig] = None,
-    ) -> MetricStats:
+    def calc_stats_from_data(self, true_data: list, pred_data: list) -> MetricStats:
         """See Metric.calc_stats_from_data."""
         stat_list = []
         for true_answer_info, pred_answer_info in zip(true_data, pred_data):
@@ -59,8 +52,9 @@ class QATatMetric(Metric):
                 prediction,
             )
 
-            config = unwrap_or(config, self.config)
-            preprocessor = ExtractiveQAPreprocessor(language=config.source_language)
+            preprocessor = ExtractiveQAPreprocessor(
+                language=self.config.source_language
+            )
 
             args_iter = itertools.product(
                 prediction_strings, ground_truth_answer_strings

--- a/explainaboard/processors/conditional_generation.py
+++ b/explainaboard/processors/conditional_generation.py
@@ -326,8 +326,8 @@ class ConditionalGenerationProcessor(Processor):
                 true_data.append(feature_table["reference"])
                 pred_data.append(feature_table["hypothesis"])
 
-            metric_names_eaas = []
-            metric_configs_noneaas = []
+            metric_names_eaas: list[str] = []
+            metric_configs_noneaas: list[MetricConfig] = []
             for metric_config in unwrap_generator(analysis_level.metric_configs):
                 if isinstance(metric_config, EaaSMetricConfig):
                     metric_names_eaas.append(metric_config.name)
@@ -348,9 +348,7 @@ class ConditionalGenerationProcessor(Processor):
             # For non-EaaS metrics
             for metric_config in metric_configs_noneaas:
                 metric_stats.append(
-                    metric_config.to_metric().calc_stats_from_data(
-                        true_data, pred_data, metric_config
-                    )
+                    metric_config.to_metric().calc_stats_from_data(true_data, pred_data)
                 )
 
             # Calculate features


### PR DESCRIPTION
This change removes `config` arguments from methods in `Metric`.

Overall, this argument is rarely utilized while it is not referred appropriately in many subclasses. Since we can instantiate another `Metric` object to use different configs, I thought that we can remove this argument without any drawbacks.

This pull request also contains some typing errors in `Metric` classes.