### PR TITLE
Use headings instead of emphasis in Markdown

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -15,9 +15,6 @@ MD024:
 MD033: false
 
 # TODO(tetsuok): Re-enable once the existing issues are fixed.
-MD036: false
-
-# TODO(tetsuok): Re-enable once the existing issues are fixed.
 MD040: false
 
 # TODO(tetsuok): Re-enable once the existing issues are fixed.

--- a/docs/cli_interface.md
+++ b/docs/cli_interface.md
@@ -23,7 +23,7 @@ with examples of how to analyze different tasks. In particular
 We welcome contributions of [more tasks](add_new_tasks.md), or detailed documentation
 for tasks where the documentation does not yet exist! Please open an issue or file a PR.
 
-**Table of Contents**
+## Table of Contents
 
 * [Text Classification](#text-classification)
 * [Text Pair Classification](#text-pair-classification)
@@ -51,7 +51,7 @@ Text classification consists of classifying text into different categories, such
 sentiment values or topics. The below example performs an analysis on the Stanford
 Sentiment Treebank, a set of sentiment tags over English reviews.
 
-**CLI Examples**
+### CLI Examples
 
 The below example loads the `sst2` dataset from DataLab:
 
@@ -72,7 +72,7 @@ detection. The example below concerns natural language infernce, predicting whet
 premise, entails, contradicts, or is neutral with respect to a hypothesis, on the
 Stanford Natural Language Inference dataset.
 
-**CLI Example**
+### CLI Example
 
 The below example loads the `snli` dataset from DataLab:
 
@@ -92,7 +92,7 @@ Conditional text generation concerns generation of one text based on other texts
 including tasks like summarization and machine translation. The below example evaluates
 a summarization system on the CNN-daily mail dataset.
 
-**CLI Example**
+### CLI Example
 
 The below example loads a miniature version of the CNN-daily mail dataset (100 lines only) from an existing file:
 
@@ -121,7 +121,7 @@ Language modeling is the task of predicting the probability for words in a text.
 You can analyze your language model outputs by inputting a file that has one log
 probability for each space-separated word. Here is an example:
 
-**CLI Example**
+### CLI Example
 
 The below example analyzes the wikitext corpus:
 
@@ -134,7 +134,7 @@ explainaboard --task language-modeling --custom-dataset-paths ./data/system_outp
 Named entity recognition recognizes entities such as people, organizations, or locations in text.
 The below examples demonstrate how you can perform such analysis on the CoNLL 2003 English named entity recognition dataset.
 
-**CLI Example**
+### CLI Example
 
 The below example loads the `conll2003` NER dataset from DataLab:
 
@@ -145,14 +145,14 @@ explainaboard --task named-entity-recognition --dataset conll2003 --sub-dataset 
 Alternatively, you can reference a dataset file directly.
 
 ```shell
-explainaboard --task named-entity-recognition --custom-dataset-paths ./data/system_outputs/conll2003/conll2003-dataset.conll --system-outputs ./data/system_outputs/conll2003/conll2003-elmo-output.conll 
+explainaboard --task named-entity-recognition --custom-dataset-paths ./data/system_outputs/conll2003/conll2003-dataset.conll --system-outputs ./data/system_outputs/conll2003/conll2003-elmo-output.conll
 ```
 
 ## Word Segmentation
 
 Word segmentation aims to segment texts without spaces between words.
 
-**CLI Example**
+### CLI Example
 
 The below example loads the `msr` dataset from DataLab:
 
@@ -172,7 +172,7 @@ explainaboard --task word-segmentation --custom-dataset-paths ./data/system_outp
 
 Dividing text into syntactically related non-overlapping groups of words.
 
-**CLI Example**
+### CLI Example
 
 The below example loads the `conll00_chunk` dataset from DataLab:
 
@@ -191,7 +191,7 @@ explainaboard --task chunking --custom-dataset-paths ./data/system_outputs/chunk
 Extractive QA attempts to answer queries based on extracting segments from an evidence passage.
 The below example performs this extraction on the dataset SQuAD.
 
-**CLI Example**
+### CLI Example
 
 Below is an example of referencing the dataset directly.
 
@@ -210,7 +210,7 @@ explainaboard --task qa-extractive --dataset squad --system-outputs MY_FILE > re
 This task aims to answer a question based on a hybrid of tabular
 and textual context, e.g., [Zhu et al.2021](https://aclanthology.org/2021.acl-long.254.pdf).
 
-**CLI Example**
+### CLI Example
 
 The below example loads the `tat_qa` dataset from DataLab.
 
@@ -232,7 +232,7 @@ unstructured documents
 Following examples show how an open-domain QA system can be evaluated with detailed analyses using
 ExplainaBoard CLI.
 
-**CLI Example**
+### CLI Example
 
 Using Build-in datasets from DataLab:
 
@@ -245,7 +245,7 @@ explainaboard --task qa-open-domain --dataset natural_questions_comp_gen   --sys
 Answer a question from multiple options.
 The following example demonstrates this on the metaphor QA dataset.
 
-**CLI Example**
+### CLI Example
 
 The below example loads the `fig_qa` dataset from DataLab.
 
@@ -263,7 +263,7 @@ explainaboard --task qa-multiple-choice --custom-dataset-paths ./data/system_out
 
 Predicting the tail entity of missing links in knowledge graphs
 
-**CLI Example**
+### CLI Example
 
 The below example loads the `fb15k_237` dataset from DataLab.
 
@@ -280,7 +280,7 @@ The below example loads the `fb15k_237` dataset from DataLab.
 
 Predict the sentiment of a text based on a specific aspect.
 
-**CLI Example**
+### CLI Example
 
 This is an example with a custom dataset.
 
@@ -292,7 +292,8 @@ explainaboard --task aspect-based-sentiment-classification --custom-dataset-path
 
 Fill in a blank based on multiple provided options
 
-**CLI Example**
+### CLI Example
+
 This is an example using the dataset from `DataLab`
 
 ```shell
@@ -303,7 +304,8 @@ explainaboard --task cloze-multiple-choice --dataset gaokao2018_np1 --sub-datase
 
 Fill in a blank based on hint
 
-**CLI Example**
+### CLI Example
+
 This is an example using the dataset from `DataLab`
 
 ```shell
@@ -313,7 +315,9 @@ explainaboard --task cloze-generative --dataset gaokao2018_np1 --sub-dataset clo
 ## [Grammatical Error Correction]
 
 Correct errors in a text
-**CLI Example**
+
+### CLI Example
+
 This is an example using the dataset from `DataLab`
 
 ```shell
@@ -329,7 +333,7 @@ features that is analyzed by ExplainaBoard is the `label` feature, so you might 
 specify other features to perform bucketing over using the `metadata` entry in the
 dataset `json` file, as is done in `sst2-tabclass-dataset.json` below.
 
-**CLI Examples**
+### CLI Examples
 
 The below example loads a dataset from an existing file:
 
@@ -342,7 +346,7 @@ explainaboard --task tabular-classification --custom-dataset-paths ./data/system
 Regression over tabular data is basically the same as tabular classification above, but
 the predicted outputs are continuous numbers instead of classes.
 
-**CLI Examples**
+### CLI Examples
 
 The below example loads a dataset from an existing file:
 
@@ -354,7 +358,7 @@ explainaboard --task tabular-regression --custom-dataset-paths ./data/system_out
 
 This task aim to detect the argument pairs from each passage pair of review and rebuttal.
 
-**CLI Examples**
+### CLI Examples
 
 The below example loads the [`ape`](https://github.com/ExpressAI/DataLab/blob/main/datasets/ape/ape.py) dataset from DataLab:
 
@@ -366,7 +370,7 @@ explainaboard --task argument-pair-extraction --dataset ape --system-outputs ./d
 
 Evaluating the reliability of automated metrics for general text generation tasks, such as text summarization.
 
-**CLI Examples**
+### CLI Examples
 
 The below example loads the meval_summeval dataset from DataLab:
 
@@ -379,7 +383,7 @@ explainaboard --task meta-evaluation-nlg --dataset meval_summeval --sub-dataset 
 Evaluating the reliability of automated metrics for [WMT Metrics shared tasks](https://wmt-metrics-task.github.io/)
  using [direct assessment](https://www.statmt.org/wmt16/slides/wmt16-news-da.pdf) (DA).
 
-**CLI Example**
+### CLI Example
 
 This is an example with a custom dataset.
 


### PR DESCRIPTION
Part of #536. This PR re-enables the disabled rule, [MD036](https://github.com/DavidAnson/markdownlint/blob/main/doc/Rules.md#md036---emphasis-used-instead-of-a-heading), and replaces emphasis with headings in Markdown.