### PR TITLE
Remove unnecessary Optional

### DIFF
--- a/docs/example_scripts/test_kg.py
+++ b/docs/example_scripts/test_kg.py
@@ -18,8 +18,8 @@ data = loader.load()
 processor = get_processor_class(TaskType.kg_link_tail_prediction)()
 sys_info = processor.process(metadata={}, sys_output=data.samples)
 
-fine_grained_res = unwrap(sys_info.results.analyses)
-overall_res = unwrap(sys_info.results.overall)
+fine_grained_res = sys_info.results.analyses
+overall_res = sys_info.results.overall
 
 # print bucket information
 for analysis in fine_grained_res:

--- a/explainaboard/info.py
+++ b/explainaboard/info.py
@@ -24,17 +24,6 @@ logger = get_logger(__name__)
 
 
 @dataclass
-class Table:
-    """A table of information.
-
-    Attributes:
-        table: A dictionary holding the table.
-    """
-
-    table: Optional[dict] = None
-
-
-@dataclass
 class PaperInfo:
     """Information about a paper.
 
@@ -84,11 +73,11 @@ class SysOutputInfo:
     target_language: str | None = None
     reload_stat: bool = True
     confidence_alpha: float = 0.05
-    system_details: Optional[dict] = None
+    system_details: dict[str, Any] = field(default_factory=dict)
     source_tokenizer: Optional[Tokenizer] = None
     target_tokenizer: Optional[Tokenizer] = None
-    analysis_levels: Optional[list[AnalysisLevel]] = None
-    analyses: Optional[list[Analysis]] = None
+    analysis_levels: list[AnalysisLevel] = field(default_factory=list)
+    analyses: list[Analysis] = field(default_factory=list)
 
     # set later
     results: Result = field(default_factory=lambda: Result(overall=[], analyses=[]))

--- a/explainaboard/meta_analyses/rank_flipping.py
+++ b/explainaboard/meta_analyses/rank_flipping.py
@@ -83,10 +83,7 @@ class RankFlippingMetaAnalysis(MetaAnalysis):
                     "num_buckets": 2,  # for rank flipping, True or False
                 }
                 for metric_config in itertools.chain.from_iterable(
-                    [
-                        x.metric_configs
-                        for x in unwrap(self.model1_report.analysis_levels)
-                    ]
+                    [x.metric_configs for x in self.model1_report.analysis_levels]
                 )
             }
         }

--- a/explainaboard/meta_analyses/ranking.py
+++ b/explainaboard/meta_analyses/ranking.py
@@ -106,7 +106,7 @@ class RankingMetaAnalysis(MetaAnalysis):
                     "num_buckets": len(self.model_reports),
                 }
                 for metric_config in itertools.chain.from_iterable(
-                    [x.metric_configs for x in unwrap(model1.analysis_levels)]
+                    [x.metric_configs for x in model1.analysis_levels]
                 )
             }
         }

--- a/explainaboard/meta_analyses/utils.py
+++ b/explainaboard/meta_analyses/utils.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from explainaboard.analysis.analyses import BucketAnalysisResult
 from explainaboard.info import SysOutputInfo
-from explainaboard.utils.typing_utils import narrow, unwrap
+from explainaboard.utils.typing_utils import narrow
 
 
 def report_to_sysout(report: SysOutputInfo) -> list[dict]:
@@ -19,7 +19,7 @@ def report_to_sysout(report: SysOutputInfo) -> list[dict]:
     """
     results_fine_grained = [
         narrow(BucketAnalysisResult, x)
-        for x in unwrap(report.results.analyses)
+        for x in report.results.analyses
         if isinstance(x, BucketAnalysisResult)
     ]
     meta_examples = []

--- a/explainaboard/metrics/f1_score.py
+++ b/explainaboard/metrics/f1_score.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 import itertools
-from typing import cast, Optional, Tuple
+from typing import cast, Tuple
 
 import numpy as np
 
@@ -37,7 +37,7 @@ class F1ScoreConfig(MetricConfig):
 
     average: str = 'micro'
     separate_match: bool = False
-    ignore_classes: Optional[list] = None
+    ignore_classes: list[str] = field(default_factory=list)
 
     def to_metric(self) -> Metric:
         """See MetricConfig.to_metric."""
@@ -74,9 +74,8 @@ class F1Score(Metric):
         stat_mult: int = 4 if config.separate_match else 3
 
         id_map: dict[str, int] = {}
-        if config.ignore_classes is not None:
-            for ignore_class in config.ignore_classes:
-                id_map[ignore_class] = -1
+        for ignore_class in config.ignore_classes:
+            id_map[ignore_class] = -1
 
         for word in itertools.chain(true_data, pred_data):
             if word not in id_map:

--- a/explainaboard/metrics/f1_score_test.py
+++ b/explainaboard/metrics/f1_score_test.py
@@ -23,7 +23,6 @@ class F1ScoreConfigTest(unittest.TestCase):
                 "F1Score",
                 average="macro",
                 separate_match=False,
-                ignore_classes=None,
             ).serialize(),
             {
                 "name": "F1Score",
@@ -31,7 +30,7 @@ class F1ScoreConfigTest(unittest.TestCase):
                 "target_language": None,
                 "average": "macro",
                 "separate_match": False,
-                "ignore_classes": None,
+                "ignore_classes": [],
             },
         )
 
@@ -42,14 +41,12 @@ class F1ScoreConfigTest(unittest.TestCase):
                     "name": "F1Score",
                     "average": "macro",
                     "separate_match": False,
-                    "ignore_classes": None,
                 }
             ),
             F1ScoreConfig(
                 "F1Score",
                 average="macro",
                 separate_match=False,
-                ignore_classes=None,
             ),
         )
 
@@ -89,7 +86,6 @@ class SeqF1ScoreConfigTest(unittest.TestCase):
                 "SeqF1Score",
                 average="macro",
                 separate_match=False,
-                ignore_classes=None,
                 tag_schema="bio",
             ).serialize(),
             {
@@ -98,7 +94,7 @@ class SeqF1ScoreConfigTest(unittest.TestCase):
                 "target_language": None,
                 "average": "macro",
                 "separate_match": False,
-                "ignore_classes": None,
+                "ignore_classes": [],
                 "tag_schema": "bio",
             },
         )
@@ -110,7 +106,6 @@ class SeqF1ScoreConfigTest(unittest.TestCase):
                     "name": "SeqF1Score",
                     "average": "macro",
                     "separate_match": False,
-                    "ignore_classes": None,
                     "tag_schema": "bio",
                 }
             ),
@@ -118,7 +113,6 @@ class SeqF1ScoreConfigTest(unittest.TestCase):
                 "SeqF1Score",
                 average="macro",
                 separate_match=False,
-                ignore_classes=None,
                 tag_schema="bio",
             ),
         )

--- a/explainaboard/processors/kg_link_tail_prediction.py
+++ b/explainaboard/processors/kg_link_tail_prediction.py
@@ -241,7 +241,7 @@ class KGLinkTailPredictionProcessor(Processor):
     #     """
 
     #     metrics = [
-    #         x.to_metric() for x in unwrap(sys_info.analysis_levels)[0].metric_configs
+    #         x.to_metric() for x in sys_info.analysis_levels[0].metric_configs
     #     ]
     #     true_data = [self._get_true_label(x) for x in sys_output]
     #     pred_data = [self._get_predicted_label(x) for x in sys_output]

--- a/explainaboard/processors/processor.py
+++ b/explainaboard/processors/processor.py
@@ -281,12 +281,11 @@ class Processor(Serializable, metaclass=abc.ABCMeta):
             a dictionary of feature name -> list of performances by bucket
         """
         all_results: list[AnalysisResult] = []
-        level_map = {v.name: i for i, v in enumerate(unwrap(sys_info.analysis_levels))}
+        level_map = {v.name: i for i, v in enumerate(sys_info.analysis_levels)}
         metrics = [
-            [y.to_metric() for y in x.metric_configs]
-            for x in unwrap(sys_info.analysis_levels)
+            [y.to_metric() for y in x.metric_configs] for x in sys_info.analysis_levels
         ]
-        for my_analysis in progress(unwrap(sys_info.analyses)):
+        for my_analysis in progress(sys_info.analyses):
             level_id = level_map[my_analysis.level]
             try:
                 all_results.append(
@@ -359,7 +358,7 @@ class Processor(Serializable, metaclass=abc.ABCMeta):
         overall_results: list[dict[str, Performance]] = []
 
         for my_level, my_cases, my_stats in zip(
-            unwrap(sys_info.analysis_levels), analysis_cases, metric_stats
+            sys_info.analysis_levels, analysis_cases, metric_stats
         ):
 
             my_results: dict[str, Performance] = {}
@@ -506,7 +505,7 @@ class Processor(Serializable, metaclass=abc.ABCMeta):
         # generate cases for each level
         analysis_cases: list[list[AnalysisCase]] = []
         metric_stats: list[list[MetricStats]] = []
-        for analysis_level in unwrap(sys_info.analysis_levels):
+        for analysis_level in sys_info.analysis_levels:
             my_cases, my_stats = self._gen_cases_and_stats(
                 sys_info, sys_output, external_stats, analysis_level
             )

--- a/explainaboard/visualizers/draw_charts.py
+++ b/explainaboard/visualizers/draw_charts.py
@@ -206,7 +206,7 @@ def draw_charts_from_reports(
             report_info.append(SysOutputInfo.from_dict(json.load(fin)))
 
     # --- Overall results
-    num_levels = len(unwrap(report_info[0].analysis_levels))
+    num_levels = len(report_info[0].analysis_levels)
     for level_id in range(num_levels):
         overall_results: list[dict[str, Performance]] = [
             x.results.overall[level_id] for x in report_info
@@ -245,7 +245,7 @@ def draw_charts_from_reports(
 
     # --- analysis results
     analysis_results: list[list[AnalysisResult]] = [
-        unwrap(x.results.analyses) for x in report_info
+        x.results.analyses for x in report_info
     ]
     if any(len(x) != len(analysis_results[0]) for x in analysis_results):
         raise ValueError(

--- a/integration_tests/argument_pair_extraction_test.py
+++ b/integration_tests/argument_pair_extraction_test.py
@@ -30,7 +30,7 @@ class ArgumentPairExtractionTest(unittest.TestCase):
         }
         processor = get_processor_class(TaskType.argument_pair_extraction)()
         sys_info = processor.process(metadata, data)
-        self.assertIsNotNone(sys_info.results.analyses)
+        self.assertGreater(len(sys_info.results.analyses), 0)
 
         overall = sys_info.results.overall[0]
         self.assertGreater(len(overall), 0)

--- a/integration_tests/aspect_based_sentiment_classification_test.py
+++ b/integration_tests/aspect_based_sentiment_classification_test.py
@@ -47,5 +47,5 @@ class AspectBasedSentimentClassificationTest(unittest.TestCase):
 
         sys_info = processor.process(metadata, data)
 
-        self.assertIsNotNone(sys_info.results.analyses)
+        self.assertGreater(len(sys_info.results.analyses), 0)
         self.assertGreater(len(sys_info.results.overall), 0)

--- a/integration_tests/cloze_hint_test.py
+++ b/integration_tests/cloze_hint_test.py
@@ -29,7 +29,7 @@ class ClozeGenerativeTest(unittest.TestCase):
         }
         processor = get_processor_class(TaskType.cloze_generative)()
         sys_info = processor.process(metadata, data, skip_failed_analyses=True)
-        self.assertIsNotNone(sys_info.results.analyses)
+        self.assertGreater(len(sys_info.results.analyses), 0)
 
 
 if __name__ == '__main__':

--- a/integration_tests/cloze_multiple_choice_test.py
+++ b/integration_tests/cloze_multiple_choice_test.py
@@ -29,7 +29,7 @@ class ClozeMultipleChoiceTest(unittest.TestCase):
         }
         processor = get_processor_class(TaskType.cloze_mutiple_choice)()
         sys_info = processor.process(metadata, data, skip_failed_analyses=True)
-        self.assertIsNotNone(sys_info.results.analyses)
+        self.assertGreater(len(sys_info.results.analyses), 0)
 
 
 if __name__ == '__main__':

--- a/integration_tests/dynamic_hits_metric_test.py
+++ b/integration_tests/dynamic_hits_metric_test.py
@@ -34,5 +34,5 @@ class KgLinkTailPredictionTest(unittest.TestCase):
 
         sys_info = processor.process(metadata, data.samples, skip_failed_analyses=True)
 
-        self.assertIsNotNone(sys_info.results.analyses)
+        self.assertGreater(len(sys_info.results.analyses), 0)
         self.assertGreater(len(sys_info.results.overall), 0)

--- a/integration_tests/extractive_qa_test.py
+++ b/integration_tests/extractive_qa_test.py
@@ -42,7 +42,7 @@ class ExtractiveQATest(unittest.TestCase):
         processor = get_processor_class(TaskType.qa_extractive)()
         sys_info = processor.process(metadata, data)
 
-        self.assertIsNotNone(sys_info.results.analyses)
+        self.assertGreater(len(sys_info.results.analyses), 0)
         overall = sys_info.results.overall[0]
         self.assertGreater(len(overall), 0)
         self.assertAlmostEqual(overall["ExactMatch"].value, 0.6974789915966386, 2)
@@ -72,7 +72,7 @@ class ExtractiveQATest(unittest.TestCase):
 
         sys_info = processor.process(metadata, data)
 
-        self.assertIsNotNone(sys_info.results.analyses)
+        self.assertGreater(len(sys_info.results.analyses), 0)
         overall = sys_info.results.overall[0]
         self.assertGreater(len(overall), 0)
         self.assertAlmostEqual(overall["ExactMatch"].value, 0.6285714285714286, 2)

--- a/integration_tests/grammar_error_correction_test.py
+++ b/integration_tests/grammar_error_correction_test.py
@@ -30,7 +30,7 @@ class GrammarErrorCorrectionTest(unittest.TestCase):
         processor = get_processor_class(TaskType.grammatical_error_correction)()
         sys_info = processor.process(metadata, data)
         self.assertAlmostEqual(sys_info.results.overall[0]["SeqCorrectCount"].value, 8)
-        self.assertIsNotNone(sys_info.results.analyses)
+        self.assertGreater(len(sys_info.results.analyses), 0)
 
 
 if __name__ == '__main__':

--- a/integration_tests/kg_link_tail_prediction_test.py
+++ b/integration_tests/kg_link_tail_prediction_test.py
@@ -63,7 +63,7 @@ class KgLinkTailPredictionTest(unittest.TestCase):
 
         sys_info = processor.process(metadata, data.samples, skip_failed_analyses=True)
 
-        self.assertIsNotNone(sys_info.results.analyses)
+        self.assertGreater(len(sys_info.results.analyses), 0)
         self.assertGreater(len(sys_info.results.overall), 0)
 
     def test_with_user_defined_features(self):
@@ -114,7 +114,7 @@ class KgLinkTailPredictionTest(unittest.TestCase):
         processor = get_processor_class(TaskType.kg_link_tail_prediction)()
         sys_info = processor.process(metadata, data.samples, skip_failed_analyses=True)
 
-        self.assertIsNotNone(sys_info.results.analyses)
+        self.assertGreater(len(sys_info.results.analyses), 0)
         self.assertGreater(len(sys_info.results.overall), 0)
 
         analysis_map = {x.name: x for x in sys_info.results.analyses if x is not None}
@@ -151,7 +151,7 @@ class KgLinkTailPredictionTest(unittest.TestCase):
 
         sys_info = processor.process(metadata, data.samples, skip_failed_analyses=True)
 
-        self.assertIsNotNone(sys_info.results.analyses)
+        self.assertGreater(len(sys_info.results.analyses), 0)
         self.assertGreater(len(sys_info.results.overall), 0)
 
         analysis_map = {x.name: x for x in sys_info.results.analyses if x is not None}

--- a/integration_tests/machine_translation_test.py
+++ b/integration_tests/machine_translation_test.py
@@ -57,7 +57,7 @@ class MachineTranslationTest(unittest.TestCase):
 
         sys_info = processor.process(metadata, data, skip_failed_analyses=True)
 
-        self.assertIsNotNone(sys_info.results.analyses)
+        self.assertGreater(len(sys_info.results.analyses), 0)
         self.assertGreater(len(sys_info.results.overall), 0)
 
     def test_default_features_dont_modify_condgen(self):

--- a/integration_tests/metric_test.py
+++ b/integration_tests/metric_test.py
@@ -141,7 +141,7 @@ class MetricTest(unittest.TestCase):
 
         sys_info = processor.process(metadata, data)
 
-        self.assertIsNotNone(sys_info.results.analyses)
+        self.assertGreater(len(sys_info.results.analyses), 0)
         overall = unwrap(sys_info.results.overall)[0]
         self.assertGreater(len(overall), 0)
         self.assertAlmostEqual(overall["ExactMatch"].value, 0.6974789915966386, 2)

--- a/integration_tests/ner_test.py
+++ b/integration_tests/ner_test.py
@@ -45,7 +45,7 @@ class NERTest(unittest.TestCase):
         processor = get_processor_class(TaskType.named_entity_recognition)()
         sys_info = processor.process(metadata, data, skip_failed_analyses=True)
 
-        self.assertIsNotNone(sys_info.results.analyses)
+        self.assertGreater(len(sys_info.results.analyses), 0)
         self.assertGreater(len(sys_info.results.overall), 0)
 
         # ------ Deep Test --------
@@ -74,7 +74,7 @@ class NERTest(unittest.TestCase):
         processor = get_processor_class(TaskType.named_entity_recognition)()
         sys_info = processor.process(metadata, data)
 
-        self.assertIsNotNone(sys_info.results.analyses)
+        self.assertGreater(len(sys_info.results.analyses), 0)
         self.assertGreater(len(sys_info.results.overall), 0)
 
         # ---------------------------------------------------------------------------
@@ -150,5 +150,5 @@ class NERTest(unittest.TestCase):
         )
         processor = get_processor_class(TaskType.named_entity_recognition)()
         sys_info = processor.process(metadata, data.samples)
-        self.assertIsNotNone(sys_info.results.analyses)
+        self.assertGreater(len(sys_info.results.analyses), 0)
         self.assertGreater(len(sys_info.results.overall), 0)

--- a/integration_tests/nlg_meta_eval_test.py
+++ b/integration_tests/nlg_meta_eval_test.py
@@ -37,5 +37,5 @@ class NLGMetaEvalTest(unittest.TestCase):
 
         sys_info = processor.process(metadata, data)
 
-        self.assertIsNotNone(sys_info.results.analyses)
+        self.assertGreater(len(sys_info.results.analyses), 0)
         self.assertGreater(len(sys_info.results.overall), 0)

--- a/integration_tests/qa_multiple_choice_test.py
+++ b/integration_tests/qa_multiple_choice_test.py
@@ -43,7 +43,7 @@ class QAMultipleChoiceTest(unittest.TestCase):
         processor = get_processor_class(TaskType.qa_multiple_choice)()
         sys_info = processor.process(metadata, data)
 
-        self.assertIsNotNone(sys_info.results.analyses)
+        self.assertGreater(len(sys_info.results.analyses), 0)
         self.assertGreater(len(sys_info.results.overall), 0)
 
     def test_multiple_qa_customized_feature(self):
@@ -75,7 +75,7 @@ class QAMultipleChoiceTest(unittest.TestCase):
 
         sys_info = processor.process(metadata, data.samples)
 
-        self.assertIsNotNone(sys_info.results.analyses)
+        self.assertGreater(len(sys_info.results.analyses), 0)
         self.assertGreater(len(sys_info.results.overall), 0)
 
 

--- a/integration_tests/qa_open_domain_test.py
+++ b/integration_tests/qa_open_domain_test.py
@@ -29,4 +29,4 @@ class QAOpenDomainTest(unittest.TestCase):
         }
         processor = get_processor_class(TaskType.qa_open_domain)()
         sys_info = processor.process(metadata, data.samples, skip_failed_analyses=True)
-        self.assertIsNotNone(sys_info.results.analyses)
+        self.assertGreater(len(sys_info.results.analyses), 0)

--- a/integration_tests/qa_table_text_hybrid_test.py
+++ b/integration_tests/qa_table_text_hybrid_test.py
@@ -29,7 +29,7 @@ class QATableTextHybridTest(unittest.TestCase):
         }
         processor = get_processor_class(TaskType.qa_tat)()
         sys_info = processor.process(metadata, data)
-        self.assertIsNotNone(sys_info.results.analyses)
+        self.assertGreater(len(sys_info.results.analyses), 0)
 
         self.assertGreater(len(sys_info.results.overall), 0)
         self.assertAlmostEqual(

--- a/integration_tests/summarization_test.py
+++ b/integration_tests/summarization_test.py
@@ -54,7 +54,7 @@ class SummarizationTest(unittest.TestCase):
 
         sys_info = processor.process(metadata, data, skip_failed_analyses=True)
 
-        self.assertIsNotNone(sys_info.results.analyses)
+        self.assertGreater(len(sys_info.results.analyses), 0)
         self.assertGreater(len(sys_info.results.overall), 0)
 
     def test_default_features_dont_modify_condgen(self):
@@ -101,7 +101,7 @@ class SummarizationTest(unittest.TestCase):
         processor = get_processor_class(TaskType.summarization)()
         sys_info = processor.process(metadata, data.samples)
 
-        self.assertIsNotNone(sys_info.results.analyses)
+        self.assertGreater(len(sys_info.results.analyses), 0)
         self.assertGreater(len(sys_info.results.overall), 0)
 
     @unittest.skip('Not yet fixed in v0.11')
@@ -137,7 +137,7 @@ class SummarizationTest(unittest.TestCase):
         sys_info = processor.process(metadata, data.samples)
         # print(sys_info.results.overall)
         # print(metadata["metric_configs"][0])
-        self.assertIsNotNone(sys_info.results.analyses)
+        self.assertGreater(len(sys_info.results.analyses), 0)
         fluency = [
             x
             for x in sys_info.results.overall[0]

--- a/integration_tests/text_classification_test.py
+++ b/integration_tests/text_classification_test.py
@@ -95,7 +95,7 @@ class TextClassificationTest(unittest.TestCase):
         processor = get_processor_class(TaskType.text_classification)()
         sys_info = processor.process(metadata, data, skip_failed_analyses=True)
 
-        self.assertIsNotNone(sys_info.results.analyses)
+        self.assertGreater(len(sys_info.results.analyses), 0)
         self.assertGreater(len(sys_info.results.overall), 0)
 
     def test_process_training_set_dependent_features(self):
@@ -118,7 +118,7 @@ class TextClassificationTest(unittest.TestCase):
         processor = get_processor_class(TaskType.text_classification)()
         sys_info = processor.process(metadata, data)
 
-        self.assertIsNotNone(sys_info.results.analyses)
+        self.assertGreater(len(sys_info.results.analyses), 0)
         self.assertGreater(len(sys_info.results.overall), 0)
 
     def test_process_metadata_in_output_file(self):
@@ -137,5 +137,5 @@ class TextClassificationTest(unittest.TestCase):
 
         sys_info = processor.process(metadata, data.samples)
 
-        self.assertIsNotNone(sys_info.results.analyses)
+        self.assertGreater(len(sys_info.results.analyses), 0)
         self.assertGreater(len(sys_info.results.overall), 0)

--- a/integration_tests/text_pair_classification_test.py
+++ b/integration_tests/text_pair_classification_test.py
@@ -61,7 +61,7 @@ class TextPairClassificationTest(unittest.TestCase):
 
         sys_info = processor.process(metadata, data.samples, skip_failed_analyses=True)
 
-        self.assertIsNotNone(sys_info.results.analyses)
+        self.assertGreater(len(sys_info.results.analyses), 0)
         self.assertGreater(len(sys_info.results.overall), 0)
 
     def test_paws_fra(self):
@@ -81,5 +81,5 @@ class TextPairClassificationTest(unittest.TestCase):
 
         sys_info = processor.process(metadata, data.samples, skip_failed_analyses=True)
 
-        self.assertIsNotNone(sys_info.results.analyses)
+        self.assertGreater(len(sys_info.results.analyses), 0)
         self.assertGreater(len(sys_info.results.overall), 0)

--- a/integration_tests/word_segmentation_test.py
+++ b/integration_tests/word_segmentation_test.py
@@ -34,5 +34,5 @@ class WordSegmentationTest(unittest.TestCase):
 
         sys_info = processor.process(metadata, data, skip_failed_analyses=True)
 
-        self.assertIsNotNone(sys_info.results.analyses)
+        self.assertGreater(len(sys_info.results.analyses), 0)
         self.assertGreater(len(sys_info.results.overall), 0)


### PR DESCRIPTION
This change removes several `Optional` and `| None` annotations from `list` and `dict` types that can represent nothing by the empty collection. This change suppresses some `unwrap` invocations from the codebase.

This change also involves several typing fixes.