### PR TITLE
Add markdownlint-cli2 to pre-commit hook and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,4 +98,16 @@ jobs:
       - name: mypy
         uses: pre-commit/action@v2.0.3
         with:
-          extra_args: mypy --all-files 
+          extra_args: mypy --all-files
+  markdownlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18.x
+      - name: lint
+        uses: pre-commit/action@v2.0.3
+        with:
+          extra_args: markdownlint-cli2 --all-files

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,5 +1,10 @@
 MD013:
   # Number of characters
   line_length: 88
+  code_blocks: false
+
+MD024:
+  # Allow multiple headings with the same content
+  siblings_only: true
 
 ignores: ["explainaboard/third_party"]

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,10 +1,26 @@
-MD013:
+# TODO(tetsuok): Re-enable once the existing issues are fixed.
+MD001: false
+
+# TODO(tetsuok): Re-enable once the existing issues are fixed.
+MD013: false
   # Number of characters
-  line_length: 88
-  code_blocks: false
+  # line_length: 88
+  # code_blocks: false
 
 MD024:
   # Allow multiple headings with the same content
   siblings_only: true
+
+# TODO(tetsuok): Re-enable once the existing issues are fixed.
+MD033: false
+
+# TODO(tetsuok): Re-enable once the existing issues are fixed.
+MD036: false
+
+# TODO(tetsuok): Re-enable once the existing issues are fixed.
+MD040: false
+
+# TODO(tetsuok): Re-enable once the existing issues are fixed.
+MD046: false
 
 ignores: ["explainaboard/third_party"]

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,5 @@
+MD013:
+  # Number of characters
+  line_length: 88
+
+ignores: ["explainaboard/third_party"]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,3 +41,8 @@ repos:
         additional_dependencies:
           - types-requests
         files: '\.py$'
+  - repo: https://github.com/DavidAnson/markdownlint-cli2
+    rev: v0.5.1
+    hooks:
+    - id: markdownlint-cli2
+    - id: markdownlint-cli2-fix

--- a/README.md
+++ b/README.md
@@ -26,7 +26,6 @@ It offers a number of different ways with which you can evaluate and understand 
 5. *Fine-grained Error Analysis*: where do errors occur?
 6. *System Combination*: Is there potential complementarity between different systems?
 
-
 ## Using Explainaboard
 
 ExplainaBoard can be used online or offline.
@@ -42,7 +41,6 @@ ability to browse outputs and upload your own system outputs.
 
 First, follow the installation directions below, then take a look at our
 [**CLI examples**](docs/cli_interface.md).
-
 
 **Install Method 1 - Standard Use:** Simple installation from PyPI (Python 3 only)
 
@@ -65,11 +63,11 @@ python -m spacy download en_core_web_sm
 pre-commit install
 ```
 
-- **Testing:** To run tests, you can run `python -m unittest`. 
+- **Testing:** To run tests, you can run `python -m unittest`.
 - **Linting and Code Style:** This project uses flake8 (linter) and black (formatter). They are enforced in the pre-commit hook and in the CI pipeline.
-    - run `python -m black .` to format code
-    - run `flake8` to lint code
-    - You can also configure your IDE to automatically format and lint the files as you are writing code.
+  - run `python -m black .` to format code
+  - run `flake8` to lint code
+  - You can also configure your IDE to automatically format and lint the files as you are writing code.
 
 After trying things out in the [CLI](docs/cli_interface.md), you can read how to add
 new [features](docs/add_new_features.md), [tasks](docs/add_new_tasks.md), or
@@ -96,4 +94,3 @@ If you find it useful in research, you can cite it in papers:
 We thanks all authors who share their system outputs with us: Ikuya Yamada, Stefan Schweter,
 Colin Raffel, Yang Liu, Li Dong. We also thank
 Vijay Viswanathan, Yiran Chen, Hiroaki Hayashi for useful discussion and feedback about ExplainaBoard.
-

--- a/docs/add_custom_features.md
+++ b/docs/add_custom_features.md
@@ -1,8 +1,9 @@
 # Add custom features for custom analysis
 
-If you want to perform custom analysis with your custom features that are not supported in the original task processors, and these features are only related to one particular system/dataset instead of the task itself, you can define the custom features and analysis in the `metadata` section in the output JSON file. 
+If you want to perform custom analysis with your custom features that are not supported in the original task processors, and these features are only related to one particular system/dataset instead of the task itself, you can define the custom features and analysis in the `metadata` section in the output JSON file.
 
 ## Example of bucket analysis
+
 Here is the output json format for bucket analysis with custom features. Discrete features should have `"dtype": "string"`, such as the subject of the sentence, etc. Continuous features should have `"dtype": "float"`, such as the count of particular words, the output logits/probability, etc.
 
 ```
@@ -50,17 +51,21 @@ Here is the output json format for bucket analysis with custom features. Discret
   ]
 }
 ```
+
 where
+
 * `feature-level` represents the fine-grained level of the analysis
-    * `example` for sentence-level analysis
-    * `span` for span-level analysis (e.g. in named entity recognition analysis)
-    * `token` for token-level analysis (e.g. in named entity conditional text generation)
+  * `example` for sentence-level analysis
+  * `span` for span-level analysis (e.g. in named entity recognition analysis)
+  * `token` for token-level analysis (e.g. in named entity conditional text generation)
 * `num_bucket`: the number of buckets to be used
 * `sample_limit`: if the number of examples are larger than sample_limit, randomly select sample_limit examples for analysis
 
 ## Example of ComboCountAnalysis
+
 ComboCountAnalysis is used to count feature combinations (e.g. for confusion matrices). It will
 return counts of each combination of values for the features named in `features`.
+
 ```
 {
   "metadata": {
@@ -81,21 +86,26 @@ return counts of each combination of values for the features named in `features`
   ]
 }
 ```
+
 where
+
 * `feature-level` represents the fine-grained level of the analysis
-    * `example` for sentence-level analysis
-    * `span` for span-level analysis (e.g. in named entity recognition analysis)
-    * `token` for token-level analysis (e.g. in named entity conditional text generation)
+  * `example` for sentence-level analysis
+  * `span` for span-level analysis (e.g. in named entity recognition analysis)
+  * `token` for token-level analysis (e.g. in named entity conditional text generation)
 * `features` should be a list of feature names where each feature are predefined. These features can be true_label, predicted_label, or other custom features.
 
 ## Example output json files
+
 * [text-classification](https://github.com/neulab/ExplainaBoard/blob/main/data/system_outputs/text-classification-custom-feature-example.json)
 * [machine-translation](https://github.com/neulab/ExplainaBoard/blob/main/integration_tests/artifacts/machine_translation/output_with_features.json)
 
-## Note 
-When running analysis with SDK command, `--custom-dataset-file-type` and `--output-file-type json` are required. 
+## Note
+
+When running analysis with SDK command, `--custom-dataset-file-type` and `--output-file-type json` are required.
 
 Example command:
+
 ```
 explainaboard --task text-classification --custom-dataset-paths path_to_my_custom_data.tsv --system-outputs path_to_my_output_with_custom_features.json --report-json path_to_my_report.json --custom-dataset-file-type tsv --output-file-type json
 ```

--- a/docs/add_new_features.md
+++ b/docs/add_new_features.md
@@ -14,6 +14,7 @@ module corresponding to its task, in this case:
 `explainaboard/processors/text_classification.py`
 
 To add a feature that is analyzed for each example:
+
 1. add an entry or two to the `features` list
 2. make sure that a `BucketAnalysis` object is added to the `analyses` list. For many
    processors, float features are added automatically, but string features need to be
@@ -60,18 +61,20 @@ class TextClassificationProcessor(Processor):
 
 
 ```
+
 where
+
 * `dtype` represents the data type of the feature
-    * `float` for continuous feature
-    * `string` for discrete feature
+  * `float` for continuous feature
+  * `string` for discrete feature
 * `description`: the description of the feature
 * `func`: a function to calculate the feature, with three arguments
-   * `info`: the SysOutputInfo object
-   * `x`: the original example data from the system output/dataset
-   * `c`: the `AnalysisCase` corresponding to this example
+  * `info`: the SysOutputInfo object
+  * `x`: the original example data from the system output/dataset
+  * `c`: the `AnalysisCase` corresponding to this example
 
 Note that it is possible to define features not only over the whole example, but also
-over individual tokens or spans. You can take a look at `sequence_labeling.py` or 
+over individual tokens or spans. You can take a look at `sequence_labeling.py` or
 `conditional_generation.py` for examples of this.
 
 ## Features and Unittests

--- a/docs/add_new_formats.md
+++ b/docs/add_new_formats.md
@@ -1,7 +1,7 @@
 # Add New Format
 
-
 ## Case 1: Supported Formats
+
 If the format of your datasets has already been supported
 by the existing library, you can directly use it without
 any library-level modification
@@ -15,7 +15,6 @@ any library-level modification
 * `TaskType.extractive_qa`
   * `FileType.json` (same format with squad)
   
-
 For example, suppose that you have a system output of the summarization task
 in `tsv` format:
 
@@ -38,15 +37,17 @@ analysis = processor.process()
 analysis.write_to_directory("./")
 ```
 
-
 ## Case 2: Unsupported Formats
+
 If your dataset is in a new format which the current SDK doesn't support, you can
+
 * (1) reformat your data into a format that the current library supports
-* (2) or re-write the `loader.load()` function to make it 
+* (2) or re-write the `loader.load()` function to make it
   support your format.
   Taking the summarization task for example, suppose that the existing SDK only supports
   `tsv` format, we can make `json` format supported by adding the following code inside
   `loaders.summarization.TextSummarizationLoader.loader()`
+
   ```python
       def load(self) -> Iterable[Dict]:
         raw_data = self._load_raw_data_points()

--- a/docs/add_new_tasks.md
+++ b/docs/add_new_tasks.md
@@ -2,14 +2,14 @@
 
 Let's take `text_classification` as an example to show how to add a new task for ExplainaBoard.
 
-To do so, you would first need to add your task to the modules `tasks.py`. 
+To do so, you would first need to add your task to the modules `tasks.py`.
 After doing so, you would also need to create a `Loader`, `Processor`, and unit tests for the
 new task, placed under the relevant directories.
 
-
 ## Task and Format Declaration
+
 (1) All the supported tasks are listed in **tasks.py**. If your task name is not listed in the file,
-please add your task to `TaskType` (enum) and the task list `_task_categories`. Task names can not 
+please add your task to `TaskType` (enum) and the task list `_task_categories`. Task names can not
 contain `space` and different words should be connected using `-`.
 
 (2) If the format of your task's dataset is not covered by `FileType` in the file
@@ -17,6 +17,7 @@ contain `space` and different words should be connected using `-`.
 task uses a standard format such as tsv, it is not necessary to add a new type).
 
 For example:
+
 ```python
 class TaskType(str, Enum):
     text_classification = "text-classification"
@@ -27,6 +28,7 @@ _task_categories: List[TaskCategory] = [
                  [Task(TaskType.text_classification, True, ["F1score", "Accuracy"])]),
 ]
 ```
+
 where the parameters in `TaskCategory` refers to the task's name, description, and the list of tasks
 
 ## Create a Loader module for your task
@@ -34,6 +36,7 @@ where the parameters in `TaskCategory` refers to the task's name, description, a
 (1) Create a new python file `text_classification.py` in the folder `explainaboard/loaders/`
 
 (2) In this file, we need to:
+
 * create a data loader for text classification task inheriting from the class `Loader`
 * implement the member function `def load(self)`
 
@@ -84,6 +87,7 @@ task to the one you're trying to implement to get hints.
 
 (3) Import this module (`text_classification.py`) in `__init__.py`
 For example, in this file `explainaboard/loaders/__init__.py`, we have:
+
 ```python
 from explainaboard.loaders import text_classification
 
@@ -97,6 +101,7 @@ __all__ = [
 (1) Create a new python file `text_classification.py` in the folder `explainaboard/processors/`
 
 (2) In this file, we need to:
+
 * create a processor for text classification task inheriting from the class `Processor`
 * define features that you aim to use for this task in the `_features` variable
 * [implement the features](add_new_features.md) that you want to use to perform analysis
@@ -107,7 +112,8 @@ you may want to override some of the functions in the base `Processor` class imp
 task, and `processors/named_entity_recognition.py` gives a good example of a more complicated task.
 
 (3) Import this module (text_classification.py) in `__init__.py`
-For example, in this file `explainaboard/processors/__init__.py`, we have: 
+For example, in this file `explainaboard/processors/__init__.py`, we have:
+
 ```python
 from explainaboard.processors import text_classification
 
@@ -116,12 +122,13 @@ __all__ = [
 ]
 ```
 
-
 ## Update new task information
+
 Once you finish all the above steps, you need to register the new task in the script
 tasks.py by declaring the supported formats, metrics, etc.
 
 For example, the following information can be added for text classification tasks.
+
 ```python
     TaskCategory(
         "text-classification",
@@ -144,4 +151,3 @@ For example, the following information can be added for text classification task
 (1) Create a new python file `test_text_classification.py` in the folder `integration_tests/`
 
 (2) Implement unit tests for this task referencing that of other similar tasks
-

--- a/docs/cli_interface.md
+++ b/docs/cli_interface.md
@@ -5,6 +5,7 @@ with examples of how to analyze different tasks. In particular
 [text classification](#text-classification) is a good example to start with.
 
 **General notes:**
+
 * Click the link on the task name for more details, or when no link exists you can open
   the example data to see what the file format looks like.
 * You can either analyze an existing dataset included in
@@ -15,7 +16,7 @@ with examples of how to analyze different tasks. In particular
   [datasets supported in DataLab](https://github.com/ExpressAI/DataLab/tree/main/datasets)
   and [add your dataset](https://github.com/ExpressAI/DataLab/blob/main/docs/SDK/add_new_datasets_into_sdk.md)
   if it doesn't exist.
-* All of the examples below will output a json report to standard out, which you can 
+* All of the examples below will output a json report to standard out, which you can
   pipe to a file such as `report.json` for later use. Also, check out our
   [visualization tools](visualization.md).
 
@@ -23,6 +24,7 @@ We welcome contributions of [more tasks](add_new_tasks.md), or detailed document
 for tasks where the documentation does not yet exist! Please open an issue or file a PR.
 
 **Table of Contents**
+
 * [Text Classification](#text-classification)
 * [Text Pair Classification](#text-pair-classification)
 * [Conditional Text Generation](#conditional-text-generation)
@@ -43,9 +45,6 @@ for tasks where the documentation does not yet exist! Please open an issue or fi
 * [Argument Pair Extraction](argument-pair-extraction)
 * [WMT Metrics Direct Assessment Meta-evaluation](#wmt-metrics-direct-assessment-meta-evaluation)
 
-
-
-
 ## [Text Classification](task_text_classification.md)
 
 Text classification consists of classifying text into different categories, such as
@@ -55,15 +54,16 @@ Sentiment Treebank, a set of sentiment tags over English reviews.
 **CLI Examples**
 
 The below example loads the `sst2` dataset from DataLab:
+
 ```shell
 explainaboard --task text-classification --dataset sst2 --system-outputs ./data/system_outputs/sst2/sst2-lstm-output.txt
 ```
 
 The below example loads a dataset from an existing file:
+
 ```shell
 explainaboard --task text-classification --custom-dataset-paths ./data/system_outputs/sst2/sst2-dataset.tsv --system-outputs ./data/system_outputs/sst2/sst2-lstm-output.txt
 ```
-
 
 ## [Text Pair Classification](task_text_pair_classification.md)
 
@@ -75,15 +75,16 @@ Stanford Natural Language Inference dataset.
 **CLI Example**
 
 The below example loads the `snli` dataset from DataLab:
+
 ```shell
 explainaboard --task text-pair-classification --dataset snli --system-outputs ./data/system_outputs/snli/snli-roberta-output.txt
 ```
 
 The below example loads a dataset from an existing file:
+
 ```shell
 explainaboard --task text-pair-classification --custom-dataset-paths ./data/system_outputs/snli/snli-dataset.tsv --system-outputs ./data/system_outputs/snli/snli-roberta-output.txt
 ```
-
 
 ## [Conditional Text Generation](task_conditional_generation.md)
 
@@ -94,18 +95,22 @@ a summarization system on the CNN-daily mail dataset.
 **CLI Example**
 
 The below example loads a miniature version of the CNN-daily mail dataset (100 lines only) from an existing file:
+
 ```shell
 explainaboard --task summarization --custom-dataset-paths ./data/system_outputs/cnndm/cnndm_mini-dataset.tsv --system-outputs ./data/system_outputs/cnndm/cnndm_mini-bart-output.txt --metrics rouge2 bart_score_en_ref
 ```
+
 Note that this uses two different metrics separated by a space.
 
 You could also load the `cnn_dailymail` dataset from DataLab.
 Because the test set is large we don't include it directly in the explainaboard repository, but you can get an example by downloading with wget:
+
 ```shell
 wget -P ./data/system_outputs/cnndm/ https://storage.googleapis.com/inspired-public-data/explainaboard/task_data/summarization/cnndm-bart-output.txt
 ```
 
 Then run the below command and it should work:
+
 ```shell
 explainaboard --task summarization --dataset cnn_dailymail --system-outputs ./data/system_outputs/cnndm/cnndm-bart-output.txt --metrics rouge2
 ```
@@ -119,6 +124,7 @@ probability for each space-separated word. Here is an example:
 **CLI Example**
 
 The below example analyzes the wikitext corpus:
+
 ```shell
 explainaboard --task language-modeling --custom-dataset-paths ./data/system_outputs/wikitext/wikitext-dataset.txt --system-outputs ./data/system_outputs/wikitext-sys1-output.txt
 ```
@@ -131,49 +137,54 @@ The below examples demonstrate how you can perform such analysis on the CoNLL 20
 **CLI Example**
 
 The below example loads the `conll2003` NER dataset from DataLab:
+
 ```shell
 explainaboard --task named-entity-recognition --dataset conll2003 --sub-dataset ner --system-outputs ./data/system_outputs/conll2003/conll2003-elmo-output.conll
 ```
 
 Alternatively, you can reference a dataset file directly.
+
 ```shell
 explainaboard --task named-entity-recognition --custom-dataset-paths ./data/system_outputs/conll2003/conll2003-dataset.conll --system-outputs ./data/system_outputs/conll2003/conll2003-elmo-output.conll 
 ```
 
-
 ## Word Segmentation
+
 Word segmentation aims to segment texts without spaces between words.
 
 **CLI Example**
 
 The below example loads the `msr` dataset from DataLab:
+
 ```shell
 explainaboard --task word-segmentation --dataset msr --system-outputs ./data/system_outputs/cws/test-msr-predictions.tsv
 ```
+
 Note that the file `test-msr-predictions.tsv` can be downloaded [here](https://datalab-hub.s3.amazonaws.com/predictions/test-msr-predictions.tsv)
 
 Alternatively, you can reference a dataset file directly.
+
 ```
 explainaboard --task word-segmentation --custom-dataset-paths ./data/system_outputs/cws/test.tsv --system-outputs ./data/system_outputs/cws/prediction.tsv
 ```
 
-
 ## Chunking
+
 Dividing text into syntactically related non-overlapping groups of words.
 
 **CLI Example**
 
 The below example loads the `conll00_chunk` dataset from DataLab:
+
 ```shell
 explainaboard --task chunking --dataset conll00_chunk --system-outputs ./data/system_outputs/chunking/test-conll00-predictions.tsv
 ```
 
 Alternatively, you can reference a dataset file directly.
+
 ```
 explainaboard --task chunking --custom-dataset-paths ./data/system_outputs/chunking/dataset-test-conll00.tsv --system-outputs ./data/system_outputs/chunking/test-conll00-predictions.tsv
 ```
-
-
 
 ## [Extractive QA](task_extractive_qa.md)
 
@@ -183,50 +194,51 @@ The below example performs this extraction on the dataset SQuAD.
 **CLI Example**
 
 Below is an example of referencing the dataset directly.
+
 ```shell
 explainaboard --task qa-extractive --custom-dataset-paths ./data/system_outputs/squad/squad_mini-dataset.json --system-outputs ./data/system_outputs/squad/squad_mini-example-output.json > report.json
 ```
 
 The below example loads the `squad` dataset from DataLab. There is an [open issue](https://github.com/neulab/ExplainaBoard/issues/239) that prevents the specification of a dataset split, so this will not work at the moment. But we are working on it.
+
 ```shell
 explainaboard --task qa-extractive --dataset squad --system-outputs MY_FILE > report.json
 ```
 
-
 ## [Hybrid Table Text QA](task_qa_table_text_hybrid.md)
+
 This task aims to answer a question based on a hybrid of tabular
 and textual context, e.g., [Zhu et al.2021](https://aclanthology.org/2021.acl-long.254.pdf).
 
-
 **CLI Example**
 
+The below example loads the `tat_qa` dataset from DataLab.
 
-The below example loads the `tat_qa` dataset from DataLab. 
 ```shell
 explainaboard --task qa-tat --output-file-type json --dataset tat_qa --system-outputs predictions_list.json > report.json
 ```
+
 where you can download the file `predictions_list.json` by:
 
 ```shell
 wget -P ./ https://explainaboard.s3.amazonaws.com/system_outputs/qa_table_text_hybrid/predictions_list.json
 ```
 
-
 ## [Open Domain QA](task_qa_open_domain.md)
-Open-domain QA aims to answer a question in the form of natural language based on large-scale 
+
+Open-domain QA aims to answer a question in the form of natural language based on large-scale
 unstructured documents
 
-Following examples show how an open-domain QA system can be evaluated with detailed analyses using 
+Following examples show how an open-domain QA system can be evaluated with detailed analyses using
 ExplainaBoard CLI.
 
 **CLI Example**
 
 Using Build-in datasets from DataLab:
+
 ```shell
 explainaboard --task qa-open-domain --dataset natural_questions_comp_gen   --system-outputs ./data/system_outputs/qa_open_domain/test.dpr.nq.txt  > report.json
 ```
-
-
 
 ## [Multiple Choice QA](task_qa_multiple_choice.md)
 
@@ -236,15 +248,16 @@ The following example demonstrates this on the metaphor QA dataset.
 **CLI Example**
 
 The below example loads the `fig_qa` dataset from DataLab.
+
 ```shell
 explainaboard --task qa-multiple-choice --dataset fig_qa --system-outputs ./data/system_outputs/fig_qa/fig_qa-gptneo-output.json > report.json
 ```
 
 And this is what it looks like with a custom dataset.
+
 ```shell
 explainaboard --task qa-multiple-choice --custom-dataset-paths ./data/system_outputs/fig_qa/fig_qa-dataset.json --system-outputs ./data/system_outputs/fig_qa/fig_qa-gptneo-output.json > report.json
 ```
-
 
 ## [KG Link Tail Prediction](task_kg_link_tail_prediction.md)
 
@@ -253,6 +266,7 @@ Predicting the tail entity of missing links in knowledge graphs
 **CLI Example**
 
 The below example loads the `fb15k_237` dataset from DataLab.
+
 ```shell
     wget https://datalab-hub.s3.amazonaws.com/predictions/test_distmult.json
     explainaboard --task kg-link-tail-prediction --dataset fb15k_237 --sub-dataset origin --system-outputs test_distmult.json > log.res
@@ -261,7 +275,6 @@ The below example loads the `fb15k_237` dataset from DataLab.
 ```shell
     explainaboard --task kg-link-tail-prediction --custom-dataset-paths ./data/system_outputs/fb15k-237/data_mini.json --system-outputs ./data/system_outputs/fb15k-237/test-kg-prediction-no-user-defined-new.json > report.json
 ```
- 
 
 ## [Aspect-based Sentiment Classification](task_aspect_based_sentiment_classification.md)
 
@@ -270,35 +283,39 @@ Predict the sentiment of a text based on a specific aspect.
 **CLI Example**
 
 This is an example with a custom dataset.
+
 ```shell
 explainaboard --task aspect-based-sentiment-classification --custom-dataset-paths ./data/system_outputs/absa/absa-dataset.txt --system-outputs ./data/system_outputs/absa/absa-example-output.tsv > report.json
 ```
 
 ## [Multiple-choice Cloze]
+
 Fill in a blank based on multiple provided options
 
 **CLI Example**
 This is an example using the dataset from `DataLab`
+
 ```shell
 explainaboard --task cloze-multiple-choice --dataset gaokao2018_np1 --sub-dataset cloze-multiple-choice --metrics CorrectScore --system-outputs ./integration_tests/artifacts/gaokao/rst_2018_quanguojuan1_cloze_choice.json > report.json
 ```
 
-
 ## [Generative Cloze]
+
 Fill in a blank based on hint
 
 **CLI Example**
 This is an example using the dataset from `DataLab`
+
 ```shell
 explainaboard --task cloze-generative --dataset gaokao2018_np1 --sub-dataset cloze-hint --metrics CorrectScore --system-outputs ./integration_tests/artifacts/gaokao/rst_2018_quanguojuan1_cloze_hint.json > report.json
 ```
 
-
-
 ## [Grammatical Error Correction]
+
 Correct errors in a text
 **CLI Example**
 This is an example using the dataset from `DataLab`
+
 ```shell
 explainaboard --task grammatical-error-correction --dataset gaokao2018_np1 --sub-dataset writing-grammar --metrics SeqCorrectScore --system-outputs ./integration_tests/artifacts/gaokao/rst_2018_quanguojuan1_gec.json > report.json
 ```
@@ -315,9 +332,11 @@ dataset `json` file, as is done in `sst2-tabclass-dataset.json` below.
 **CLI Examples**
 
 The below example loads a dataset from an existing file:
+
 ```shell
 explainaboard --task tabular-classification --custom-dataset-paths ./data/system_outputs/sst2_tabclass/sst2-tabclass-dataset.json --system-outputs ./data/system_outputs/sst2/sst2-lstm-output.txt
 ```
+
 ## Tabular Regression
 
 Regression over tabular data is basically the same as tabular classification above, but
@@ -326,38 +345,36 @@ the predicted outputs are continuous numbers instead of classes.
 **CLI Examples**
 
 The below example loads a dataset from an existing file:
+
 ```shell
 explainaboard --task tabular-regression --custom-dataset-paths ./data/system_outputs/sst2_tabreg/sst2-tabclass-dataset.json --system-outputs ./data/system_outputs/sst2_tabreg/sst2-tabreg-lstm-output.txt
 ```
 
-
 ## [Argument Pair Extraction](argument_pair_extraction.md)
+
 This task aim to detect the argument pairs from each passage pair of review and rebuttal.
 
 **CLI Examples**
 
-The below example loads the [`ape`](https://github.com/ExpressAI/DataLab/blob/main/datasets/ape/ape.py) dataset from DataLab: 
+The below example loads the [`ape`](https://github.com/ExpressAI/DataLab/blob/main/datasets/ape/ape.py) dataset from DataLab:
+
 ```shell
 explainaboard --task argument-pair-extraction --dataset ape --system-outputs ./data/system_outputs/ape/ape_predictions.txt
 ```
 
-
-
- 
 ## [Meta Evaluation NLG]
+
 Evaluating the reliability of automated metrics for general text generation tasks, such as text summarization.
 
 **CLI Examples**
 
-The below example loads the meval_summeval dataset from DataLab: 
+The below example loads the meval_summeval dataset from DataLab:
+
 ```shell
 explainaboard --task meta-evaluation-nlg --dataset meval_summeval --sub-dataset coherence --system-outputs ./data/system_outputs/summeval/sumeval_bart.json > report.json
 ```
- 
-
 
 ## [WMT Metrics Direct Assessment Meta-evaluation](task_meta_evaluation.md)
-
 
 Evaluating the reliability of automated metrics for [WMT Metrics shared tasks](https://wmt-metrics-task.github.io/)
  using [direct assessment](https://www.statmt.org/wmt16/slides/wmt16-news-da.pdf) (DA).
@@ -365,6 +382,7 @@ Evaluating the reliability of automated metrics for [WMT Metrics shared tasks](h
 **CLI Example**
 
 This is an example with a custom dataset.
+
 ```shell
 explainaboard \
     --task meta-evaluation-wmt-da \
@@ -376,8 +394,7 @@ explainaboard \
     --target-language en
 ```
 
-
-This is an example with a dataset supported by DataLab, for example 
+This is an example with a dataset supported by DataLab, for example
 [wmt20_metrics_with_score](https://github.com/ExpressAI/DataLab/blob/main/datasets/wmt20_metrics_with_score/wmt20_metrics_with_score.py).
 
 ```shell
@@ -390,5 +407,3 @@ explainaboard \
     --source-language en \
     --target-language en
 ```
-
- 

--- a/docs/concepts_about_system_analysis.md
+++ b/docs/concepts_about_system_analysis.md
@@ -1,60 +1,67 @@
 # Concepts about System Analysis
+
 In these docs, we will explain some important concepts that
 you need to know before performing system analyses using Explainaboard.
 
 ## What are a "dataset" and a "system output"?
+
 To perform an analysis of your results, usually, two types of files should be prepared: "dataset"
-and "system output" 
+and "system output"
 
 ### `Dataset`
-A "dataset" usually consists of test inputs together with true outputs (e.g. gold-standard labels for classification tasks 
+
+A "dataset" usually consists of test inputs together with true outputs (e.g. gold-standard labels for classification tasks
 or reference outputs for text generation tasks).
 For example, in text classification, a `dataset` organized in tsv format may look like this:
+
 ```text
 I love this movie   positive
 The movie is too long   negative
 ...
-``` 
+```
 
 ### `System output`
+
 `System output` is frequently composed of predicted labels (or hypotheses, e.g., system-generated text),
 but sometimes `system output` will also contain test samples, such as `CoNLL` format in sequence labeling tasks.
 For example, in text classification, the `system output` could be organized in a text format:
+
 ```text
 positive
 negative
 ...
 ```
 
-
-
 ## "Datalab datasets" and "custom datasets"
+
 ExplainaBoard currently supports two sources for datasets: one is through [Datalab](https://aclanthology.org/2022.acl-demo.18.pdf) (Xiao et al 2022) and the
 other is custom.
+
 * if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
 we recommend that you load it through DataLab. This is for several reasons:
- (1) you don't have to prepare the data yourself, 
- (2) you can be sure that your accuracy numbers will be comparable with those calculated 
+ (1) you don't have to prepare the data yourself,
+ (2) you can be sure that your accuracy numbers will be comparable with those calculated
  by other people using ExplainaBoard, and
  (3) DataLab datasets support analysis with features calculated over the training set,
   which can be informative.
 
 For example, the following command can be used to perform system analysis on `sst2` dataset (supported by datalab)
+
 ```shell script
 explainaboard --task text-classification --dataset sst2 --system-outputs ./data/system_outputs/sst2/sst2-lstm-output.txt
 ```
+
 If the dataset hasn't been supported by datalab, we then need to prepare the dataset in a format supported by ExplainaBoard
  (this varies from task-to-task, see the task-specific documentation) and specify a file path:
+
 ```shell script
 explainaboard --task text-classification --custom-dataset-paths ./data/system_outputs/sst2/sst2-dataset.tsv --system-outputs ./data/system_outputs/sst2/sst2-lstm-output.txt
 ```
 
-* if your datasets haven't been supported by datalab but you want them supported, you can follow this 
+* if your datasets haven't been supported by datalab but you want them supported, you can follow this
 [doc](https://github.com/ExpressAI/DataLab/blob/main/docs/SDK/add_new_datasets_into_sdk.md) to add them.
 
-
-
-
 ## How different formats (e.g. json, tsv, etc.) are supported
+
 In ExplainaBoard, users are allowed to prepare custom datasets with different formats, such as
 `json`, `tsv` etc. We will detail this in each task's description.

--- a/docs/final_check_for_contribution.md
+++ b/docs/final_check_for_contribution.md
@@ -1,20 +1,22 @@
 # Final Check when You're Contributing as an SDK Developer
 
-
 Hi, first, thanks for your brilliant contribution to ExplainaBoard SDK :smiley: !
 
 This doc provides some friendly reminders for ExplainaBoard developers so that all relevant scripts and docs
 can be kept up-to-date whenever new functionalities have been implemented in ExplainaBoard.
 
+- #### When you add a new task
 
+  - please register your task in the script [`tasks.py`](https://github.com/neulab/ExplainaBoard/blob/main/explainaboard/tasks.py)
+  - please add unit tests for your task in the folder [`tests`](https://github.com/neulab/ExplainaBoard/tree/main/integration_tests)
+  - please update [`cli_interface.md'](https://github.com/neulab/ExplainaBoard/blob/main/docs/cli_interface.md) to add the cli information of your task
 
-- #### When you add a new task:
-    - please register your task in the script [`tasks.py`](https://github.com/neulab/ExplainaBoard/blob/main/explainaboard/tasks.py)
-    - please add unit tests for your task in the folder [`tests`](https://github.com/neulab/ExplainaBoard/tree/main/integration_tests)
-    - please update [`cli_interface.md'](https://github.com/neulab/ExplainaBoard/blob/main/docs/cli_interface.md) to add the cli information of your task
-- #### When you add a new metric or re-naming evaluation metrics,
-    - please add a unittest in [`test_metric.py`](https://github.com/neulab/ExplainaBoard/blob/main/integration_tests/test_metric.py)
-    - please update the metric information in the relevant [processors](https://github.com/neulab/ExplainaBoard/blob/main/explainaboard/processors)
-- #### When you add a new supported format,
-    - please add a unittest in the folder [`tests`](https://github.com/neulab/ExplainaBoard/tree/main/integration_tests)
-    - please update the loader for appropriate tasks in [loaders](https://github.com/neulab/ExplainaBoard/blob/main/explainaboard/loaders)
+- #### When you add a new metric or re-naming evaluation metrics
+
+  - please add a unittest in [`test_metric.py`](https://github.com/neulab/ExplainaBoard/blob/main/integration_tests/test_metric.py)
+  - please update the metric information in the relevant [processors](https://github.com/neulab/ExplainaBoard/blob/main/explainaboard/processors)
+
+- #### When you add a new supported format
+
+  - please add a unittest in the folder [`tests`](https://github.com/neulab/ExplainaBoard/tree/main/integration_tests)
+  - please update the loader for appropriate tasks in [loaders](https://github.com/neulab/ExplainaBoard/blob/main/explainaboard/loaders)

--- a/docs/get_evaluation_results_programatically.md
+++ b/docs/get_evaluation_results_programatically.md
@@ -1,19 +1,14 @@
 # How to Evaluate your Models Programmatically?
 
+This doc details
 
-This doc details 
 * how to evaluate your systems using ExplainaBoard programmatically
-* how to collect different results 
-
-
-
-
+* how to collect different results
 
 ## Evaluation
 
 Take the `kg-link-tail-prediction` task, for example, by running the following code,
 all analysis information will be stored in `sys_info.`
-
 
 ```python
 from explainaboard import TaskType, get_loader_class, get_processor_class
@@ -28,21 +23,21 @@ processor = get_processor_class(TaskType.kg_link_tail_prediction)()
 sys_info = processor.process(metadata={}, sys_output=data.samples)
 ```
 
-
 ## Manipulate Analysis Results
+
 The above code conducts the evaluation and puts everything in `sys_info.` In what follows,
 we will see how different types of information from `sys_info` are collected.
 
-
 #### Save analysis report locally
+
 ```python
 sys_info.print_as_json(file=open("./report.json", 'w'))
 ```
 
 Here is an [example](https://github.com/neulab/ExplainaBoard/blob/86d96b83d5ebf60adbdbdaa3a00883546fa05fde/data/reports/report_kg.json).
 
-
 #### Get overall results of different metrics
+
 ```python
 for overall_level in sys_info.results.overall:
     for metric_stat in overall_level:

--- a/docs/multilingual_multitask_evaluation.md
+++ b/docs/multilingual_multitask_evaluation.md
@@ -2,9 +2,8 @@
 
 ExplainaBoard currently supports multilingual/multitask evaluation.
 
-
-
 ## Data Preparation
+
 To achieve multilingual/multitask evaluation, the system outputs files must been organized into JSON
 format with following skeleton:
 
@@ -23,82 +22,82 @@ format with following skeleton:
 ]
 }
 ```
+
 where `...` will be instantiated task-dependently. Specifically,
+
 * [Example](../data/system_outputs/multilingual/json/mlpp/marc/) for text classification
 * [Example](../data/system_outputs/multilingual/json/mlpp/xnli/) for sentence pair classification
 * [Example](../data/system_outputs/multilingual/json/mlpp/xquad/) for extractive question answering
 
 Once the system outputs are ready, evaluation can be conducted through following steps.
 
-
-
 ## 1. Generate Analysis Reports for System Output Collections
-
-
-
 
 ```
 explainaboard --system-outputs ./data/system_outputs/multilingual/json/mt5base/xnli/*
 ```
 
-
 then all system outputs in the folder `./data/system_outputs/multilingual/json/mt5base/xnli/`
-- `test-de_7213.json` (system output on `de` language)
-- `test-en_7676.json` (system output on `en` language)
-- `test-es_7377.json` (system output on `es` language) 
-- `test-zh_7117.json` (system output on `zh` language) 
+
+* `test-de_7213.json` (system output on `de` language)
+* `test-en_7676.json` (system output on `en` language)
+* `test-es_7377.json` (system output on `es` language)
+* `test-zh_7117.json` (system output on `zh` language)
 
  will be processed automatically, and two types of files will be generated:
- 
- #### (1) analysis reports
-  * include both overall results and fine-grained analysis of a system
-  * `json` format 
-  * in the folder `output/reports`
- #### (2) historgram figures
-   * each figure could be regarded as a visualization of corresponding analysis report, that provides fine-grained evaluation
-   results for a system along certain feature (e.g., sentence length)
-  * `png` format (would be useful for paper writing)
-  * in the folder `output/figures`
 
+#### (1) analysis reports
+
+* include both overall results and fine-grained analysis of a system
+* `json` format
+* in the folder `output/reports`
+
+#### (2) historgram figures
+
+* each figure could be regarded as a visualization of corresponding analysis report, that provides fine-grained evaluation
+   results for a system along certain feature (e.g., sentence length)
+* `png` format (would be useful for paper writing)
+* in the folder `output/figures`
 
 ## 2. More Datasets (tasks), More Systems
 
 We can repeat the above process, using ExplainaBoard SDK to performan analysis for different tasks (datasets) from different languages.
-For example, 
+For example,
 
 * Differant languages on `marc` dataset (text classification task) using `mt5base (a.k.a CL-mt5base)` system
+
 ```shell
 explainaboard --system-outputs ./data/system_outputs/multilingual/json/mt5base/marc/*
 ```
 
 * Differant languages on `xquad` dataset (text classification task) using `mt5base` system
+
 ```shell
 explainaboard --system-outputs ./data/system_outputs/multilingual/json/mt5base/xquad/*
 ```
 
 * Differant languages on `xnli` dataset (natural language inference task) using `mlpp (a.k.a CL-mlpp15out1sum)` system
+
 ```shell
 explainaboard --system-outputs ./data/system_outputs/multilingual/json/mlpp/xnli/*
 ```
 
 * Differant languages on `marc` dataset (text classification task) using `mlpp` system
+
 ```shell
 explainaboard --system-outputs ./data/system_outputs/multilingual/json/mlpp/marc/*
 ```
 
-
 * Differant languages on `xquad` dataset (extractive question answwering) using `mlpp` system
+
 ```shell
 explainaboard --system-outputs ./data/system_outputs/multilingual/json/mlpp/xquad/*
 ```
 
-
-
-
-
-##  Meta Analysis over Generated Reports
+## Meta Analysis over Generated Reports
 
 After the above two steps, for all system outputs from
+
 * two systems: `mt5base`, `mlpp`
 * three tasks (datasets): `xnli`, `marc`, `xquad`
 * multiple languages (e.g., `de`, `en`, `es`, `zh`)
@@ -107,12 +106,12 @@ After the above two steps, for all system outputs from
 
 ExplainaBoard SDK (CLI) provides some interfaces to achieve this goal, for example
 
-
 ### Print Overall Results of different tasks, models, languages
 
 ```shell
 explainaboard --reports ./output/reports/*
 ```
+
 then you will get:
 
 ```
@@ -149,13 +148,12 @@ F1ScoreQA:      0.812   0.782   0.816
 
 ### Filter Results based on Customized "Query"
 
-ExplainaBoard also provides interface that users could filter all results with their specified 
+ExplainaBoard also provides interface that users could filter all results with their specified
 conditions. For example, if we only care about results on  `xnli` and `marc` datasets
 
 ```
 explainaboard --reports ./output/reports/* --datasets xnli marc
 ```
-
 
 Then, following results will be obtained:
 
@@ -181,15 +179,15 @@ Language:       de      en      es      fr      ja      zh
 Accuracy:       0.933   0.920   0.934   0.933   0.914   0.868
 ```  
 
-
 ### Aggregated Results based on Customized "Query"
-ExplainaBoard SDK allows users to aggregate results along different dimension. For example, if we aim to
-know the average performance ove all languages for each dataset, 
 
+ExplainaBoard SDK allows users to aggregate results along different dimension. For example, if we aim to
+know the average performance ove all languages for each dataset,
 
 ```
 explainaboard --reports ./output/reports/* --languages-aggregation average
 ```
+
 Then following results will be printed:
 
 ```
@@ -224,8 +222,6 @@ Language:       all_languages
 F1ScoreQA:      0.803
 ```
 
-
-
 ### System Pair Analysis of Two Groups of Results
 
 Using ExplainaBoard SDK, users can easily get the performance gap (system1 minus system2) over different
@@ -250,6 +246,3 @@ Model: CL-mlpp15out1sum V.S CL-mt5base, Dataset: xnli
 Language:       es      en      zh
 Accuracy:       0.030   0.020   0.019
 ```
- 
- 
- 

--- a/docs/programmatic_interface.md
+++ b/docs/programmatic_interface.md
@@ -1,7 +1,7 @@
 # Programmatic Interface
 
 Below is some example code that demonstrates how you can access ExplainaBoard programmatically.
-You can see more about the supported tasks and data formats in 
+You can see more about the supported tasks and data formats in
 
 You can process an existing dataset, such as `sst2`:
 

--- a/docs/task_argument_pair_extraction.md
+++ b/docs/task_argument_pair_extraction.md
@@ -9,13 +9,11 @@ can be analyzed in a similar way.
 
 ## Data Preparation
 
- 
-
 ### Format of `Dataset` File
- 
 
 * (1) `datalab`: if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
     you fortunately don't need to prepare the dataset. For example, you can examine the specific format organized in datalab by following commands:
+
     ```python
     from datalabs import load_dataset
     dataset = load_dataset("ape")
@@ -28,30 +26,27 @@ can be analyzed in a similar way.
 In order to perform analysis of your results, they should be in the following conll format:
 
 ```
-O	O
-O	O
-O	O
-O	O
-O	O
-O	O
-O	O
-O	O
-B-1	B-1
-I-1	I-1
-B-2	I-1
-I-2	I-1
-I-2	I-1
-I-2	I-1
-I-2	I-1
-I-2	I-1
+O O
+O O
+O O
+O O
+O O
+O O
+O O
+O O
+B-1 B-1
+I-1 I-1
+B-2 I-1
+I-2 I-1
+I-2 I-1
+I-2 I-1
+I-2 I-1
+I-2 I-1
 ```
+
 where the first column represents true tag, the second column represents predicted tag.
 
-
-
 An example system output file is here: [ape_predictions.txt](../../data/system_outputs/ape/ape_predictions.txt)
-
-  
 
 ## Performing Basic Analysis
 
@@ -60,12 +55,12 @@ In order to perform your basic analysis, we can run the following command:
 ```shell
 explainaboard --task argument-pair-extraction --dataset ape --system-outputs ./data/system_outputs/ape/ape_predictions.txt
 ```
+
 where
+
 * `--task`: denotes the task name, you can find all supported task names [here](https://github.com/neulab/ExplainaBoard/blob/main/docs/supported_tasks.md)
-* `--system-outputs`: denote the path of system outputs. Multiple one should be 
+* `--system-outputs`: denote the path of system outputs. Multiple one should be
   separated by space, for example, system1 system2
 * `--dataset`: denotes the dataset name
 * `report.json`: the generated analysis file with json format. You can find the file [here](https://github.com/ExpressAI/ExplainaBoard/blob/main/data/reports/report.json). Tips: use a json viewer
                   like [this one](http://jsonviewer.stack.hu/) for better interpretation.
-
-

--- a/docs/task_aspect_based_sentiment_classification.md
+++ b/docs/task_aspect_based_sentiment_classification.md
@@ -3,32 +3,29 @@
 Before diving into the detail of this doc, you're strongly recommended to know [some
 important concepts about system analyses](concepts_about_system_analysis.md).
 
-
 In this file we describe how to analyze aspect-based sentiment classification models.
 We will give an example using the `aspect-based-sentiment-classification` [laptop](https://github.com/neulab/ExplainaBoard/blob/main/data/system_outputs/absa/test-aspect.tsv) dataset, but other datasets
 can be analyzed in a similar way.
 
 ## Data Preparation
 
- 
-
 ### Format of `Dataset` File
 
-
-
 * (1) `datalab`: if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
-    you fortunately don't need to prepare the dataset. 
+    you fortunately don't need to prepare the dataset.
 
 * (2) `tsv` (without column names at the first row), see one [example](https://github.com/neulab/ExplainaBoard/blob/main/data/system_outputs/absa/absa-dataset.tsv)
+
 ```python
-Boot time	 Boot time  is super fast, around anywhere from 35 seconds to 1 minute.	positive
-Windows 8	Did not enjoy the new  Windows 8  and  touchscreen functions .	negative
+Boot time  Boot time  is super fast, around anywhere from 35 seconds to 1 minute. positive
+Windows 8 Did not enjoy the new  Windows 8  and  touchscreen functions . negative
 ...
 ```
+
 where the first 1st, 2nd, 3rd column represent aspect text, sentence and true label respectively.
 
-
 * (3) `json` (basically, it's a list of dictionaries with three keys: `aspect`, `text` and `true_label`)
+
 ```json
 [
   {"aspect":"Boot time", "text": "Boot time  is super fast, around anywhere from 35 seconds to 1 minute.", "true_label": "positive"},
@@ -36,27 +33,25 @@ where the first 1st, 2nd, 3rd column represent aspect text, sentence and true la
 ]
 ```
 
-
-
 ### Format of `System Output` File
-In this task, your system outputs should be as follows:
 
+In this task, your system outputs should be as follows:
 
 ```
 predicted_label
 ```
 
-Let's say we have several files such as 
-* [absa-example-output.tsv](https://github.com/neulab/ExplainaBoard/blob/main/data/system_outputs/absa/absa-example-output.tsv) 
- 
+Let's say we have several files such as
+
+* [absa-example-output.tsv](https://github.com/neulab/ExplainaBoard/blob/main/data/system_outputs/absa/absa-example-output.tsv)
 
 etc. from different systems.
-
 
 ## Performing Basic Analysis
 
 If your dataset exists in DataLab you can read it directly from there. However, here
 we will give an example of using a custom dataset, which takes this form:
+
 ```
 aspect \t sentence \t true_label 
 ```
@@ -66,10 +61,11 @@ In order to perform your basic analysis, we can run the following command:
 ```shell
 explainaboard --task aspect-based-sentiment-classification --custom-dataset-paths ./data/system_outputs/absa/absa-dataset.txt --system-outputs ./data/system_outputs/absa/absa-example-output.tsv > report.json
 ```
+
 where
+
 * `--task`: denotes the task name, you can find all supported task names [here](https://github.com/neulab/ExplainaBoard/blob/main/docs/supported_tasks.md)
-* `--system-outputs`: denote the path of system outputs. Multiple one should be 
+* `--system-outputs`: denote the path of system outputs. Multiple one should be
   separated by space, for example, system1 system2
 * `report.json`: the generated analysis file with json format. You can find the file [here](https://github.com/neulab/ExplainaBoard/blob/main/data/reports/report_absa.json). Tips: use a json viewer
                   like [this one](http://jsonviewer.stack.hu/) for better interpretation.
-

--- a/docs/task_conditional_generation.md
+++ b/docs/task_conditional_generation.md
@@ -3,7 +3,6 @@
 Before diving into the detail of this doc, you're strongly recommended to know [some
 important concepts about system analyses](concepts_about_system_analysis.md).
 
-
 Conditional text generation is a class of tasks where you generate text based on some conditioning context.
 This can include a wide variety of tasks, such as:
 
@@ -14,24 +13,24 @@ This can include a wide variety of tasks, such as:
 * **Code Generation:** generates a program *y* in a programming language such as Python given an input command *x* in natural language.
   An example dataset may be the [CoNaLa](https://conala-corpus.github.io/) English to Python generation dataset.
 
-
 ## Data Preparation
 
- 
 ### Format of `Dataset` File
 
-
 * (1) `datalab`: if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
-    you fortunately don't need to prepare the dataset. 
+    you fortunately don't need to prepare the dataset.
 
 * (2) `tsv` (without column names at the first row), see one [example](https://github.com/neulab/ExplainaBoard/blob/main/data/system_outputs/cnndm/cnndm_mini-dataset.tsv)
+
 ```python
 This is a good movie    这是一部好电影
 ...
 ```
+
 where the first column represents source text and the 2nd column denotes gold reference.
 
 * (3) `json` (basically, it's a list of dictionaries with two keys: `source` and `reference`)
+
 ```json
 [
   {"source": "This is a good movie", "reference": "这是一部好电影"},
@@ -39,26 +38,26 @@ where the first column represents source text and the 2nd column denotes gold re
 ]
 ```
 
-
-
-
 ### Format of `System Output` File
-In this task, your system outputs should be as follows:
 
+In this task, your system outputs should be as follows:
 
 ```
 predicted_output_text
 ```
 
 Here is an example system output file for summarization on a subset of the CNN/Daily Mail articles:
-* [cnndm_mini-bart-output.txt](https://github.com/neulab/ExplainaBoard/blob/main/data/system_outputs/cnndm/cnndm_mini-bart-output.txt) 
+
+* [cnndm_mini-bart-output.txt](https://github.com/neulab/ExplainaBoard/blob/main/data/system_outputs/cnndm/cnndm_mini-bart-output.txt)
 
 And here are two examples for machine translation from Slovak to English, an NMT and phrase-based MT system:
-* [ted_multi_slk_eng-nmt-output.txt](https://github.com/neulab/ExplainaBoard/blob/main/data/system_outputs/ted_multi/ted_multi_slk_eng-nmt-output.txt) 
-* [ted_multi_slk_eng-pbmt-output.txt](https://github.com/neulab/ExplainaBoard/blob/main/data/system_outputs/ted_multi/ted_multi_slk_eng-pbmt-output.txt) 
+
+* [ted_multi_slk_eng-nmt-output.txt](https://github.com/neulab/ExplainaBoard/blob/main/data/system_outputs/ted_multi/ted_multi_slk_eng-nmt-output.txt)
+* [ted_multi_slk_eng-pbmt-output.txt](https://github.com/neulab/ExplainaBoard/blob/main/data/system_outputs/ted_multi/ted_multi_slk_eng-pbmt-output.txt)
 
 Here is an example output for code generation. Note that this is in JSON format, and specifically specifies Python as the output language.
 This is important so the code is tokenized properly during evaluation.
+
 * [conala-baseline-output.json](https://github.com/neulab/ExplainaBoard/blob/main/data/system_outputs/conala/conala-baseline-output.json)
 
 ## Performing Basic Analysis on Summarization
@@ -67,11 +66,13 @@ The preferred method of doing analysis is to load the dataset from DataLab.
 You can load the`cnn_dailymail` dataset but because the test set is large we don't
 include it directly in the explainaboard repository, but you can get an example by
 downloading with wget:
+
 ```shell
 wget -P ./data/system_outputs/cnndm/ https://storage.googleapis.com/inspired-public-data/explainaboard/task_data/summarization/cnndm-bart-output.txt
 ```
 
 Then run the below command and it should work:
+
 ```shell
 explainaboard --task summarization --dataset cnn_dailymail --system-outputs ./data/system_outputs/cnndm/cnndm-bart-output.txt --metrics rouge2
 ```
@@ -86,11 +87,13 @@ explainaboard --task summarization --dataset cnn_dailymail --system-outputs ./da
   the JSON into a prettified and readable format.
 
 In addition, you can use a custom dataset, in which case the format should be
+
 ```
 source_sentence \t target_sentence
 ```
 
 In this case, we can directly use the miniature dataset distributed with the repo:
+
 ```shell
 explainaboard --task summarization --custom-dataset-paths ./data/system_outputs/cnndm/cnndm_mini-dataset.tsv --system-outputs ./data/system_outputs/cnndm/cnndm_mini-bart-output.txt --metrics rouge2 bart_score_en_ref
 ```
@@ -100,21 +103,25 @@ explainaboard --task summarization --custom-dataset-paths ./data/system_outputs/
 ### Machine Translation
 
 Try it out for translation as below. The examples use a custom dataset that is not included in DataLab at the moment.
+
 ```shell
 explainaboard --task machine-translation --custom-dataset-paths ./data/system_outputs/ted_multi/ted_multi_slk_eng-dataset.tsv --system-outputs ./data/system_outputs/ted_multi/ted_multi_slk_eng-nmt-output.txt --metrics bleu comet
 ```
+
 Note 1: The number of `--custom-dataset-paths` need to match the number of `system-outputs`
 
-Note 2: If you want to perform **pair-wise analysis** for two system outputs on the same reference, you can pass in the paths separated by space, for example, `--system-outputs system1 system2`. Please also pass in the same paths twice for `--custom-dataset-paths`, for example, `--custom-dataset-paths path1 path1`. 
+Note 2: If you want to perform **pair-wise analysis** for two system outputs on the same reference, you can pass in the paths separated by space, for example, `--system-outputs system1 system2`. Please also pass in the same paths twice for `--custom-dataset-paths`, for example, `--custom-dataset-paths path1 path1`.
 
 ### Code Generation
 
 You can try out evaluation of code generation on the CoNaLa dataset in DataLab as below:
+
 ```shell
 explainaboard --task machine-translation --dataset conala --output-file-type json --system-outputs ./data/system_outputs/conala/conala-baseline-output.json --report-json report.json
 ```
 
 You can also use a custom code generation dataset:
+
 ```shell
 explainaboard --task machine-translation --custom-dataset-file-type json --custom-dataset-paths data/system_outputs/conala/conala-dataset.json --output-file-type json --system-outputs ./data/system_outputs/conala/conala-baseline-output.json --report-json report.json
 ```

--- a/docs/task_extractive_qa.md
+++ b/docs/task_extractive_qa.md
@@ -3,22 +3,18 @@
 Before diving into the detail of this doc, you're strongly recommended to know [some
 important concepts about system analyses](concepts_about_system_analysis.md).
 
-
-
 In this file we describe how to analyze models trained on extractive QA datasets, for example
 [`squad`](http://datalab.nlpedia.ai/#/normal_dataset/6163a29beb9872f33252b01b/dataset_samples).
 
-
 ## Data Preparation
-
- 
 
 ### Format of `Dataset` File
 
 * (1) `datalab`: if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
-    you fortunately don't need to prepare the dataset. 
+    you fortunately don't need to prepare the dataset.
 
 * (2) `json` (basically, it's a list of dictionaries with three keys: `context`, `question`, and `answers`)
+
 ```json
 [
   {"context": "Super Bowl 50 was an American footb", "question": "Which NFL team represented the AFC at Super Bowl 50?", 'answers': {'text': ['Denver Broncos', 'Denver Broncos', 'Denver Broncos'], 'answer_start': [177, 177, 177]}},
@@ -26,9 +22,8 @@ In this file we describe how to analyze models trained on extractive QA datasets
 ]
 ```
 
-
-
 ### Format of `System Output` File
+
 In order to perform analysis of your results, they should be in the following
 JSON format:
 
@@ -39,18 +34,23 @@ JSON format:
         }
     }
 ```
-where 
+
+where
+
 * `predicted_answers`: denotes the predicted answers
 
 An example system output file is here:
-* [squad_mini-example-output.json](https://github.com/neulab/ExplainaBoard/blob/main/data/system_outputs/squad/squad_mini-example-output.json) 
+
+* [squad_mini-example-output.json](https://github.com/neulab/ExplainaBoard/blob/main/data/system_outputs/squad/squad_mini-example-output.json)
 
 ## Performing Basic Analysis
 
 The below example loads the `squad` dataset from DataLab. There is an [open issue](https://github.com/neulab/ExplainaBoard/issues/239) that prevents the specification of a dataset split, so this will not work at the moment. But we are working on it.
+
 ```shell
 explainaboard --task qa-extractive --dataset squad --system-outputs MY_FILE > report.json
 ```
+
 * `--task`: denotes the task name.
 * `--system-outputs`: denote the path of system outputs. Multiple one should be
   separated by space, for example, system1 system2
@@ -59,11 +59,13 @@ explainaboard --task qa-extractive --dataset squad --system-outputs MY_FILE > re
   like [this one](http://jsonviewer.stack.hu/) for better interpretation.
 
 You can use a custom dataset directly:
+
 ```shell
 explainaboard --task qa-extractive --custom-dataset-paths ./data/system_outputs/squad/squad_mini-dataset.json --system-outputs ./data/system_outputs/squad/squad_mini-example-output.json > report.json
 ```
 
 The dataset can be in the following format:
+
 ```json
 {
   "id": "4",
@@ -82,6 +84,7 @@ The dataset can be in the following format:
 ```
 
 If there are multiple true answers, the above format cam be modified to:
+
 ```json
 {
         "id": "4",

--- a/docs/task_grammatical_error_correction.md
+++ b/docs/task_grammatical_error_correction.md
@@ -3,31 +3,26 @@
 Before diving into the detail of this doc, you're strongly recommended to know [some
 important concepts about system analyses](concepts_about_system_analysis.md).
 
-
 Grammatical error correction is the task of correcting different kinds of errors in text, such as spelling errors. If you're interested in how datasets for this task look like, you can
 perform the following command after installing [`DataLab`](https://github.com/ExpressAI/DataLab#installation)
+
 ```python
 from datalabs import load_dataset
 dataset = load_dataset("gaokao2018_np1", "writing_grammar")
 print(dataset['test'][0])
 ```
- 
-In what follows, we will describe how to analyze grammatical error correction systems. 
 
-
-
+In what follows, we will describe how to analyze grammatical error correction systems.
 
 ## Data Preparation
 
-
 ### Format of `Dataset` File
 
- 
 * (1) `datalab`: if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
-    you fortunately don't need to prepare the dataset. 
-
+    you fortunately don't need to prepare the dataset.
 
 ### Format of `System Output` File
+
 In order to perform an analysis of your results, your system outputs should be arranged into following
 format:
 
@@ -47,26 +42,28 @@ format:
   }
 ]
 ```
-where 
+
+where
+
 * the `len(start_idx) == len(end_idx) == len(corrections)`, representing how many corrections your
 your systems think should be made
 * the combination of start_idx and end_idx (e.g., (`start_idx[i]`, `end_idx[i]`)) tells the where should be corrected in the original text.
 * the value of corrections (`corrections[i]`) tells what correction should be made
 
-
-
-
 ## Performing Basic Analysis
 
 Let's say we have one system output file:
-* [rst_2018_quanguojuan1_gec.json](https://github.com/neulab/ExplainaBoard/TBC) 
+
+* [rst_2018_quanguojuan1_gec.json](https://github.com/neulab/ExplainaBoard/TBC)
 
 The below example loads the `gaokao2018_np1` dataset (with the subdataset name of `writing-grammar`) from DataLab:
+
 ```shell
 explainaboard --task grammatical-error-correction --dataset gaokao2018_np1 --sub-dataset writing-grammar --metrics SeqCorrectScore --system-outputs ./integration_tests/artifacts/gaokao/rst_2018_quanguojuan1_gec.json > report.json
 ```
 
 where
+
 * `--task`: denotes the task name, you can find all supported task names [here](https://github.com/neulab/ExplainaBoard/blob/main/docs/cli_interface.md)
 * `--system-outputs`: denote the path of system outputs. Multiple one should be
   separated by space, for example, system1 system2

--- a/docs/task_kg_link_tail_prediction.md
+++ b/docs/task_kg_link_tail_prediction.md
@@ -1,6 +1,5 @@
 # Analyzing Knowledge Graph Link Tail Prediction Task
 
-
 Before diving into the detail of this doc, you're strongly recommended to know [some
 important concepts about system analyses](concepts_about_system_analysis.md).
 
@@ -8,42 +7,33 @@ In this file we describe how to analyze models trained to predict the tail entit
 [`fb15k-237`](https://www.microsoft.com/en-us/download/details.aspx?id=52312).
 
 ## Outline
+
 * Evaluation with Build-in Features
-    * Data Preparation
-    * Perform Analysis with CLI
-    * Visualization Locally
+  * Data Preparation
+  * Perform Analysis with CLI
+  * Visualization Locally
 * Evaluation with Customized Features
-    * Data Preparation
-    * Perform Analysis with CLI
-
-
-
-
+  * Data Preparation
+  * Perform Analysis with CLI
 
 ## Evaluation with Build-in Features
 
-
-
 ### Data Preparation
-
-
 
 #### Format of `Dataset` File
 
 * (1) `datalab`: if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
-    you fortunately don't need to prepare the dataset. 
+    you fortunately don't need to prepare the dataset.
 
 * (2) `json` (basically, it's a list of dictionaries with two keys: `gold_head`,
         `gold_predicate`, and `gold_tail`)
+
 ```json
 [
   {"gold_head": "abc", "gold_predicate": "dummy relation", "gold_tail":"cde"},
   ...
 ]
 ```
-
-
-
 
 #### Format of `System Output` File
 
@@ -83,17 +73,18 @@ In this task, your system outputs should be as follows:
     
 ]
 ```
+
 where
+
 * `gold_head`: true head entity
 * `gold_predicate`: true relation
 * `gold_tail`: true tail entity
 * `predict`: it suggest what type of information (e.g., `head`, `predicate`, `tail`) will be predicted
 * `predictions`: a list of predictions
 
-Let's say we have one system output file: 
-* [test-kg-prediction-no-user-defined.json](https://github.com/neulab/ExplainaBoard/blob/main/integration_tests/artifacts/test-kg-prediction-no-user-defined.json) 
+Let's say we have one system output file:
 
-
+* [test-kg-prediction-no-user-defined.json](https://github.com/neulab/ExplainaBoard/blob/main/integration_tests/artifacts/test-kg-prediction-no-user-defined.json)
 
 ### Perform Analysis with CLI
 
@@ -103,10 +94,12 @@ In order to perform your basic analysis, we can run the following command:
 explainaboard --task kg-link-tail-prediction --custom-dataset-paths ./data/system_outputs/fb15k-237/test-kg-prediction-no-user-defined.json --system-outputs ./data/system_outputs/fb15k-237/test-kg-prediction-no-user-defined.json > report.json
 
 ```
+
 where
-* `--task`: denotes the task name. 
+
+* `--task`: denotes the task name.
 * `--custom-dataset-paths`: the path of test samples
-* `--system-outputs`: denote the path of system outputs. Multiple one should be 
+* `--system-outputs`: denote the path of system outputs. Multiple one should be
   separated by space, for example, system1 system2
 * `--dataset`:optional, denotes the dataset name
 * `report.json`: the generated analysis file with json format. Tips: use a json viewer like [`this one`](http://jsonviewer.stack.hu/) for better interpretation.
@@ -117,34 +110,30 @@ you could also run (the advantage is that more bucketing features will be suppor
 ```shell
     explainaboard --task kg-link-tail-prediction --dataset fb15k_237 --sub-dataset origin --system-outputs test_distmult.json > log.res
 ```
-where 
+
+where
+
 * `test_distmult.json` represents the system output file, for example, you can download
 the above one [here](https://datalab-hub.s3.amazonaws.com/predictions/test_distmult.json
 )
 
-
-
 ### Bucketing Features
+
 * Toy feature `tail_entity_length`: the number of words in `true_tail`
 * More meaningful features to be added soon
 
-
 ### Visualization Locally
+
 Once the above command has been successfully conducted, histogram figures will be generated automatically in the folder
 `./output/figures/test-kg-prediction-no-user-defined-new/`, where each figure represent a fine-grained evaluation
 results along one features (e.g., relation type).
- 
-We have carefully designed and beautified these figures which 
+
+We have carefully designed and beautified these figures which
 could be directly applied for paper writing as needed.
 
 One example is shown below,
 
-
 <img src="./figures/entity_type_level_MeanReciprocalRank.png" width="600"/>
-
-
-
-
 
 ## Evaluation with Customized Features
 
@@ -207,9 +196,9 @@ An example system output is [provided](https://github.com/neulab/ExplainaBoard/b
 explainaboard --task kg-link-tail-prediction --custom-dataset-paths ./data/system_outputs/fb15k-237/data_mini.json --system-outputs ./data/system_outputs/fb15k-237/test-kg-prediction-no-user-defined-new.json > report.json
 ```
 
-
 ## Advanced Usage
-Intead of ExplainaBoard CLI, users could explore more functionality by using 
+
+Intead of ExplainaBoard CLI, users could explore more functionality by using
 pythonic interface provided by ExplainaBoard.
 
 ### Simple Example
@@ -231,8 +220,8 @@ sys_info = processor.process(metadata={}, sys_output=data.samples)
 sys_info.write_to_directory('./')
 ```
 
-
 ### Customized Bucket Order
+
 In some situation, users aim to specify the bucket order according to their needs.
 The following code gives an example.
 
@@ -265,6 +254,7 @@ sys_info = processor.process(metadata, data.samples)
 ```
 
 The options for the `"sort_by"` option are:
+
 1. `"key"` (default): sort by the bucket's lower boundary, alphabetically, low-to-high.
 2. `"performance_value"`: sort by bucket performance. Since each bucket has multiple metrics associated with it, use the `"sort_by_metric"` to choose which metric to sort on.
 3. `"n_bucket_samples"`, sort by the number of samples in each bucket.
@@ -272,10 +262,12 @@ The options for the `"sort_by"` option are:
 The `"sort_by_metric"` option is applicable when the `"sort_by"` option is set to `"performance_value"`. The options for the `"sort_by_metric"` option are `"Hits"`, `"MR"`, `"MRR"`, etc: sort by a specific metric name. These names refer to the `metric_name` keyword in your metric definitions (i.e. what you pass into the `"metric_configs"` key in the `metadata` dictionary).
 
 The `"sort_by_metric"` option is applicable when the `"sort_by"` option is set to `"performance_value"`. The options for the `"sort_ascending"` option are:
+
 1. `False` (default): sort high-to-low.
 2. `True`: sort low-to-high; useful for e.g. the `"MeanRank"` metric.
 
 ### Customized Hits K
+
 The value of K in `Hits` metric could also be specified by users when needed. Below is an example of how to use this configuration while performing bucket sorting by the custom metric:
 
 ```python
@@ -341,6 +333,7 @@ sys_info = processor.process(metadata, data.samples)
 
 The basic idea is that users can specify other system-related information (e.g., hyper-parameters)
 via adding a key-value into `metadata`
+
 ```python
 metadata = {
     "task_name": TaskType.text_classification.value,
@@ -348,9 +341,11 @@ metadata = {
     "system_details": system_details,
 }
 ```
+
 [Here](https://github.com/neulab/ExplainaBoard/blob/main/integration_tests/test_system_details.py) is a complete code.
 
 ### Meta/Quantitative Analysis
+
 A preliminary version of the rank-flipping quantitative analysis has been implemented. Example code:
 
 ```python
@@ -386,6 +381,7 @@ print(meta_analysis_results)
 ```
 
 Meta-analysis for bucket-level ranking tables:
+
 ```python
 from explainaboard import RankingMetaAnalysis, TaskType, get_custom_dataset_loader, get_processor_class
 

--- a/docs/task_knowledge_graph.md
+++ b/docs/task_knowledge_graph.md
@@ -1,19 +1,15 @@
 # Analysis Example: Knowledge Graph Task
 
-This doc walks through how knowledge graph-based tasks are evaluated interactively using ExplainaBoard 
+This doc walks through how knowledge graph-based tasks are evaluated interactively using ExplainaBoard
 web application.
 
-
 ## Prerequisite Docs
+
 * [How to make a submission?](how_to_make_a_submission.md)
 * [how to perform interactive evaluation?](how_to_make_interactive_evaluation.md)
 
-
-
 ## Example
-
 
 <img src="./fig/task_kg.png" width="400"/>
 
 where `user-defined-distmult.json` is the file that can be downloaded [here](https://github.com/PhaelIshall/KGExplainaBoard/tree/main/user-defined).
- 

--- a/docs/task_meta_evaluation.md
+++ b/docs/task_meta_evaluation.md
@@ -1,12 +1,13 @@
 # Analyzing Meta Evaluation for NLG Tasks
 
-
 ## Data Preparation
 
 The dataset file format is:
+
 ```
 SYSName \t SEGID \t TestSet \t src \t ref \t sys \t manualRaw \t manualZ
 ```
+
 * SYSName is the name of system being scored.
 * SEGID is the ID of segment being scored.
 * TestSet is the ID of the test set.
@@ -14,9 +15,10 @@ SYSName \t SEGID \t TestSet \t src \t ref \t sys \t manualRaw \t manualZ
 * ref is the reference sentence.
 * sys is the sentence to be scored.
 * manualRaw is the manual evaluated raw score.
-* manualZ is the manual evaluated Z score, standardized for each annotator. 
+* manualZ is the manual evaluated Z score, standardized for each annotator.
 
 We have an example dataset file:
+
 * [data.tsv](./data/system_outputs/nlg_meta_evaluation/wmt20-DA/cs-en/data.tsv)
 
 More dataset files can be found at [WMT-DA-20](https://drive.google.com/drive/u/0/folders/1JXpo0yxPLYlNgLbOfP1bzs9z6SOx76Wo).
@@ -30,12 +32,11 @@ systemScore2
 ```
 
 We have an example system outputs file:
+
 * [score.txt](./data/system_outputs/nlg_meta_evaluation/wmt20-DA/cs-en/score.txt)
 
-
-
-
 ## Performing Basic Analysis
+
 You can load the dataset from an existing file using the
 `--custom-dataset-paths` option
 
@@ -49,9 +50,8 @@ explainaboard \
     --source-language en \
     --target-language en
 ```
- 
 
-You can also use a dataset supported by DataLab, for example 
+You can also use a dataset supported by DataLab, for example
 [wmt20_metrics_with_score](https://github.com/ExpressAI/DataLab/blob/main/datasets/wmt20_metrics_with_score/wmt20_metrics_with_score.py).
 
 ```shell
@@ -64,7 +64,3 @@ explainaboard \
     --source-language en \
     --target-language en
 ```
-
-
-
-

--- a/docs/task_qa_multiple_choice.md
+++ b/docs/task_qa_multiple_choice.md
@@ -9,15 +9,14 @@ can be analyzed in a similar way.
 
 ## Data Preparation
 
- 
-
 ### Format of `Dataset` File
 
 * (1) `datalab`: if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
-    you fortunately don't need to prepare the dataset. 
+    you fortunately don't need to prepare the dataset.
 
 * (2) `json` (basically, it's a list of dictionaries with two keys: `context`
                , `options`, `question`, and `answers`)
+
 ```json
 [
   {'context': 'The girl had the flightiness of a sparrow', 'question': '', 'answers': {'text': 'The girl was very fickle.', 'option_index': 0}, 'options': ['The girl was very fickle.', 'The girl was very stable.']},
@@ -26,9 +25,7 @@ can be analyzed in a similar way.
 ]
 ```
 
-
 ### Format of `System Output` File
-
 
 In order to perform analysis of your results, they should be in the following json format:
 
@@ -53,24 +50,24 @@ In order to perform analysis of your results, they should be in the following js
   ...
 ]
 ```
+
 where
+
 * `context` represents the text providing context information
 * `question` represents the question, which could be null in some scenario
 * `options` is a list of string, denoting all potential options.
 * `answers` is a dictionary with two elements:
-    * `text`: the true answer text
-    * `option_index`: the index options for true answer
+  * `text`: the true answer text
+  * `option_index`: the index options for true answer
 * `predicted_answers` is a dictionary with two elements:
-    * `text`: the predicted answer text
-    * `option_index`: the index options for predicted answer
-    
+  * `text`: the predicted answer text
+  * `option_index`: the index options for predicted answer
 
-Let's say we have several files such as 
-* [gpt2.json](https://github.com/neulab/ExplainaBoard/blob/main/data/system_outputs/fig_qa/gpt2.json) 
+Let's say we have several files such as
 
+* [gpt2.json](https://github.com/neulab/ExplainaBoard/blob/main/data/system_outputs/fig_qa/gpt2.json)
 
 etc. from different systems.
-
 
 ## Performing Basic Analysis
 
@@ -79,16 +76,15 @@ In order to perform your basic analysis, we can run the following command:
 ```shell
     explainaboard --task qa-multiple-choice --system-outputs ./data/system_outputs/fig_qa/gpt2.json > report.json
 ```
+
 where
+
 * `--task`: denotes the task name, you can find all supported task names [here](https://github.com/neulab/ExplainaBoard/blob/main/docs/supported_tasks.md)
-* `--system-outputs`: denote the path of system outputs. Multiple one should be 
+* `--system-outputs`: denote the path of system outputs. Multiple one should be
   separated by space, for example, system1 system2
 * `--dataset`:optional, denotes the dataset name
 * `report.json`: the generated analysis file with json format. You can find the file [here](https://github.com/ExpressAI/ExplainaBoard/blob/main/data/reports/report.json). Tips: use a json viewer
                   like [this one](http://jsonviewer.stack.hu/) for better interpretation.
-
-
-
 
 Now let's look at the results to see what sort of interesting insights we can
 glean from them.
@@ -98,9 +94,12 @@ TODO: add insights
 ## Advanced Analysis Options
 
 One also can perform pair-wise analysis:
+
 ```shell
 explainaboard --task qa-multiple-choice --system-outputs model_1 model_2 > report.json
 ```
+
 where two system outputs are fed separated by space.
+
 * `report.json`: the generated analysis file with json format, whose schema is similar to the above one with single system evaluation except that
    all performance values are obtained using the sys1 subtract sys2.

--- a/docs/task_qa_open_domain.md
+++ b/docs/task_qa_open_domain.md
@@ -9,14 +9,13 @@ can be analyzed in a similar way.
 
 ## Data Preparation
 
- 
-
 ### Format of `Dataset` File
 
 * (1) `datalab`: if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
-    you fortunately don't need to prepare the dataset. 
+    you fortunately don't need to prepare the dataset.
 
 * (2) `json` (basically, it's a list of dictionaries with two keys: `question` and `answers`)
+
 ```json
 [
   {'question': 'who got the first nobel prize in physics', 'answers': ['Wilhelm Conrad Röntgen']},
@@ -24,8 +23,6 @@ can be analyzed in a similar way.
   ...
 ]
 ```
-
-
 
 ### Format of `System Output` File
 
@@ -36,17 +33,15 @@ william henry bragg
 may 18, 2018
 ...
 ```
+
 where each line represents one predicted answer.
 An example system output file is here: [test.dpr.nq.txt](https://github.com/neulab/ExplainaBoard/blob/add_customized_features_from_config/data/system_outputs/qa_open_domain/test.dpr.nq.txt)
 
- 
+Let's say we have several files such as
 
-Let's say we have several files such as 
-* [gpt2.json](https://github.com/neulab/ExplainaBoard/blob/main/data/system_outputs/fig_qa/gpt2.json) 
-
+* [gpt2.json](https://github.com/neulab/ExplainaBoard/blob/main/data/system_outputs/fig_qa/gpt2.json)
 
 etc. from different systems.
-
 
 ## Performing Basic Analysis
 
@@ -55,12 +50,12 @@ In order to perform your basic analysis, we can run the following command:
 ```shell
 explainaboard --task qa-open-domain --dataset natural_questions_comp_gen   --system-outputs ./data/system_outputs/qa_open_domain/test.dpr.nq.txt  > report.json
 ```
+
 where
+
 * `--task`: denotes the task name, you can find all supported task names [here](https://github.com/neulab/ExplainaBoard/blob/main/docs/supported_tasks.md)
-* `--system-outputs`: denote the path of system outputs. Multiple one should be 
+* `--system-outputs`: denote the path of system outputs. Multiple one should be
   separated by space, for example, system1 system2
 * `--dataset`:denotes the dataset name
 * `report.json`: the generated analysis file with json format. You can find the file [here](https://github.com/ExpressAI/ExplainaBoard/blob/main/data/reports/report.json). Tips: use a json viewer
                   like [this one](http://jsonviewer.stack.hu/) for better interpretation.
-
-

--- a/docs/task_qa_table_text_hybrid.md
+++ b/docs/task_qa_table_text_hybrid.md
@@ -3,20 +3,17 @@
 Before diving into the detail of this doc, you're strongly recommended to know [some
 important concepts about system analyses](concepts_about_system_analysis.md).
 
-
-
-In this file we describe how to analyze QA models trained on datasets 
+In this file we describe how to analyze QA models trained on datasets
 with a hybrid of tabular and textual context.
-
 
 ## Data Preparation
 
- 
 ### Format of `Dataset` File
+
 In this task, only the `datalab` format is supported so far:
 
 * (1) `datalab`: if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
-    you fortunately don't need to prepare the dataset. 
+    you fortunately don't need to prepare the dataset.
 
 ### Format of `System Output` File
 
@@ -30,17 +27,18 @@ In this task, your system outputs should be:
 ...
 ]
 ```
+
 where each line represents one predicted answer. Specifically,
+
 * `q_id` represents the question id
 * `answer` denotes the predicted answer
 * `scale` is the predicted scale.
 
-Check this [page](https://www.datafountain.cn/competitions/573/datasets) to know detailed 
+Check this [page](https://www.datafountain.cn/competitions/573/datasets) to know detailed
 definition of `scale`.
 
 An example system output file is here: [predictions_list.json](https://explainaboard.s3.amazonaws.com/system_outputs/qa_table_text_hybrid/predictions_list.json)
 
- 
 ## Performing Basic Analysis
 
 In order to perform your basic analysis, we can run the following command:
@@ -48,12 +46,12 @@ In order to perform your basic analysis, we can run the following command:
 ```shell
 explainaboard --task qa-tat --output-file-type json --dataset tat_qa --system-outputs predictions_list.json > report.json
 ```
+
 where
+
 * `--task`: denotes the task name, you can find all supported task names [here](https://github.com/neulab/ExplainaBoard/blob/main/docs/supported_tasks.md)
-* `--system-outputs`: denote the path of system outputs. Multiple one should be 
+* `--system-outputs`: denote the path of system outputs. Multiple one should be
   separated by space, for example, system1 system2
 * `--dataset`:denotes the dataset name
 * `report.json`: the generated analysis file with json format. You can find the file [here](https://github.com/ExpressAI/ExplainaBoard/blob/main/data/reports/report.json). Tips: use a json viewer
                   like [this one](http://jsonviewer.stack.hu/) for better interpretation.
-
-

--- a/docs/task_text_classification.md
+++ b/docs/task_text_classification.md
@@ -1,6 +1,5 @@
 # Analyzing Text Classification
 
-
 Before diving into the detail of this doc, you're strongly recommended to know [some
 important concepts about system analyses](concepts_about_system_analysis.md).
 
@@ -9,19 +8,22 @@ We will give an example using the `text-classification` [sst2](https://github.co
 can be analyzed in a similar way.
 
 ## Data Preparation
- 
+
 ### Format of `Dataset` File
 
 * (1) `datalab`: if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
-    you fortunately don't need to prepare the dataset. 
+    you fortunately don't need to prepare the dataset.
   
 * (2) `tsv` (without column names at the first row), see one [example](https://github.com/neulab/ExplainaBoard/blob/main/data/system_outputs/sst2/sst2-dataset.tsv)
+
 ```python
 I love this movie   positive
 The movie is too long   negative
 ...
 ```
+
 * (3) `json` (basically, it's a list of dictionaries with two keys: `text` and `true_label`)
+
 ```json
 [
   {"text": "I love this movie", "true_label": "positive"},
@@ -29,9 +31,6 @@ The movie is too long   negative
   ...
 ]
 ```
-
-
-
 
 ### Format of `System Output` File
 
@@ -41,21 +40,23 @@ In this task, your system outputs should be as follows:
 predicted_label
 ```
 
-Let's say we have several files such as 
-* [sst2-lstm.tsv](https://github.com/neulab/ExplainaBoard/blob/main/data/system_outputs/sst2/sst2-lstm-output.txt) 
+Let's say we have several files such as
+
+* [sst2-lstm.tsv](https://github.com/neulab/ExplainaBoard/blob/main/data/system_outputs/sst2/sst2-lstm-output.txt)
 * [sst2-cnn.tsv](https://github.com/neulab/ExplainaBoard/blob/main/data/system_outputs/sst2/sst2-cnn-output.txt)
 
 etc. from different systems.
 
-
 ## Performing Basic Analysis
 
 The below example loads the `sst2` dataset from DataLab:
+
 ```shell
 explainaboard --task text-classification --dataset sst2 --system-outputs ./data/system_outputs/sst2/sst2-lstm-output.txt
 ```
 
 where
+
 * `--task`: denotes the task name, you can find all supported task names [here](https://github.com/neulab/ExplainaBoard/blob/main/docs/cli_interface.md)
 * `--system-outputs`: denote the path of system outputs. Multiple one should be
   separated by space, for example, system1 system2
@@ -71,6 +72,7 @@ explainaboard --task text-classification --custom-dataset-paths ./data/system_ou
 ```
 
 in which case the file format of this file is TSV
+
 ```
 text \t true_label
 ```
@@ -78,10 +80,13 @@ text \t true_label
 ## Advanced Analysis Options
 
 One also can perform pair-wise analysis:
+
 ```shell
 explainaboard --task text-classification --dataset sst2 --system-outputs ./data/system_outputs/sst2/sst2-lstm-output.txt ./data/system_outputs/sst2/sst2-cnn-output.txt > report.json
 ```
+
 where two system outputs are fed separated by space.
-* `report.json`: the generated analysis file with json format, whose schema is similar 
+
+* `report.json`: the generated analysis file with json format, whose schema is similar
   to the above one with single system evaluation except that
   all performance values are obtained using the sys1 subtract sys2.

--- a/docs/task_text_pair_classification.md
+++ b/docs/task_text_pair_classification.md
@@ -3,10 +3,9 @@
 Before diving into the detail of this doc, you're strongly recommended to know [some
 important concepts about system analyses](concepts_about_system_analysis.md).
 
-
 In this file we describe how to analyze text pair classification models,
 such as natural language inference (NLI), paraphrase identification etc.
-We will give an example using the `nature-language-inference` 
+We will give an example using the `nature-language-inference`
 [SNLI](https://nlp.stanford.edu/projects/snli/)
 
 ## Data Preparation
@@ -14,15 +13,18 @@ We will give an example using the `nature-language-inference`
 ### Format of `Dataset` File
 
 * (1) `datalab`: if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
-    you fortunately don't need to prepare the dataset. 
+    you fortunately don't need to prepare the dataset.
 
 * (2) `tsv` (without column names at the first row), see one [example](https://github.com/neulab/ExplainaBoard/blob/main/data/system_outputs/snli/snli-dataset.tsv)
+
 ```python
 A man playing an electric guitar on stage.   A man playing banjo on the floor.  contradiction
 A man playing an electric guitar on stage.   A man is performing for cash.  neutral
 ...
 ```
+
 * (3) `json` (basically, it's a list of dictionaries with three keys: `text1`, `text2` and `true_label`)
+
 ```json
 [
   {"text1": "A man playing an electric guitar on stage.", "text2": "A man playing banjo on the floor.", "true_label": "contradiction"},
@@ -30,8 +32,6 @@ A man playing an electric guitar on stage.   A man is performing for cash.  neut
   ...
 ]
 ```
-
-
 
 ### Format of `System Output` File
 
@@ -41,19 +41,20 @@ In this task, your system outputs should be one predicted label per line:
 predicted_label
 ```
 
-Let's say we have one system output file from a RoBERTa model. 
-* [snli.bert](https://github.com/neulab/ExplainaBoard/blob/main/data/system_outputs/snli/snli-roberta-output.txt) 
+Let's say we have one system output file from a RoBERTa model.
 
-
+* [snli.bert](https://github.com/neulab/ExplainaBoard/blob/main/data/system_outputs/snli/snli-roberta-output.txt)
 
 ## Performing Basic Analysis
 
 The below example loads the `snli` dataset from DataLab:
+
 ```shell
 explainaboard --task text-pair-classification --dataset snli --system-outputs ./data/system_outputs/snli/snli-roberta-output.txt
 ```
 
 where
+
 * `--task`: denotes the task name, you can find all supported task names [here](https://github.com/neulab/ExplainaBoard/blob/main/docs/cli_interface.md)
 * `--system-outputs`: denote the path of system outputs. Multiple one should be
   separated by space, for example, system1 system2

--- a/docs/visualization.md
+++ b/docs/visualization.md
@@ -13,6 +13,7 @@ also some rudimentary visualization tools at your disposal.
 **Charts:** If you want to draw visualizations of the bucketed analysis results or
 confusion matrices offline, you can run the following command over one or more
 reports:
+
 ```shell
 python -m explainaboard.visualizers.draw_charts --reports report1.json report2.json
 ```

--- a/docs/web/how_to_make_a_submission.md
+++ b/docs/web/how_to_make_a_submission.md
@@ -1,36 +1,31 @@
 # How to make a submission through ExplainaBoard Web Platform
 
-
 ## Step 1: Sign in and login in
+
 You first need to register an ExplainaBoard account [here](https://explainaboard.inspiredco.ai/).
 (Notably: you don't need to have an account if you just aim to browse some public system results or leaderboard.)
 
-
-## Step 2: Choose the `Systems` bar and click the `New` button.
+## Step 2: Choose the `Systems` bar and click the `New` button
 
 (1) Choose `Systems` from the navigation menu
  <img src="./fig/system-bar.png" width="80"/>
- 
- 
+
 (2) Click the `New` button
 
 <img src="./fig/new-button.png" width="400"/>
-
 
 ## Step 3: Fill out the submission form
 
 <img src="./fig/submission-form.png" width="500"/>
 
 In this form, you need to fill out the following information
+
 * `System Name`: the name of your system (an intuitive and unique name is recommended, for example, `qa_bert_small`)
 * `Task`: select one task that ExplainaBoard supports now. (If your task is not supported yet, you can make an issue
 at [the ExplainaBoard SDK repo](https://github.com/neulab/ExplainaBoard) or contribute by [adding a new task](https://github.com/neulab/ExplainaBoard/blob/main/docs/add_new_tasks.md))
-* `Use custom dataset`: If your system predictions are run based on a dataset that is not supported by ExplainaBoard, 
+* `Use custom dataset`: If your system predictions are run based on a dataset that is not supported by ExplainaBoard,
 you need to choose `use custom dataset?` and upload the test set of your dataset. You can find examples of the required format for each task in our [command-line interface examples](https://github.com/neulab/ExplainaBoard/blob/main/docs/cli_interface.md). Otherwise, you just need to choose a dataset from the `Dataset` check box.
 * `Dataset`: Select a dataset that's supported by ExplainaBoard.
 * `Metrics`: Select evaluation metrics
 * `Make it private?`: If chosen, system outputs together with analysis report can only be observed privately. Otherwise, it will be open to the world.
 * `Source code link:` Optional
-
-
-

--- a/docs/web/how_to_make_interactive_evaluation.md
+++ b/docs/web/how_to_make_interactive_evaluation.md
@@ -1,15 +1,14 @@
 # How to Perform Interactive Evaluation using the ExplainaBoard Web Platform
 
-
 ExplainaBoard makes it possible to perform interactive evaluation from multiple perspectives:
 
+## Customized Bucket Number
 
+##### Background
 
-##  Customized Bucket Number
-##### Background:
 ExplainaBoard achieves interpretable evaluation by bucketing evaluation performance
 into different categories based on some pre-defined features.
-For example, according the the text sample's length, system performance could 
+For example, according the the text sample's length, system performance could
 be grouped into 4 buckets: [2,12], [13,18], [19,24], [25,52].
 
 If you are interested in more details, [Liu et al.2021](https://aclanthology.org/2021.acl-demo.34.pdf), [Fu et al.2020](http://aclanthology.lst.uni-saarland.de/2020.emnlp-main.489.pdf) are highly recommended.
@@ -18,20 +17,22 @@ When using ExplainaBoard Web, users can customize the number
 of buckets. For example:
 
 ##### bucket number: 4
+
 <img src="./fig/customized_bucket.png" width="300"/>
 
 The bucket number could be updated to 5 when
+
 * clicking `+` button
 * clicking `Update analysis`
 
 ##### bucket number: 5
+
 <img src="./fig/customized_bucket_2.png" width="300"/>
 
-
-
-
 ## Customized Bucket Interval
+
 The bucket interval could also been re-specified by:
+
 * adjusting the position of the circle in the blue line.
 * clicking the `Update analysis`
 
@@ -39,7 +40,6 @@ For example:
 
 `[2,12], [13,18], [19,24], [25,52]`  -> `[2,12], [12,18], [18,26], [26,52]`
 
-
 ##### bucket number: 5
-<img src="./fig/customized_bucket_3.png" width="300"/>
 
+<img src="./fig/customized_bucket_3.png" width="300"/>


### PR DESCRIPTION
Part of #536. This is the initial step to lint Markdown files in CI. This PR adds a Markdown linter tool, [markdownlint-cli2](https://github.com/DavidAnson/markdownlint-cli2) to pre-commit hook and CI to lint Markdown files. Also adds the configuration file `.markdownlint.yaml` which allows to change the behavior of the linter. Changes in Markdown files were automatically fixed by `pre-commit run markdownlint-cli2-fix --all-files`. The linter discovered more than 100 errors. Those errors are suppressed by turning the corresponding checks off in the config file in order to make CI green (this is a temporary solution to add the linter to CI without introducing a big bang change which fixes all of the issues in a single PR). I'll fix the remaining issues in follow-up PRs to turn the disabled checks on.