### PR TITLE
list[dict[Performance]] to dict[dict[Performance]]

### DIFF
--- a/docs/example_scripts/test_kg.py
+++ b/docs/example_scripts/test_kg.py
@@ -31,7 +31,7 @@ sys_info.print_as_json(file=open("./report.json", 'w'))
 
 
 # get overall results of different metrics
-for name, metric_info in sys_info.results.overall[0].items():
+for name, metric_info in sys_info.results.overall["example"].items():
     value = metric_info.value
     confidence_score_low = metric_info.confidence_score_low
     confidence_score_high = metric_info.confidence_score_high

--- a/explainaboard/explainaboard_main.py
+++ b/explainaboard/explainaboard_main.py
@@ -522,9 +522,9 @@ def main():
             logger = get_logger('report')
 
             logger.info('--- Overall Performance')
-            for overall_level in report.results.overall:
+            for level_name, overall_level in report.results.overall.items():
                 for metric_name, metric_stat in overall_level.items():
-                    logger.info(f'{metric_name}\t{metric_stat.value}')
+                    logger.info(f'{level_name}\t{metric_name}\t{metric_stat.value}')
             logger.info('')
             logger.info('--- Fine-grained Analyses')
             for analysis in report.results.analyses:

--- a/explainaboard/info.py
+++ b/explainaboard/info.py
@@ -80,7 +80,7 @@ class SysOutputInfo:
     analyses: list[Analysis] = field(default_factory=list)
 
     # set later
-    results: Result = field(default_factory=lambda: Result(overall=[], analyses=[]))
+    results: Result = field(default_factory=lambda: Result(overall={}, analyses=[]))
 
     def to_dict(self) -> dict:
         """Serialization function."""

--- a/explainaboard/processors/processor.py
+++ b/explainaboard/processors/processor.py
@@ -378,7 +378,7 @@ class Processor(metaclass=abc.ABCMeta):
         self,
         sys_info: SysOutputInfo,
         metric_stats: list[dict[str, MetricStats]],
-    ) -> list[dict[str, Performance]]:
+    ) -> dict[str, dict[str, Performance]]:
         """Get the overall performance according to metrics.
 
         Args:
@@ -389,7 +389,7 @@ class Processor(metaclass=abc.ABCMeta):
         Returns:
             a dictionary of metrics to overall performance numbers
         """
-        overall_results: list[dict[str, Performance]] = []
+        overall_results: dict[str, dict[str, Performance]] = {}
 
         for my_level, my_stats in zip(sys_info.analysis_levels, metric_stats):
             my_results: dict[str, Performance] = {}
@@ -410,7 +410,7 @@ class Processor(metaclass=abc.ABCMeta):
                     confidence_score_high=ci.high if ci is not None else None,
                 )
 
-            overall_results.append(my_results)
+            overall_results[my_level.name] = my_results
 
         return overall_results
 

--- a/explainaboard/visualizers/draw_charts.py
+++ b/explainaboard/visualizers/draw_charts.py
@@ -206,10 +206,9 @@ def draw_charts_from_reports(
             report_info.append(SysOutputInfo.from_dict(json.load(fin)))
 
     # --- Overall results
-    num_levels = len(report_info[0].analysis_levels)
-    for level_id in range(num_levels):
+    for analysis in report_info[0].analyses:
         overall_results: list[dict[str, Performance]] = [
-            x.results.overall[level_id] for x in report_info
+            x.results.overall[analysis.level] for x in report_info
         ]
         overall_metric_names = sorted((overall_results[0].keys()))
 

--- a/explainaboard/visualizers/performance_gap.py
+++ b/explainaboard/visualizers/performance_gap.py
@@ -36,10 +36,10 @@ def get_pairwise_performance_gap(
     Returns:
         A SystemOutputInfo object that has the difference between the performances.
     """
-    overall = [
-        _diff_overall(o1, o2)
-        for o1, o2 in zip(sys1.results.overall, sys2.results.overall)
-    ]
+    overall = {
+        level: _diff_overall(sys1.results.overall[level], sys2.results.overall[level])
+        for level in sys1.results.overall
+    }
 
     analyses: list[AnalysisResult] = []
 

--- a/integration_tests/argument_pair_extraction_test.py
+++ b/integration_tests/argument_pair_extraction_test.py
@@ -32,7 +32,7 @@ class ArgumentPairExtractionTest(unittest.TestCase):
         sys_info = processor.process(metadata, data)
         self.assertGreater(len(sys_info.results.analyses), 0)
 
-        overall = sys_info.results.overall[0]
+        overall = sys_info.results.overall["example"]
         self.assertGreater(len(overall), 0)
         self.assertAlmostEqual(overall["F1"].value, 0.25625, 4)
 

--- a/integration_tests/extractive_qa_test.py
+++ b/integration_tests/extractive_qa_test.py
@@ -43,7 +43,7 @@ class ExtractiveQATest(unittest.TestCase):
         sys_info = processor.process(metadata, data)
 
         self.assertGreater(len(sys_info.results.analyses), 0)
-        overall = sys_info.results.overall[0]
+        overall = sys_info.results.overall["example"]
         self.assertGreater(len(overall), 0)
         self.assertAlmostEqual(overall["ExactMatch"].value, 0.6974789915966386, 2)
         self.assertAlmostEqual(overall["F1"].value, 0.8235975260931867, 2)
@@ -73,7 +73,7 @@ class ExtractiveQATest(unittest.TestCase):
         sys_info = processor.process(metadata, data)
 
         self.assertGreater(len(sys_info.results.analyses), 0)
-        overall = sys_info.results.overall[0]
+        overall = sys_info.results.overall["example"]
         self.assertGreater(len(overall), 0)
         self.assertAlmostEqual(overall["ExactMatch"].value, 0.6285714285714286, 2)
         self.assertAlmostEqual(overall["F1"].value, 0.7559651817716333, 2)

--- a/integration_tests/grammar_error_correction_test.py
+++ b/integration_tests/grammar_error_correction_test.py
@@ -29,7 +29,9 @@ class GrammarErrorCorrectionTest(unittest.TestCase):
         }
         processor = get_processor_class(TaskType.grammatical_error_correction)()
         sys_info = processor.process(metadata, data)
-        self.assertAlmostEqual(sys_info.results.overall[0]["SeqCorrectCount"].value, 8)
+        self.assertAlmostEqual(
+            sys_info.results.overall["example"]["SeqCorrectCount"].value, 8
+        )
         self.assertGreater(len(sys_info.results.analyses), 0)
 
 

--- a/integration_tests/meta_eval_wmt_da_test.py
+++ b/integration_tests/meta_eval_wmt_da_test.py
@@ -39,5 +39,5 @@ class MetaEvalWMTDATest(unittest.TestCase):
         self.assertGreater(len(sys_info.results.analyses), 0)
         self.assertGreater(len(sys_info.results.overall), 0)
         self.assertAlmostEqual(
-            sys_info.results.overall[0]["SegKtauCorr"].value, -0.0169, 3
+            sys_info.results.overall["example"]["SegKtauCorr"].value, -0.0169, 3
         )

--- a/integration_tests/metric_test.py
+++ b/integration_tests/metric_test.py
@@ -142,7 +142,7 @@ class MetricTest(unittest.TestCase):
         sys_info = processor.process(metadata, data)
 
         self.assertGreater(len(sys_info.results.analyses), 0)
-        overall = unwrap(sys_info.results.overall)[0]
+        overall = sys_info.results.overall["example"]
         self.assertGreater(len(overall), 0)
         self.assertAlmostEqual(overall["ExactMatch"].value, 0.6974789915966386, 2)
         self.assertAlmostEqual(overall["F1"].value, 0.8235975260931867, 2)

--- a/integration_tests/qa_table_text_hybrid_test.py
+++ b/integration_tests/qa_table_text_hybrid_test.py
@@ -33,7 +33,7 @@ class QATableTextHybridTest(unittest.TestCase):
 
         self.assertGreater(len(sys_info.results.overall), 0)
         self.assertAlmostEqual(
-            sys_info.results.overall[0]["ExactMatchQATat"].value, 0.746978, 3
+            sys_info.results.overall["example"]["ExactMatchQATat"].value, 0.746978, 3
         )
 
 


### PR DESCRIPTION
Fixes #530
Part of #491

This change replaces the representation of `overall`: `list[dict[str, Performance]]` with `dict[str, dict[str, Performance]]`.