### PR TITLE
MetricResult.get_value_or_none

### DIFF
--- a/explainaboard/analysis/analyses.py
+++ b/explainaboard/analysis/analyses.py
@@ -291,8 +291,8 @@ class BucketAnalysis(Analysis):
                         confidence_alpha=confidence_alpha,
                     )
 
-                    value = unwrap(metric_result.get_value(Score, "score")).value
-                    ci = metric_result.get_value(ConfidenceInterval, "score_ci")
+                    value = metric_result.get_value(Score, "score").value
+                    ci = metric_result.get_value_or_none(ConfidenceInterval, "score_ci")
                     if ci is not None:
                         ci_low = ci.low
                         ci_high = ci.high

--- a/explainaboard/metrics/accuracy_test.py
+++ b/explainaboard/metrics/accuracy_test.py
@@ -13,7 +13,6 @@ from explainaboard.metrics.accuracy import (
     SeqCorrectCountConfig,
 )
 from explainaboard.metrics.metric import Score
-from explainaboard.utils.typing_utils import unwrap
 
 
 class AccuracyConfigTest(unittest.TestCase):
@@ -42,9 +41,7 @@ class AccuracyTest(unittest.TestCase):
         true = ['a', 'b', 'a', 'b', 'a', 'b']
         pred = ['a', 'b', 'a', 'b', 'b', 'a']
         result = metric.evaluate(true, pred, confidence_alpha=0.05)
-        self.assertAlmostEqual(
-            unwrap(result.get_value(Score, "score")).value, 2.0 / 3.0
-        )
+        self.assertAlmostEqual(result.get_value(Score, "score").value, 2.0 / 3.0)
 
 
 class CorrectCountConfigTest(unittest.TestCase):
@@ -76,7 +73,7 @@ class CorrectCountTest(unittest.TestCase):
         true = ['a', 'b', 'a', 'b', 'a', 'b']
         pred = ['a', 'b', 'a', 'b', 'b', 'a']
         result = metric.evaluate(true, pred, confidence_alpha=0.05)
-        self.assertAlmostEqual(unwrap(result.get_value(Score, "score")).value, 4)
+        self.assertAlmostEqual(result.get_value(Score, "score").value, 4)
 
 
 class SeqCorrectCountConfigTest(unittest.TestCase):
@@ -135,4 +132,4 @@ class SeqCorrectCountTest(unittest.TestCase):
             }
         ]
         result = metric.evaluate(true, pred)
-        self.assertAlmostEqual(unwrap(result.get_value(Score, "score")).value, 5)
+        self.assertAlmostEqual(result.get_value(Score, "score").value, 5)

--- a/explainaboard/metrics/f1_score_test.py
+++ b/explainaboard/metrics/f1_score_test.py
@@ -13,7 +13,6 @@ from explainaboard.metrics.f1_score import (
     SeqF1ScoreConfig,
 )
 from explainaboard.metrics.metric import Score
-from explainaboard.utils.typing_utils import unwrap
 
 
 class F1ScoreConfigTest(unittest.TestCase):
@@ -60,9 +59,7 @@ class F1ScoreTest(unittest.TestCase):
         pred = ['a', 'b', 'a', 'b', 'b', 'a', 'c', 'a']
         sklearn_f1 = f1_score(true, pred, average='micro')
         result = metric.evaluate(true, pred, confidence_alpha=0.05)
-        self.assertAlmostEqual(
-            unwrap(result.get_value(Score, "score")).value, sklearn_f1
-        )
+        self.assertAlmostEqual(result.get_value(Score, "score").value, sklearn_f1)
 
     def test_evaluate_macro(self) -> None:
         metric = F1ScoreConfig(average='macro').to_metric()
@@ -70,9 +67,7 @@ class F1ScoreTest(unittest.TestCase):
         pred = ['a', 'b', 'a', 'b', 'b', 'a', 'c', 'a']
         sklearn_f1 = f1_score(true, pred, average='macro')
         result = metric.evaluate(true, pred, confidence_alpha=None)
-        self.assertAlmostEqual(
-            unwrap(result.get_value(Score, "score")).value, sklearn_f1
-        )
+        self.assertAlmostEqual(result.get_value(Score, "score").value, sklearn_f1)
 
 
 class SeqF1ScoreConfigTest(unittest.TestCase):
@@ -128,9 +123,7 @@ class SeqF1ScoreTest(unittest.TestCase):
         ]
         metric = SeqF1ScoreConfig(average='micro', tag_schema='bio').to_metric()
         result = metric.evaluate(true, pred, confidence_alpha=None)
-        self.assertAlmostEqual(
-            unwrap(result.get_value(Score, "score")).value, 2.0 / 3.0
-        )
+        self.assertAlmostEqual(result.get_value(Score, "score").value, 2.0 / 3.0)
 
     def test_evaluate_macro(self) -> None:
         true = [
@@ -143,6 +136,4 @@ class SeqF1ScoreTest(unittest.TestCase):
         ]
         metric = SeqF1ScoreConfig(average='macro', tag_schema='bio').to_metric()
         result = metric.evaluate(true, pred, confidence_alpha=None)
-        self.assertAlmostEqual(
-            unwrap(result.get_value(Score, "score")).value, 3.0 / 4.0
-        )
+        self.assertAlmostEqual(result.get_value(Score, "score").value, 3.0 / 4.0)

--- a/explainaboard/metrics/metric.py
+++ b/explainaboard/metrics/metric.py
@@ -123,7 +123,28 @@ class MetricResult(Serializable):
         """
         self._values = values
 
-    def get_value(self, cls: type[MetricValueT], name: str) -> MetricValueT | None:
+    def get_value(self, cls: type[MetricValueT], name: str) -> MetricValueT:
+        """Obtains a value with specific type and name.
+
+        Args:
+            cls: Subtype of MetricValue that the resulting value has to be of.
+            name: Name of the value.
+
+        Raises:
+            ValueError: `name` not found, or the value is not an instance of `cls`.
+        """
+        value = self._values.get(name)
+        if value is None:
+            raise ValueError(f"MetricValue \"{name}\" not found.")
+        if not isinstance(value, cls):
+            raise ValueError(
+                f"MetricValue \"{name}\" is not a subclass of {cls.__name__}."
+            )
+        return value
+
+    def get_value_or_none(
+        self, cls: type[MetricValueT], name: str
+    ) -> MetricValueT | None:
         """Obtains a value with specific type and name.
 
         Args:
@@ -133,10 +154,10 @@ class MetricResult(Serializable):
         Returns:
             A MetricValue with `name` and `cls`, or None if such value does not exist.
         """
-        value = self._values.get(name)
-        if value is None:
+        try:
+            return self.get_value(cls, name)
+        except ValueError:
             return None
-        return value if isinstance(value, cls) else None
 
     def serialize(self) -> dict[str, SerializableData]:
         """See Serializable.serialize."""

--- a/explainaboard/metrics/metric_test.py
+++ b/explainaboard/metrics/metric_test.py
@@ -133,12 +133,35 @@ class MetricResultTest(unittest.TestCase):
         result = MetricResult({"bar": score, "baz": ci})
 
         # get_value() should return existing objects.
-        self.assertIsNone(result.get_value(Score, "foo"))
+        with self.assertRaisesRegex(ValueError, r"^MetricValue \"foo\" not found.$"):
+            result.get_value(Score, "foo")
         self.assertIs(result.get_value(Score, "bar"), score)
-        self.assertIsNone(result.get_value(Score, "baz"))
-        self.assertIsNone(result.get_value(ConfidenceInterval, "foo"))
-        self.assertIsNone(result.get_value(ConfidenceInterval, "bar"))
+        with self.assertRaisesRegex(
+            ValueError, r"^MetricValue \"baz\" is not a subclass of Score.$"
+        ):
+            result.get_value(Score, "baz")
+        with self.assertRaisesRegex(ValueError, r"^MetricValue \"foo\" not found.$"):
+            result.get_value(ConfidenceInterval, "foo")
+        with self.assertRaisesRegex(
+            ValueError,
+            r"^MetricValue \"bar\" is not a subclass of ConfidenceInterval.$",
+        ):
+            result.get_value(ConfidenceInterval, "bar")
         self.assertIs(result.get_value(ConfidenceInterval, "baz"), ci)
+
+    def test_get_value_or_none(self) -> None:
+        score = Score(1.0)
+        ci = ConfidenceInterval(1.0, 2.0, 0.5)
+
+        result = MetricResult({"bar": score, "baz": ci})
+
+        # get_value_or_none() should return existing objects.
+        self.assertIsNone(result.get_value_or_none(Score, "foo"))
+        self.assertIs(result.get_value_or_none(Score, "bar"), score)
+        self.assertIsNone(result.get_value_or_none(Score, "baz"))
+        self.assertIsNone(result.get_value_or_none(ConfidenceInterval, "foo"))
+        self.assertIsNone(result.get_value_or_none(ConfidenceInterval, "bar"))
+        self.assertIs(result.get_value_or_none(ConfidenceInterval, "baz"), ci)
 
 
 class MetricTest(unittest.TestCase):
@@ -316,15 +339,15 @@ class MetricTest(unittest.TestCase):
         metric = _DummyMetric(_DummyMetricConfig("test"))
         stats = SimpleMetricStats(np.array([1.0, 2.0, 3.0, 4.0, 5.0]))
         result = metric.evaluate_from_stats(stats, confidence_alpha=None)
-        self.assertEqual(unwrap(result.get_value(Score, "score")).value, 3.0)
-        self.assertIsNone(result.get_value(ConfidenceInterval, "score_ci"))
+        self.assertEqual(result.get_value(Score, "score").value, 3.0)
+        self.assertIsNone(result.get_value_or_none(ConfidenceInterval, "score_ci"))
 
     def test_evaluate_from_stats_tdist_with_ci(self) -> None:
         metric = _DummyMetric(_DummyMetricConfig("test"))
         stats = SimpleMetricStats(np.array([1.0, 2.0, 3.0, 4.0, 5.0]))
         result = metric.evaluate_from_stats(stats, confidence_alpha=0.05)
-        self.assertEqual(unwrap(result.get_value(Score, "score")).value, 3.0)
-        ci = unwrap(result.get_value(ConfidenceInterval, "score_ci"))
+        self.assertEqual(result.get_value(Score, "score").value, 3.0)
+        ci = result.get_value(ConfidenceInterval, "score_ci")
         self.assertAlmostEqual(ci.low, -0.9264863229551219)
         self.assertAlmostEqual(ci.high, 6.926486322955122)
 
@@ -332,22 +355,22 @@ class MetricTest(unittest.TestCase):
         metric = _DummyMetric(_DummyMetricConfig("test"))
         stats = SimpleMetricStats(np.array([3.0]))
         result = metric.evaluate_from_stats(stats, confidence_alpha=0.05)
-        self.assertEqual(unwrap(result.get_value(Score, "score")).value, 3.0)
-        self.assertIsNone(result.get_value(ConfidenceInterval, "score_ci"))
+        self.assertEqual(result.get_value(Score, "score").value, 3.0)
+        self.assertIsNone(result.get_value_or_none(ConfidenceInterval, "score_ci"))
 
     def test_evaluate_from_stats_bootstrap_without_ci(self) -> None:
         metric = _DummyMetric(_DummyMetricConfig("test", is_simple_average=False))
         stats = SimpleMetricStats(np.array([1.0, 2.0, 3.0, 4.0, 5.0]))
         result = metric.evaluate_from_stats(stats, confidence_alpha=None)
-        self.assertEqual(unwrap(result.get_value(Score, "score")).value, 3.0)
-        self.assertIsNone(result.get_value(ConfidenceInterval, "score_ci"))
+        self.assertEqual(result.get_value(Score, "score").value, 3.0)
+        self.assertIsNone(result.get_value_or_none(ConfidenceInterval, "score_ci"))
 
     def test_evaluate_from_stats_bootstrap_with_ci(self) -> None:
         metric = _DummyMetric(_DummyMetricConfig("test", is_simple_average=False))
         stats = SimpleMetricStats(np.array([1.0, 2.0, 3.0, 4.0, 5.0]))
         result = metric.evaluate_from_stats(stats, confidence_alpha=0.05)
-        self.assertEqual(unwrap(result.get_value(Score, "score")).value, 3.0)
-        ci = unwrap(result.get_value(ConfidenceInterval, "score_ci"))
+        self.assertEqual(result.get_value(Score, "score").value, 3.0)
+        ci = result.get_value(ConfidenceInterval, "score_ci")
         print(dataclasses.asdict(ci))
         # TODO(odahsi): According to the current default settings of bootstrapping,
         # estimated confidence intervals tends to become very wide for small data
@@ -358,5 +381,5 @@ class MetricTest(unittest.TestCase):
         metric = _DummyMetric(_DummyMetricConfig("test", is_simple_average=False))
         stats = SimpleMetricStats(np.array([3.0]))
         result = metric.evaluate_from_stats(stats, confidence_alpha=0.05)
-        self.assertEqual(unwrap(result.get_value(Score, "score")).value, 3.0)
-        self.assertIsNone(result.get_value(ConfidenceInterval, "score_ci"))
+        self.assertEqual(result.get_value(Score, "score").value, 3.0)
+        self.assertIsNone(result.get_value_or_none(ConfidenceInterval, "score_ci"))

--- a/explainaboard/metrics/ranking_test.py
+++ b/explainaboard/metrics/ranking_test.py
@@ -13,7 +13,6 @@ from explainaboard.metrics.ranking import (
     MeanReciprocalRank,
     MeanReciprocalRankConfig,
 )
-from explainaboard.utils.typing_utils import unwrap
 
 
 class HitsConfigTest(unittest.TestCase):
@@ -43,9 +42,7 @@ class HitsTest(unittest.TestCase):
         true = ['a', 'b', 'a', 'b', 'a', 'b']
         pred = [['a', 'b'], ['c', 'd'], ['c', 'a'], ['a', 'c'], ['b', 'a'], ['a', 'b']]
         result = metric.evaluate(true, pred, confidence_alpha=0.05)
-        self.assertAlmostEqual(
-            unwrap(result.get_value(Score, "score")).value, 4.0 / 6.0
-        )
+        self.assertAlmostEqual(result.get_value(Score, "score").value, 4.0 / 6.0)
 
 
 class MeanReciprocalRankConfigTest(unittest.TestCase):
@@ -77,9 +74,7 @@ class MeanReciprocalRankTest(unittest.TestCase):
         true = ['a', 'b', 'a', 'b', 'a', 'b']
         pred = [['a', 'b'], ['c', 'd'], ['c', 'a'], ['a', 'c'], ['b', 'a'], ['a', 'b']]
         result = metric.evaluate(true, pred, confidence_alpha=0.05)
-        self.assertAlmostEqual(
-            unwrap(result.get_value(Score, "score")).value, 2.5 / 6.0
-        )
+        self.assertAlmostEqual(result.get_value(Score, "score").value, 2.5 / 6.0)
 
 
 class MeanRankConfigTest(unittest.TestCase):

--- a/explainaboard/processors/processor.py
+++ b/explainaboard/processors/processor.py
@@ -401,8 +401,8 @@ class Processor(metaclass=abc.ABCMeta):
                     confidence_alpha=sys_info.confidence_alpha,
                 )
 
-                value = unwrap(metric_result.get_value(Score, "score")).value
-                ci = metric_result.get_value(ConfidenceInterval, "score_ci")
+                value = metric_result.get_value(Score, "score").value
+                ci = metric_result.get_value_or_none(ConfidenceInterval, "score_ci")
 
                 my_results[metric_name] = Performance(
                     value=value,

--- a/integration_tests/metric_test.py
+++ b/integration_tests/metric_test.py
@@ -15,7 +15,6 @@ import explainaboard.metrics.eaas
 import explainaboard.metrics.f1_score
 from explainaboard.metrics.metric import Score
 import explainaboard.metrics.ranking
-from explainaboard.utils.typing_utils import unwrap
 
 
 class MetricTest(unittest.TestCase):
@@ -90,27 +89,25 @@ class MetricTest(unittest.TestCase):
                 # EaaS-returned value should be same as explainaboard-calculated value
                 self.assertAlmostEqual(
                     full_result['scores'][i]['corpus'],
-                    unwrap(
-                        metric.evaluate_from_stats(full_stats).get_value(Score, "score")
-                    ).value,
+                    metric.evaluate_from_stats(full_stats)
+                    .get_value(Score, "score")
+                    .value,
                 )
                 self.assertAlmostEqual(
                     half_result['scores'][i]['corpus'],
-                    unwrap(
-                        metric.evaluate_from_stats(half_stats).get_value(Score, "score")
-                    ).value,
+                    metric.evaluate_from_stats(half_stats)
+                    .get_value(Score, "score")
+                    .value,
                 )
                 # Stats calculated over half corpus should be the same as the stats
                 # split away from the full corpus
                 self.assertAlmostEqual(
-                    unwrap(
-                        metric.evaluate_from_stats(half_stats).get_value(Score, "score")
-                    ).value,
-                    unwrap(
-                        metric.evaluate_from_stats(split_stats).get_value(
-                            Score, "score"
-                        )
-                    ).value,
+                    metric.evaluate_from_stats(half_stats)
+                    .get_value(Score, "score")
+                    .value,
+                    metric.evaluate_from_stats(split_stats)
+                    .get_value(Score, "score")
+                    .value,
                 )
 
     def test_qa_metrics(self) -> None:


### PR DESCRIPTION
This introduces following changes:

- `MetricResult.get_value`: returns `MetricValue` (originally `MetricValue | None`)
- Introduce `MetricResult.get_value_or_none`: returns `MetricValue | None`

In most cases `get_value` was used with `unwrap`, which increases the complexity of the code. This change mitigates some burden with keeping availability to obtain optional MetricValues.