### PR TITLE
Fix skipping heading levels in Markdown

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,7 +1,4 @@
 # TODO(tetsuok): Re-enable once the existing issues are fixed.
-MD001: false
-
-# TODO(tetsuok): Re-enable once the existing issues are fixed.
 MD013: false
   # Number of characters
   # line_length: 88

--- a/docs/final_check_for_contribution.md
+++ b/docs/final_check_for_contribution.md
@@ -5,18 +5,18 @@ Hi, first, thanks for your brilliant contribution to ExplainaBoard SDK :smiley: 
 This doc provides some friendly reminders for ExplainaBoard developers so that all relevant scripts and docs
 can be kept up-to-date whenever new functionalities have been implemented in ExplainaBoard.
 
-- #### When you add a new task
+## When you add a new task
 
-  - please register your task in the script [`tasks.py`](https://github.com/neulab/ExplainaBoard/blob/main/explainaboard/tasks.py)
-  - please add unit tests for your task in the folder [`tests`](https://github.com/neulab/ExplainaBoard/tree/main/integration_tests)
-  - please update [`cli_interface.md'](https://github.com/neulab/ExplainaBoard/blob/main/docs/cli_interface.md) to add the cli information of your task
+- please register your task in the script [`tasks.py`](https://github.com/neulab/ExplainaBoard/blob/main/explainaboard/tasks.py)
+- please add unit tests for your task in the folder [`tests`](https://github.com/neulab/ExplainaBoard/tree/main/integration_tests)
+- please update [`cli_interface.md'](https://github.com/neulab/ExplainaBoard/blob/main/docs/cli_interface.md) to add the cli information of your task
 
-- #### When you add a new metric or re-naming evaluation metrics
+## When you add a new metric or re-naming evaluation metrics
 
-  - please add a unittest in [`test_metric.py`](https://github.com/neulab/ExplainaBoard/blob/main/integration_tests/test_metric.py)
-  - please update the metric information in the relevant [processors](https://github.com/neulab/ExplainaBoard/blob/main/explainaboard/processors)
+- please add a unittest in [`test_metric.py`](https://github.com/neulab/ExplainaBoard/blob/main/integration_tests/test_metric.py)
+- please update the metric information in the relevant [processors](https://github.com/neulab/ExplainaBoard/blob/main/explainaboard/processors)
 
-- #### When you add a new supported format
+## When you add a new supported format
 
-  - please add a unittest in the folder [`tests`](https://github.com/neulab/ExplainaBoard/tree/main/integration_tests)
-  - please update the loader for appropriate tasks in [loaders](https://github.com/neulab/ExplainaBoard/blob/main/explainaboard/loaders)
+- please add a unittest in the folder [`tests`](https://github.com/neulab/ExplainaBoard/tree/main/integration_tests)
+- please update the loader for appropriate tasks in [loaders](https://github.com/neulab/ExplainaBoard/blob/main/explainaboard/loaders)

--- a/docs/get_evaluation_results_programatically.md
+++ b/docs/get_evaluation_results_programatically.md
@@ -28,7 +28,7 @@ sys_info = processor.process(metadata={}, sys_output=data.samples)
 The above code conducts the evaluation and puts everything in `sys_info.` In what follows,
 we will see how different types of information from `sys_info` are collected.
 
-#### Save analysis report locally
+### Save analysis report locally
 
 ```python
 sys_info.print_as_json(file=open("./report.json", 'w'))

--- a/docs/multilingual_multitask_evaluation.md
+++ b/docs/multilingual_multitask_evaluation.md
@@ -46,13 +46,13 @@ then all system outputs in the folder `./data/system_outputs/multilingual/json/m
 
  will be processed automatically, and two types of files will be generated:
 
-#### (1) analysis reports
+### (1) analysis reports
 
 * include both overall results and fine-grained analysis of a system
 * `json` format
 * in the folder `output/reports`
 
-#### (2) historgram figures
+### (2) historgram figures
 
 * each figure could be regarded as a visualization of corresponding analysis report, that provides fine-grained evaluation
    results for a system along certain feature (e.g., sentence length)
@@ -116,32 +116,32 @@ then you will get:
 
 ```
 ----------------------------------------
-Model: CL-mlpp15out1sum, Dataset: xnli 
+Model: CL-mlpp15out1sum, Dataset: xnli
 Language:       ar      en      es      zh
 Accuracy:       0.696   0.787   0.768   0.731
 
 ----------------------------------------
-Model: CL-mlpp15out1sum, Dataset: marc 
+Model: CL-mlpp15out1sum, Dataset: marc
 Language:       de      en      es      fr      ja      zh
 Accuracy:       0.933   0.915   0.934   0.926   0.915   0.871
 
 ----------------------------------------
-Model: CL-mlpp15out1sum, Dataset: xquad 
+Model: CL-mlpp15out1sum, Dataset: xquad
 Language:       en      es      zh
 F1ScoreQA:      0.824   0.782   0.816
 
 ----------------------------------------
-Model: CL-mt5base, Dataset: xnli 
+Model: CL-mt5base, Dataset: xnli
 Language:       de      en      es      zh
 Accuracy:       0.721   0.768   0.738   0.712
 
 ----------------------------------------
-Model: CL-mt5base, Dataset: marc 
+Model: CL-mt5base, Dataset: marc
 Language:       de      en      es      fr      ja      zh
 Accuracy:       0.933   0.920   0.934   0.933   0.914   0.868
 
 ----------------------------------------
-Model: CL-mt5base, Dataset: xquad 
+Model: CL-mt5base, Dataset: xquad
 Language:       en      es      zh
 F1ScoreQA:      0.812   0.782   0.816
 ```
@@ -159,25 +159,25 @@ Then, following results will be obtained:
 
 ```
 ----------------------------------------
-Model: CL-mlpp15out1sum, Dataset: xnli 
+Model: CL-mlpp15out1sum, Dataset: xnli
 Language:       ar      en      es      zh
 Accuracy:       0.696   0.787   0.768   0.731
 
 ----------------------------------------
-Model: CL-mlpp15out1sum, Dataset: marc 
+Model: CL-mlpp15out1sum, Dataset: marc
 Language:       de      en      es      fr      ja      zh
 Accuracy:       0.933   0.915   0.934   0.926   0.915   0.871
 
 ----------------------------------------
-Model: CL-mt5base, Dataset: xnli 
+Model: CL-mt5base, Dataset: xnli
 Language:       de      en      es      zh
 Accuracy:       0.721   0.768   0.738   0.712
 
 ----------------------------------------
-Model: CL-mt5base, Dataset: marc 
+Model: CL-mt5base, Dataset: marc
 Language:       de      en      es      fr      ja      zh
 Accuracy:       0.933   0.920   0.934   0.933   0.914   0.868
-```  
+```
 
 ### Aggregated Results based on Customized "Query"
 
@@ -192,32 +192,32 @@ Then following results will be printed:
 
 ```
 ----------------------------------------
-Model: CL-mlpp15out1sum, Dataset: xnli 
+Model: CL-mlpp15out1sum, Dataset: xnli
 Language:       all_languages
 Accuracy:       0.746
 
 ----------------------------------------
-Model: CL-mlpp15out1sum, Dataset: marc 
+Model: CL-mlpp15out1sum, Dataset: marc
 Language:       all_languages
 Accuracy:       0.916
 
 ----------------------------------------
-Model: CL-mlpp15out1sum, Dataset: xquad 
+Model: CL-mlpp15out1sum, Dataset: xquad
 Language:       all_languages
 F1ScoreQA:      0.807
 
 ----------------------------------------
-Model: CL-mt5base, Dataset: xnli 
+Model: CL-mt5base, Dataset: xnli
 Language:       all_languages
 Accuracy:       0.735
 
 ----------------------------------------
-Model: CL-mt5base, Dataset: marc 
+Model: CL-mt5base, Dataset: marc
 Language:       all_languages
 Accuracy:       0.917
 
 ----------------------------------------
-Model: CL-mt5base, Dataset: xquad 
+Model: CL-mt5base, Dataset: xquad
 Language:       all_languages
 F1ScoreQA:      0.803
 ```
@@ -237,12 +237,12 @@ Then following results will be printed:
 
 ```
 ----------------------------------------
-Model: CL-mlpp15out1sum V.S CL-mt5base, Dataset: marc 
+Model: CL-mlpp15out1sum V.S CL-mt5base, Dataset: marc
 Language:       de      zh      fr      ja      es      en
 Accuracy:       -0.000  0.003   -0.007  0.001   0.000   -0.005
 
 ----------------------------------------
-Model: CL-mlpp15out1sum V.S CL-mt5base, Dataset: xnli 
+Model: CL-mlpp15out1sum V.S CL-mt5base, Dataset: xnli
 Language:       es      en      zh
 Accuracy:       0.030   0.020   0.019
 ```

--- a/docs/web/how_to_make_interactive_evaluation.md
+++ b/docs/web/how_to_make_interactive_evaluation.md
@@ -4,7 +4,7 @@ ExplainaBoard makes it possible to perform interactive evaluation from multiple 
 
 ## Customized Bucket Number
 
-##### Background
+### Background
 
 ExplainaBoard achieves interpretable evaluation by bucketing evaluation performance
 into different categories based on some pre-defined features.
@@ -16,7 +16,7 @@ If you are interested in more details, [Liu et al.2021](https://aclanthology.org
 When using ExplainaBoard Web, users can customize the number
 of buckets. For example:
 
-##### bucket number: 4
+#### bucket number: 4
 
 <img src="./fig/customized_bucket.png" width="300"/>
 
@@ -25,7 +25,7 @@ The bucket number could be updated to 5 when
 * clicking `+` button
 * clicking `Update analysis`
 
-##### bucket number: 5
+#### bucket number: 5
 
 <img src="./fig/customized_bucket_2.png" width="300"/>
 
@@ -40,6 +40,6 @@ For example:
 
 `[2,12], [13,18], [19,24], [25,52]`  -> `[2,12], [12,18], [18,26], [26,52]`
 
-##### bucket number: 5
+### bucket number: 5
 
 <img src="./fig/customized_bucket_3.png" width="300"/>


### PR DESCRIPTION
Part of #536. This PR re-enables disabled rule [MD001](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md001---heading-levels-should-only-increment-by-one-level-at-a-time), and corrects skipped heading levels in Markdown files.