### PR TITLE
Move configs from setup.py to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,49 @@
+[metadata]
+name = explainaboard
+version = attr: version.__version__
+description = Explainable Leaderboards for Natural Language Processing
+long_description = file: README.md
+long_description_content_type = text/markdown
+url = https://github.com/neulab/ExplainaBoard
+author = Pengfei Liu
+license = MIT License
+classifiers =
+    Intended Audience :: Developers
+    Topic :: Text Processing
+    Topic :: Scientific/Engineering :: Artificial Intelligence
+    License :: OSI Approved :: MIT License
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3 :: Only
+
+[options]
+packages = find:
+include_package_data = True
+install_requires =
+    datalabs>=0.4.9
+    eaas>=0.3.9
+    lexicalrichness!=0.1.6
+    matplotlib
+    nltk>=3.2
+    numpy
+    sacrebleu
+    scikit-learn
+    scipy
+    seqeval
+    spacy
+    tqdm
+    wheel
+
+[options.extras_require]
+dev = pre-commit
+
+[options.package_data]
+explainaboard.resources = *.json
+
+[options.entry_points]
+console_scripts =
+    explainaboard = explainaboard.explainaboard_main:main
+
 [flake8]
 application-import-names = explainaboard
 exclude = __pycache__, datasets

--- a/setup.py
+++ b/setup.py
@@ -1,56 +1,8 @@
-import codecs
 import os
 
-from setuptools import find_packages, setup
-from version import __version__
+from setuptools import setup
 
-setup(
-    name="explainaboard",
-    version=__version__,
-    description="Explainable Leaderboards for Natural Language Processing",
-    long_description=codecs.open("README.md", encoding="utf-8").read(),
-    long_description_content_type="text/markdown",
-    url="https://github.com/neulab/ExplainaBoard",
-    author="Pengfei Liu",
-    license="MIT License",
-    classifiers=[
-        "Intended Audience :: Developers",
-        "Topic :: Text Processing",
-        "Topic :: Scientific/Engineering :: Artificial Intelligence",
-        "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3 :: Only",
-    ],
-    packages=find_packages(),
-    package_data={"explainaboard.resources": ["*.json"]},
-    entry_points={
-        "console_scripts": [
-            "explainaboard=explainaboard.explainaboard_main:main",
-        ],
-    },
-    install_requires=[
-        "datalabs>=0.4.9",
-        "eaas>=0.3.9",
-        "lexicalrichness!=0.1.6",
-        "matplotlib",
-        "nltk>=3.2",
-        "numpy",
-        "sacrebleu",
-        "scikit-learn",
-        "scipy",
-        "seqeval",
-        "spacy",
-        "tqdm",
-        "wheel",
-    ],
-    extras_require={
-        "dev": [
-            "pre-commit",
-        ],
-    },
-    include_package_data=True,
-)
+setup()
 
 # TODO(odashi): Consider avoiding external invocation to install required models.
 os.system("python -m spacy download en_core_web_sm")


### PR DESCRIPTION
This PR moves configs from `setup.py` to `setup.cfg` as part of #490. For details of the syntax of `setup.cfg`, see the [documentation of setuptools](https://setuptools.pypa.io/en/latest/userguide/declarative_config.html).