### PR TITLE
Enable checking the use of inline HTML in Markdown

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -12,6 +12,10 @@ MD024:
   siblings_only: true
 
 MD033:
+  # Allows the following tags becasue there is no reasonable counterpart in Markdown.
+  # The <a> tag can be used to use an image as a link. The <img> tag can be used to
+  # change image size. Note that there is no standardized way to change image size in
+  # Markdown yet.
   allowed_elements: [a, img]
 
 # TODO(tetsuok): Re-enable once the existing issues are fixed.

--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -11,8 +11,8 @@ MD024:
   # Allow multiple headings with the same content
   siblings_only: true
 
-# TODO(tetsuok): Re-enable once the existing issues are fixed.
-MD033: false
+MD033:
+  allowed_elements: [a, img]
 
 # TODO(tetsuok): Re-enable once the existing issues are fixed.
 MD036: false

--- a/README.md
+++ b/README.md
@@ -1,15 +1,12 @@
 # ExplainaBoard: An Explainable Leaderboard for NLP
 
-<p align="center">
-  <img src="./fig/logo-full-v2.png" width="800" class="center">
-  <br />
-  <br />
-  <a href="https://github.com/neulab/ExplainaBoard/blob/main/LICENSE"><img alt="License" src="https://img.shields.io/github/license/neulab/ExplainaBoard" /></a>
-  <a href="https://github.com/neulab/ExplainaBoard/stargazers"><img alt="GitHub stars" src="https://img.shields.io/github/stars/neulab/ExplainaBoard" /></a>
-  <a href="https://pypi.org/project//"><img alt="PyPI" src="https://img.shields.io/pypi/v/explainaboard" /></a>
-  <a href="https://github.com/psf/black"><img alt="Code Style" src="https://img.shields.io/badge/code%20style-black-black" /></a>
-  <a href=".github/workflows/ci.yml"><img alt="Integration Tests" src="https://github.com/neulab/ExplainaBoard/actions/workflows/ci.yml/badge.svg?event=push" /></a>
-</p>
+<img src="./fig/logo-full-v2.png" width="800" class="center">
+
+[![License](https://img.shields.io/github/license/neulab/ExplainaBoard)](https://github.com/neulab/ExplainaBoard/blob/main/LICENSE)
+[![GitHub stars](https://img.shields.io/github/stars/neulab/ExplainaBoard)](https://github.com/neulab/ExplainaBoard/stargazers)
+[![PyPI](https://img.shields.io/pypi/v/explainaboard)](https://pypi.org/project/explainaboard/)
+[![Code Style](https://img.shields.io/badge/code%20style-black-black)](https://github.com/psf/black)
+[![Integration Tests](https://github.com/neulab/ExplainaBoard/actions/workflows/ci.yml/badge.svg?event=push)](.github/workflows/ci.yml)
 
 ## What is ExplainaBoard?
 


### PR DESCRIPTION
Part of #536. This PR re-enables the disabled rule, [MD033](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md033---inline-html), allowing the use of `<a>` and `<img>` tags. Also changes the writing styles of badges from HTML to Markdown because I didn't see the necessity of the consistent alignment between badges and the logo image.