### PR TITLE
Allowed specification of the metric #dimensions

### DIFF
--- a/explainaboard/metrics/metric.py
+++ b/explainaboard/metrics/metric.py
@@ -450,11 +450,13 @@ class Metric(metaclass=abc.ABCMeta):
                 - Non-batched data: []
                 - Batched data: [num_batches]
         """
-        if agg_stats.ndim not in (1, 2):
+        if agg_stats.ndim not in (self.stats_dim(), self.stats_dim() + 1):
             raise ValueError(f"Invalid shape size: {agg_stats.shape}")
 
         result = self._calc_metric_from_aggregate(agg_stats)
-        result_shape = () if agg_stats.ndim == 1 else (agg_stats.shape[0],)
+        result_shape = (
+            () if agg_stats.ndim == self.stats_dim() else (agg_stats.shape[0],)
+        )
 
         assert result.shape == result_shape, (
             "BUG: invalid operation: "
@@ -492,6 +494,10 @@ class Metric(metaclass=abc.ABCMeta):
         last dimension of the returned ndarray.
         """
         return False
+
+    def stats_dim(self) -> int:
+        """The dimension of the sufficient statistics."""
+        return 1
 
     def calc_confidence_interval(
         self,

--- a/explainaboard/metrics/nlg_meta_evaluation.py
+++ b/explainaboard/metrics/nlg_meta_evaluation.py
@@ -111,28 +111,21 @@ class CorrelationWMTDAMetric(Metric):
 
         return scores
 
+    def stats_dim(self) -> int:
+        """See Metric.stats_dim."""
+        return 2
+
     def _aggregate_stats(self, stats: MetricStats) -> np.ndarray:
         """See Metric.aggregate_stats."""
-        if stats.is_batched():
-            data = stats.get_batch_data()
-            assert data.shape[-1] == 4
-            return data.reshape((data.shape[0], data.shape[-2] * data.shape[-1]))
-        else:
-            data = stats.get_data()
-            assert data.shape[-1] == 4
-            return data.reshape((data.shape[-2] * data.shape[-1]))
+        return stats.get_batch_data() if stats.is_batched() else stats.get_data()
 
     def _calc_metric_from_aggregate(self, agg_stats: np.ndarray) -> np.ndarray:
         """See Metric.calc_metric_from_aggregate."""
         if agg_stats.ndim == 1:
-            agg_stats = agg_stats.reshape((int(agg_stats.shape[0] / 4), 4))
             val = self.calc_metric_from_aggregate_single(agg_stats)
             return np.array(val)
         else:
             n_samples = agg_stats.shape[0]
-            agg_stats = agg_stats.reshape(
-                (agg_stats.shape[0], int(agg_stats.shape[1] / 4), 4)
-            )
             ret_metric = np.zeros(n_samples)
             for i, single_stat in enumerate(agg_stats):
                 val = self.calc_metric_from_aggregate_single(single_stat)


### PR DESCRIPTION
This PR loosens the restriction that sufficient statistics must be a vector, and allows them to be a tensor with the dimension equal to `Metric.stats_dim()`.

It also demonstrates how this works on the `nlg_meta_evaluation()` metric.

@pfliu-nlp and @odashi : could you please check this PR as a potential solution to the discussion in https://github.com/neulab/ExplainaBoard/pull/527 ?