### PR TITLE
Wrap Markdown text at 88 columns

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,9 +1,8 @@
 config:
-  # TODO(tetsuok): Re-enable once the existing issues are fixed.
-  MD013: false
+  MD013:
     # Number of characters
-    # line_length: 88
-    # code_blocks: false
+    line_length: 88
+    code_blocks: false
 
   MD024:
     # Allow multiple headings with the same content

--- a/README.md
+++ b/README.md
@@ -10,7 +10,11 @@
 
 ## What is ExplainaBoard?
 
-When developing a natural language processing (NLP or AI) system, often one of the hardest things is to understand where your system is working and where it is failing, and deciding what to do next. ExplainaBoard is a tool that *inspects your system outputs*, *identifies what is working and what is not working*, and helps *inspire you with ideas of where to go next*.
+When developing a natural language processing (NLP or AI) system, often one of the
+hardest things is to understand where your system is working and where it is failing,
+and deciding what to do next. ExplainaBoard is a tool that *inspects your system
+outputs*, *identifies what is working and what is not working*, and helps *inspire you
+with ideas of where to go next*.
 
 <img src="./fig/intro.png" width="300" align="right">
 
@@ -47,7 +51,8 @@ pip install explainaboard
 python -m spacy download en_core_web_sm  # if you plan to use the AspectBasedSentimentClassificationProcessor
 ```
 
-**Install Method 2 - Development:** Install from the source and develop locally (Python 3 only)
+**Install Method 2 - Development:** Install from the source and develop locally (Python
+3 only)
 
 ```bash
 # Clone current repo
@@ -61,10 +66,12 @@ pre-commit install
 ```
 
 - **Testing:** To run tests, you can run `python -m unittest`.
-- **Linting and Code Style:** This project uses flake8 (linter) and black (formatter). They are enforced in the pre-commit hook and in the CI pipeline.
+- **Linting and Code Style:** This project uses flake8 (linter) and black (formatter).
+  They are enforced in the pre-commit hook and in the CI pipeline.
   - run `python -m black .` to format code
   - run `flake8` to lint code
-  - You can also configure your IDE to automatically format and lint the files as you are writing code.
+  - You can also configure your IDE to automatically format and lint the files as you
+    are writing code.
 
 After trying things out in the [CLI](docs/cli_interface.md), you can read how to add
 new [features](docs/add_new_features.md), [tasks](docs/add_new_tasks.md), or
@@ -72,8 +79,8 @@ new [features](docs/add_new_features.md), [tasks](docs/add_new_tasks.md), or
 
 ## Acknowledgement
 
-ExplainaBoard is developed by Carnegie Mellon University, Inspired Cognition Inc., and other collaborators.
-If you find it useful in research, you can cite it in papers:
+ExplainaBoard is developed by Carnegie Mellon University, Inspired Cognition Inc., and
+other collaborators. If you find it useful in research, you can cite it in papers:
 
     @inproceedings{liu-etal-2021-explainaboard,
         title = "{E}xplaina{B}oard: An Explainable Leaderboard for {NLP}",

--- a/docs/add_custom_features.md
+++ b/docs/add_custom_features.md
@@ -1,10 +1,16 @@
 # Add custom features for custom analysis
 
-If you want to perform custom analysis with your custom features that are not supported in the original task processors, and these features are only related to one particular system/dataset instead of the task itself, you can define the custom features and analysis in the `metadata` section in the output JSON file.
+If you want to perform custom analysis with your custom features that are not supported
+in the original task processors, and these features are only related to one particular
+system/dataset instead of the task itself, you can define the custom features and
+analysis in the `metadata` section in the output JSON file.
 
 ## Example of bucket analysis
 
-Here is the output json format for bucket analysis with custom features. Discrete features should have `"dtype": "string"`, such as the subject of the sentence, etc. Continuous features should have `"dtype": "float"`, such as the count of particular words, the output logits/probability, etc.
+Here is the output json format for bucket analysis with custom features. Discrete
+features should have `"dtype": "string"`, such as the subject of the sentence, etc.
+Continuous features should have `"dtype": "float"`, such as the count of particular
+words, the output logits/probability, etc.
 
 ```
 {
@@ -59,12 +65,13 @@ where
   * `span` for span-level analysis (e.g. in named entity recognition analysis)
   * `token` for token-level analysis (e.g. in named entity conditional text generation)
 * `num_bucket`: the number of buckets to be used
-* `sample_limit`: if the number of examples are larger than sample_limit, randomly select sample_limit examples for analysis
+* `sample_limit`: if the number of examples are larger than sample_limit, randomly
+  select sample_limit examples for analysis
 
 ## Example of ComboCountAnalysis
 
-ComboCountAnalysis is used to count feature combinations (e.g. for confusion matrices). It will
-return counts of each combination of values for the features named in `features`.
+ComboCountAnalysis is used to count feature combinations (e.g. for confusion matrices).
+It will return counts of each combination of values for the features named in `features`.
 
 ```
 {
@@ -93,7 +100,8 @@ where
   * `example` for sentence-level analysis
   * `span` for span-level analysis (e.g. in named entity recognition analysis)
   * `token` for token-level analysis (e.g. in named entity conditional text generation)
-* `features` should be a list of feature names where each feature are predefined. These features can be true_label, predicted_label, or other custom features.
+* `features` should be a list of feature names where each feature are predefined. These
+  features can be true_label, predicted_label, or other custom features.
 
 ## Example output json files
 
@@ -102,7 +110,8 @@ where
 
 ## Note
 
-When running analysis with SDK command, `--custom-dataset-file-type` and `--output-file-type json` are required.
+When running analysis with SDK command, `--custom-dataset-file-type` and
+`--output-file-type json` are required.
 
 Example command:
 

--- a/docs/add_new_features.md
+++ b/docs/add_new_features.md
@@ -90,11 +90,13 @@ If you want to add features that are dependent on the training set, you will nee
 
 1. Implement a `get_statistics` function that saves the statistics from the training set
 2. Declare `require_training_set=True` in the feature definition
-3. Use the passed-in `statistics` object to access the training set statistics when calculating features
+3. Use the passed-in `statistics` object to access the training set statistics when
+   calculating features
 
 It is probably best to learn by example, so you can take a look at `get_num_oov` in
 `processors/text_classification.py`.
 
 ## Add Custom Features
 
-If you want to add system/dataset-related features that don't apply to the task itself, check [add_custom_features](add_custom_features.md)
+If you want to add system/dataset-related features that don't apply to the task itself,
+check [add_custom_features](add_custom_features.md).

--- a/docs/add_new_tasks.md
+++ b/docs/add_new_tasks.md
@@ -1,16 +1,18 @@
 # Add New Tasks
 
-Let's take `text_classification` as an example to show how to add a new task for ExplainaBoard.
+Let's take `text_classification` as an example to show how to add a new task for
+ExplainaBoard.
 
 To do so, you would first need to add your task to the modules `tasks.py`.
-After doing so, you would also need to create a `Loader`, `Processor`, and unit tests for the
-new task, placed under the relevant directories.
+After doing so, you would also need to create a `Loader`, `Processor`, and unit tests
+for the new task, placed under the relevant directories.
 
 ## Task and Format Declaration
 
-(1) All the supported tasks are listed in **tasks.py**. If your task name is not listed in the file,
-please add your task to `TaskType` (enum) and the task list `_task_categories`. Task names can not
-contain `space` and different words should be connected using `-`.
+(1) All the supported tasks are listed in **tasks.py**. If your task name is not listed
+in the file, please add your task to `TaskType` (enum) and the task list
+`_task_categories`. Task names can not contain `space` and different words should be
+connected using `-`.
 
 (2) If the format of your task's dataset is not covered by `FileType` in the file
 `explainaboard/constants.py`, please manually add the new format (in the case that your
@@ -29,11 +31,13 @@ _task_categories: List[TaskCategory] = [
 ]
 ```
 
-where the parameters in `TaskCategory` refers to the task's name, description, and the list of tasks
+where the parameters in `TaskCategory` refers to the task's name, description, and the
+list of tasks.
 
 ## Create a Loader module for your task
 
-(1) Create a new python file `text_classification.py` in the folder `explainaboard/loaders/`
+(1) Create a new python file `text_classification.py` in the folder
+`explainaboard/loaders/`
 
 (2) In this file, we need to:
 
@@ -41,7 +45,7 @@ where the parameters in `TaskCategory` refers to the task's name, description, a
 * implement the member function `def load(self)`
 
 Here is the example for text classification:
-  
+
 ```python
 from typing import Dict, Iterable, List
 from explainaboard.constants import *
@@ -106,10 +110,11 @@ __all__ = [
 * define features that you aim to use for this task in the `_features` variable
 * [implement the features](add_new_features.md) that you want to use to perform analysis
 
-Note that for simpler tests, this is mostly all that you need to do. For more complex tasks,
-you may want to override some of the functions in the base `Processor` class implemented in
-`processors/processor.py`. `processors/text_classification.py` gives a good example of a simpler
-task, and `processors/named_entity_recognition.py` gives a good example of a more complicated task.
+Note that for simpler tests, this is mostly all that you need to do. For more complex
+tasks, you may want to override some of the functions in the base `Processor` class
+implemented in `processors/processor.py`. `processors/text_classification.py` gives a
+good example of a simpler task, and `processors/named_entity_recognition.py` gives a
+good example of a more complicated task.
 
 (3) Import this module (text_classification.py) in `__init__.py`
 For example, in this file `explainaboard/processors/__init__.py`, we have:

--- a/docs/cli_interface.md
+++ b/docs/cli_interface.md
@@ -95,7 +95,8 @@ a summarization system on the CNN-daily mail dataset.
 
 ### CLI Example
 
-The below example loads a miniature version of the CNN-daily mail dataset (100 lines only) from an existing file:
+The below example loads a miniature version of the CNN-daily mail dataset (100 lines
+only) from an existing file:
 
 ```shell
 explainaboard --task summarization --custom-dataset-paths ./data/system_outputs/cnndm/cnndm_mini-dataset.tsv --system-outputs ./data/system_outputs/cnndm/cnndm_mini-bart-output.txt --metrics rouge2 bart_score_en_ref
@@ -104,7 +105,8 @@ explainaboard --task summarization --custom-dataset-paths ./data/system_outputs/
 Note that this uses two different metrics separated by a space.
 
 You could also load the `cnn_dailymail` dataset from DataLab.
-Because the test set is large we don't include it directly in the explainaboard repository, but you can get an example by downloading with wget:
+Because the test set is large we don't include it directly in the explainaboard
+repository, but you can get an example by downloading with wget:
 
 ```shell
 wget -P ./data/system_outputs/cnndm/ https://storage.googleapis.com/inspired-public-data/explainaboard/task_data/summarization/cnndm-bart-output.txt
@@ -132,8 +134,9 @@ explainaboard --task language-modeling --custom-dataset-paths ./data/system_outp
 
 ## Named Entity Recognition
 
-Named entity recognition recognizes entities such as people, organizations, or locations in text.
-The below examples demonstrate how you can perform such analysis on the CoNLL 2003 English named entity recognition dataset.
+Named entity recognition recognizes entities such as people, organizations, or locations
+in text. The below examples demonstrate how you can perform such analysis on the CoNLL
+2003 English named entity recognition dataset.
 
 ### CLI Example
 
@@ -200,7 +203,10 @@ Below is an example of referencing the dataset directly.
 explainaboard --task qa-extractive --custom-dataset-paths ./data/system_outputs/squad/squad_mini-dataset.json --system-outputs ./data/system_outputs/squad/squad_mini-example-output.json > report.json
 ```
 
-The below example loads the `squad` dataset from DataLab. There is an [open issue](https://github.com/neulab/ExplainaBoard/issues/239) that prevents the specification of a dataset split, so this will not work at the moment. But we are working on it.
+The below example loads the `squad` dataset from DataLab. There is an
+[open issue](https://github.com/neulab/ExplainaBoard/issues/239) that prevents the
+specification of a dataset split, so this will not work at the moment. But we are
+working on it.
 
 ```shell
 explainaboard --task qa-extractive --dataset squad --system-outputs MY_FILE > report.json
@@ -230,8 +236,8 @@ wget -P ./ https://explainaboard.s3.amazonaws.com/system_outputs/qa_table_text_h
 Open-domain QA aims to answer a question in the form of natural language based on large-scale
 unstructured documents
 
-Following examples show how an open-domain QA system can be evaluated with detailed analyses using
-ExplainaBoard CLI.
+Following examples show how an open-domain QA system can be evaluated with detailed
+analyses using ExplainaBoard CLI.
 
 ### CLI Example
 
@@ -361,7 +367,8 @@ This task aim to detect the argument pairs from each passage pair of review and 
 
 ### CLI Examples
 
-The below example loads the [`ape`](https://github.com/ExpressAI/DataLab/blob/main/datasets/ape/ape.py) dataset from DataLab:
+The below example loads the [`ape`](https://github.com/ExpressAI/DataLab/blob/main/datasets/ape/ape.py)
+dataset from DataLab:
 
 ```shell
 explainaboard --task argument-pair-extraction --dataset ape --system-outputs ./data/system_outputs/ape/ape_predictions.txt
@@ -373,7 +380,8 @@ Given an argument, the task aims to identify one matched argument from a list of
 
 ### CLI Examples
 
-The example below loads the [`iapi`](https://github.com/ExpressAI/DataLab/blob/main/datasets/iapi/iapi.py) dataset from DataLab:
+The example below loads the [`iapi`](https://github.com/ExpressAI/DataLab/blob/main/datasets/iapi/iapi.py)
+dataset from DataLab:
 
 ```shell
 explainaboard --task argument-pair-identification --dataset iapi --system-outputs data/system_outputs/iapi/predictions.txt > report.json
@@ -381,7 +389,8 @@ explainaboard --task argument-pair-identification --dataset iapi --system-output
 
 ## [Meta Evaluation NLG]
 
-Evaluating the reliability of automated metrics for general text generation tasks, such as text summarization.
+Evaluating the reliability of automated metrics for general text generation tasks, such
+as text summarization.
 
 ### CLI Examples
 

--- a/docs/concepts_about_system_analysis.md
+++ b/docs/concepts_about_system_analysis.md
@@ -5,14 +5,15 @@ you need to know before performing system analyses using Explainaboard.
 
 ## What are a "dataset" and a "system output"?
 
-To perform an analysis of your results, usually, two types of files should be prepared: "dataset"
-and "system output"
+To perform an analysis of your results, usually, two types of files should be prepared:
+"dataset" and "system output."
 
 ### `Dataset`
 
-A "dataset" usually consists of test inputs together with true outputs (e.g. gold-standard labels for classification tasks
-or reference outputs for text generation tasks).
-For example, in text classification, a `dataset` organized in tsv format may look like this:
+A "dataset" usually consists of test inputs together with true outputs (e.g.
+gold-standard labels for classification tasks or reference outputs for text generation
+tasks). For example, in text classification, a `dataset` organized in tsv format may
+look like this:
 
 ```text
 I love this movie   positive
@@ -22,9 +23,10 @@ The movie is too long   negative
 
 ### `System output`
 
-`System output` is frequently composed of predicted labels (or hypotheses, e.g., system-generated text),
-but sometimes `system output` will also contain test samples, such as `CoNLL` format in sequence labeling tasks.
-For example, in text classification, the `system output` could be organized in a text format:
+`System output` is frequently composed of predicted labels (or hypotheses, e.g.,
+system-generated text), but sometimes `system output` will also contain test samples,
+such as `CoNLL` format in sequence labeling tasks. For example, in text classification,
+the `system output` could be organized in a text format:
 
 ```text
 positive
@@ -34,8 +36,9 @@ negative
 
 ## "Datalab datasets" and "custom datasets"
 
-ExplainaBoard currently supports two sources for datasets: one is through [Datalab](https://aclanthology.org/2022.acl-demo.18.pdf) (Xiao et al 2022) and the
-other is custom.
+ExplainaBoard currently supports two sources for datasets: one is through
+[Datalab](https://aclanthology.org/2022.acl-demo.18.pdf) (Xiao et al 2022) and the other
+is custom.
 
 * if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
 we recommend that you load it through DataLab. This is for several reasons:
@@ -45,23 +48,26 @@ we recommend that you load it through DataLab. This is for several reasons:
  (3) DataLab datasets support analysis with features calculated over the training set,
   which can be informative.
 
-For example, the following command can be used to perform system analysis on `sst2` dataset (supported by datalab)
+For example, the following command can be used to perform system analysis on `sst2`
+dataset (supported by datalab)
 
 ```shell script
 explainaboard --task text-classification --dataset sst2 --system-outputs ./data/system_outputs/sst2/sst2-lstm-output.txt
 ```
 
-If the dataset hasn't been supported by datalab, we then need to prepare the dataset in a format supported by ExplainaBoard
- (this varies from task-to-task, see the task-specific documentation) and specify a file path:
+If the dataset hasn't been supported by datalab, we then need to prepare the dataset in
+a format supported by ExplainaBoard (this varies from task-to-task, see the
+task-specific documentation) and specify a file path:
 
 ```shell script
 explainaboard --task text-classification --custom-dataset-paths ./data/system_outputs/sst2/sst2-dataset.tsv --system-outputs ./data/system_outputs/sst2/sst2-lstm-output.txt
 ```
 
-* if your datasets haven't been supported by datalab but you want them supported, you can follow this
-[doc](https://github.com/ExpressAI/DataLab/blob/main/docs/SDK/add_new_datasets_into_sdk.md) to add them.
+* if your datasets haven't been supported by datalab but you want them supported, you
+  can follow this [doc](https://github.com/ExpressAI/DataLab/blob/main/docs/SDK/add_new_datasets_into_sdk.md)
+  to add them.
 
 ## How different formats (e.g. json, tsv, etc.) are supported
 
-In ExplainaBoard, users are allowed to prepare custom datasets with different formats, such as
-`json`, `tsv` etc. We will detail this in each task's description.
+In ExplainaBoard, users are allowed to prepare custom datasets with different formats,
+such as `json`, `tsv` etc. We will detail this in each task's description.

--- a/docs/final_check_for_contribution.md
+++ b/docs/final_check_for_contribution.md
@@ -2,14 +2,16 @@
 
 Hi, first, thanks for your brilliant contribution to ExplainaBoard SDK :smiley: !
 
-This doc provides some friendly reminders for ExplainaBoard developers so that all relevant scripts and docs
-can be kept up-to-date whenever new functionalities have been implemented in ExplainaBoard.
+This doc provides some friendly reminders for ExplainaBoard developers so that all
+relevant scripts and docs can be kept up-to-date whenever new functionalities have been
+implemented in ExplainaBoard.
 
 ## When you add a new task
 
 - please register your task in the script [`tasks.py`](https://github.com/neulab/ExplainaBoard/blob/main/explainaboard/tasks.py)
 - please add unit tests for your task in the folder [`tests`](https://github.com/neulab/ExplainaBoard/tree/main/integration_tests)
-- please update [`cli_interface.md'](https://github.com/neulab/ExplainaBoard/blob/main/docs/cli_interface.md) to add the cli information of your task
+- please update [`cli_interface.md'](https://github.com/neulab/ExplainaBoard/blob/main/docs/cli_interface.md)
+  to add the cli information of your task
 
 ## When you add a new metric or re-naming evaluation metrics
 

--- a/docs/multilingual_multitask_evaluation.md
+++ b/docs/multilingual_multitask_evaluation.md
@@ -4,8 +4,8 @@ ExplainaBoard currently supports multilingual/multitask evaluation.
 
 ## Data Preparation
 
-To achieve multilingual/multitask evaluation, the system outputs files must been organized into JSON
-format with following skeleton:
+To achieve multilingual/multitask evaluation, the system outputs files must been
+organized into JSON format with following skeleton:
 
 ```JSON
 {
@@ -26,8 +26,10 @@ format with following skeleton:
 where `...` will be instantiated task-dependently. Specifically,
 
 * [Example](../data/system_outputs/multilingual/json/mlpp/marc/) for text classification
-* [Example](../data/system_outputs/multilingual/json/mlpp/xnli/) for sentence pair classification
-* [Example](../data/system_outputs/multilingual/json/mlpp/xquad/) for extractive question answering
+* [Example](../data/system_outputs/multilingual/json/mlpp/xnli/) for sentence pair
+  classification
+* [Example](../data/system_outputs/multilingual/json/mlpp/xquad/) for extractive
+  question answering
 
 Once the system outputs are ready, evaluation can be conducted through following steps.
 
@@ -54,29 +56,33 @@ then all system outputs in the folder `./data/system_outputs/multilingual/json/m
 
 ### (2) historgram figures
 
-* each figure could be regarded as a visualization of corresponding analysis report, that provides fine-grained evaluation
-   results for a system along certain feature (e.g., sentence length)
+* each figure could be regarded as a visualization of corresponding analysis report,
+  that provides fine-grained evaluation results for a system along certain feature
+  (e.g., sentence length)
 * `png` format (would be useful for paper writing)
 * in the folder `output/figures`
 
 ## 2. More Datasets (tasks), More Systems
 
-We can repeat the above process, using ExplainaBoard SDK to performan analysis for different tasks (datasets) from different languages.
-For example,
+We can repeat the above process, using ExplainaBoard SDK to performan analysis for
+different tasks (datasets) from different languages. For example,
 
-* Differant languages on `marc` dataset (text classification task) using `mt5base (a.k.a CL-mt5base)` system
+* Differant languages on `marc` dataset (text classification task) using
+  `mt5base (a.k.a CL-mt5base)` system
 
 ```shell
 explainaboard --system-outputs ./data/system_outputs/multilingual/json/mt5base/marc/*
 ```
 
-* Differant languages on `xquad` dataset (text classification task) using `mt5base` system
+* Differant languages on `xquad` dataset (text classification task) using `mt5base`
+  system
 
 ```shell
 explainaboard --system-outputs ./data/system_outputs/multilingual/json/mt5base/xquad/*
 ```
 
-* Differant languages on `xnli` dataset (natural language inference task) using `mlpp (a.k.a CL-mlpp15out1sum)` system
+* Differant languages on `xnli` dataset (natural language inference task) using
+  `mlpp (a.k.a CL-mlpp15out1sum)` system
 
 ```shell
 explainaboard --system-outputs ./data/system_outputs/multilingual/json/mlpp/xnli/*
@@ -88,7 +94,8 @@ explainaboard --system-outputs ./data/system_outputs/multilingual/json/mlpp/xnli
 explainaboard --system-outputs ./data/system_outputs/multilingual/json/mlpp/marc/*
 ```
 
-* Differant languages on `xquad` dataset (extractive question answwering) using `mlpp` system
+* Differant languages on `xquad` dataset (extractive question answwering) using `mlpp`
+  system
 
 ```shell
 explainaboard --system-outputs ./data/system_outputs/multilingual/json/mlpp/xquad/*
@@ -102,7 +109,8 @@ After the above two steps, for all system outputs from
 * three tasks (datasets): `xnli`, `marc`, `xquad`
 * multiple languages (e.g., `de`, `en`, `es`, `zh`)
 
-, corresponding reports have been generated. The next step is to perform analysis based on these reports.
+, corresponding reports have been generated. The next step is to perform analysis based
+on these reports.
 
 ExplainaBoard SDK (CLI) provides some interfaces to achieve this goal, for example
 
@@ -148,8 +156,9 @@ F1ScoreQA:      0.812   0.782   0.816
 
 ### Filter Results based on Customized "Query"
 
-ExplainaBoard also provides interface that users could filter all results with their specified
-conditions. For example, if we only care about results on  `xnli` and `marc` datasets
+ExplainaBoard also provides interface that users could filter all results with their
+specified conditions. For example, if we only care about results on  `xnli` and `marc`
+datasets
 
 ```
 explainaboard --reports ./output/reports/* --datasets xnli marc
@@ -181,8 +190,8 @@ Accuracy:       0.933   0.920   0.934   0.933   0.914   0.868
 
 ### Aggregated Results based on Customized "Query"
 
-ExplainaBoard SDK allows users to aggregate results along different dimension. For example, if we aim to
-know the average performance ove all languages for each dataset,
+ExplainaBoard SDK allows users to aggregate results along different dimension. For
+example, if we aim to know the average performance ove all languages for each dataset,
 
 ```
 explainaboard --reports ./output/reports/* --languages-aggregation average
@@ -224,10 +233,10 @@ F1ScoreQA:      0.803
 
 ### System Pair Analysis of Two Groups of Results
 
-Using ExplainaBoard SDK, users can easily get the performance gap (system1 minus system2) over different
-datasets (tasks) and different languages.
-For example, the following command represent: the performance gap between two systems on all languages
-from `mar` and `xnli` datasets.
+Using ExplainaBoard SDK, users can easily get the performance gap (system1 minus
+system2) over different datasets (tasks) and different languages.
+For example, the following command represent: the performance gap between two systems on
+ all languages from `mar` and `xnli` datasets.
 
 ```
 explainaboard --reports ./output/reports/* --datasets marc xnli --systems-aggregation minus

--- a/docs/task_argument_pair_extraction.md
+++ b/docs/task_argument_pair_extraction.md
@@ -4,15 +4,17 @@ Before diving into the detail of this doc, you're strongly recommended to know [
 important concepts about system analyses](concepts_about_system_analysis.md).
 
 In this file we describe how to analyze APE models.
-We will give an example using the  [ape](https://github.com/ExpressAI/DataLab/blob/main/datasets/ape/ape.py) dataset, but other datasets
-can be analyzed in a similar way.
+We will give an example using the [ape](https://github.com/ExpressAI/DataLab/blob/main/datasets/ape/ape.py)
+dataset, but other datasets can be analyzed in a similar way.
 
 ## Data Preparation
 
 ### Format of `Dataset` File
 
-* (1) `datalab`: if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
-    you fortunately don't need to prepare the dataset. For example, you can examine the specific format organized in datalab by following commands:
+* (1) `datalab`: if your datasets have been supported by
+  [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets), you fortunately
+  don't need to prepare the dataset. For example, you can examine the specific format
+  organized in datalab by following commands:
 
     ```python
     from datalabs import load_dataset
@@ -23,7 +25,8 @@ can be analyzed in a similar way.
 
 ### Format of `System Output` File
 
-In order to perform analysis of your results, they should be in the following conll format:
+In order to perform analysis of your results, they should be in the following conll
+format:
 
 ```
 O O
@@ -58,9 +61,12 @@ explainaboard --task argument-pair-extraction --dataset ape --system-outputs ./d
 
 where
 
-* `--task`: denotes the task name, you can find all supported task names [here](https://github.com/neulab/ExplainaBoard/blob/main/docs/supported_tasks.md)
+* `--task`: denotes the task name, you can find all supported task names
+  [here](https://github.com/neulab/ExplainaBoard/blob/main/docs/supported_tasks.md)
 * `--system-outputs`: denote the path of system outputs. Multiple one should be
   separated by space, for example, system1 system2
 * `--dataset`: denotes the dataset name
-* `report.json`: the generated analysis file with json format. You can find the file [here](https://github.com/ExpressAI/ExplainaBoard/blob/main/data/reports/report.json). Tips: use a json viewer
-                  like [this one](http://jsonviewer.stack.hu/) for better interpretation.
+* `report.json`: the generated analysis file with json format. You can find the file
+  [here](https://github.com/ExpressAI/ExplainaBoard/blob/main/data/reports/report.json).
+  Tips: use a json viewer like [this one](http://jsonviewer.stack.hu/) for better
+  interpretation.

--- a/docs/task_argument_pair_identification.md
+++ b/docs/task_argument_pair_identification.md
@@ -1,12 +1,13 @@
 # Analyzing the Argument Pair Identification (API) Task
 
 In this file we describe how to analyze API models.
-We will give an example using the  [ape](https://github.com/ExpressAI/DataLab/blob/main/datasets/iapi/iapi.py) dataset, but other datasets
-can be analyzed in a similar way.
+We will give an example using the [ape](https://github.com/ExpressAI/DataLab/blob/main/datasets/iapi/iapi.py)
+dataset, but other datasets can be analyzed in a similar way.
 
 ## Data Preparation
 
-In order to perform analysis of your results, they should be in the following text format:
+In order to perform analysis of your results, they should be in the following text
+format:
 
 ```
 0
@@ -33,9 +34,12 @@ explainaboard --task argument-pair-identification --dataset iapi --system-output
 
 where
 
-* `--task`: denotes the task name, you can find all supported task names [here](https://github.com/neulab/ExplainaBoard/blob/main/docs/supported_tasks.md)
+* `--task`: denotes the task name, you can find all supported task names
+  [here](https://github.com/neulab/ExplainaBoard/blob/main/docs/supported_tasks.md)
 * `--system-outputs`: denote the path of system outputs. Multiple paths should be
   separated by a space, for example, system1 system2
 * `--dataset`: denotes the dataset name
-* `report.json`: the generated analysis file with json format. You can find the file [here](https://github.com/ExpressAI/ExplainaBoard/blob/main/data/reports/report.json). Tips: use a json viewer
-                  like [this one](http://jsonviewer.stack.hu/) for better interpretation.
+* `report.json`: the generated analysis file with json format. You can find the file
+  [here](https://github.com/ExpressAI/ExplainaBoard/blob/main/data/reports/report.json).
+  Tips: use a json viewer like [this one](http://jsonviewer.stack.hu/) for better
+  interpretation.

--- a/docs/task_aspect_based_sentiment_classification.md
+++ b/docs/task_aspect_based_sentiment_classification.md
@@ -4,17 +4,20 @@ Before diving into the detail of this doc, you're strongly recommended to know [
 important concepts about system analyses](concepts_about_system_analysis.md).
 
 In this file we describe how to analyze aspect-based sentiment classification models.
-We will give an example using the `aspect-based-sentiment-classification` [laptop](https://github.com/neulab/ExplainaBoard/blob/main/data/system_outputs/absa/test-aspect.tsv) dataset, but other datasets
-can be analyzed in a similar way.
+We will give an example using the `aspect-based-sentiment-classification`
+[laptop](https://github.com/neulab/ExplainaBoard/blob/main/data/system_outputs/absa/test-aspect.tsv)
+dataset, but other datasets can be analyzed in a similar way.
 
 ## Data Preparation
 
 ### Format of `Dataset` File
 
-* (1) `datalab`: if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
-    you fortunately don't need to prepare the dataset.
+* (1) `datalab`: if your datasets have been supported by
+  [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets), you fortunately
+  don't need to prepare the dataset.
 
-* (2) `tsv` (without column names at the first row), see one [example](https://github.com/neulab/ExplainaBoard/blob/main/data/system_outputs/absa/absa-dataset.tsv)
+* (2) `tsv` (without column names at the first row), see one
+  [example](https://github.com/neulab/ExplainaBoard/blob/main/data/system_outputs/absa/absa-dataset.tsv)
 
 ```python
 Boot time  Boot time  is super fast, around anywhere from 35 seconds to 1 minute. positive
@@ -24,7 +27,8 @@ Windows 8 Did not enjoy the new  Windows 8  and  touchscreen functions . negativ
 
 where the first 1st, 2nd, 3rd column represent aspect text, sentence and true label respectively.
 
-* (3) `json` (basically, it's a list of dictionaries with three keys: `aspect`, `text` and `true_label`)
+* (3) `json` (basically, it's a list of dictionaries with three keys: `aspect`, `text`
+  and `true_label`)
 
 ```json
 [
@@ -53,7 +57,7 @@ If your dataset exists in DataLab you can read it directly from there. However, 
 we will give an example of using a custom dataset, which takes this form:
 
 ```
-aspect \t sentence \t true_label 
+aspect \t sentence \t true_label
 ```
 
 In order to perform your basic analysis, we can run the following command:
@@ -64,8 +68,11 @@ explainaboard --task aspect-based-sentiment-classification --custom-dataset-path
 
 where
 
-* `--task`: denotes the task name, you can find all supported task names [here](https://github.com/neulab/ExplainaBoard/blob/main/docs/supported_tasks.md)
+* `--task`: denotes the task name, you can find all supported task names
+  [here](https://github.com/neulab/ExplainaBoard/blob/main/docs/supported_tasks.md)
 * `--system-outputs`: denote the path of system outputs. Multiple one should be
   separated by space, for example, system1 system2
-* `report.json`: the generated analysis file with json format. You can find the file [here](https://github.com/neulab/ExplainaBoard/blob/main/data/reports/report_absa.json). Tips: use a json viewer
-                  like [this one](http://jsonviewer.stack.hu/) for better interpretation.
+* `report.json`: the generated analysis file with json format. You can find the file
+  [here](https://github.com/neulab/ExplainaBoard/blob/main/data/reports/report_absa.json).
+  Tips: use a json viewer like [this one](http://jsonviewer.stack.hu/) for better
+  interpretation.

--- a/docs/task_conditional_generation.md
+++ b/docs/task_conditional_generation.md
@@ -3,15 +3,17 @@
 Before diving into the detail of this doc, you're strongly recommended to know [some
 important concepts about system analyses](concepts_about_system_analysis.md).
 
-Conditional text generation is a class of tasks where you generate text based on some conditioning context.
-This can include a wide variety of tasks, such as:
+Conditional text generation is a class of tasks where you generate text based on some
+conditioning context. This can include a wide variety of tasks, such as:
 
 * **Text Summarization:** generates a summary *y* given an input document *x*.
   An example dataset may be [CNN/Daily Mail](http://datalab.nlpedia.ai/#/normal_dataset/6176883933e51a7edda9dd68/dataset_metadata).
-* **Machine Translation:** generates a text *y* in one language given an input text *x* in another language.
+* **Machine Translation:** generates a text *y* in one language given an input text *x*
+  in another language.
   An example dataset may be the [TED Multilingual Dataset](https://huggingface.co/datasets/ted_multi).
-* **Code Generation:** generates a program *y* in a programming language such as Python given an input command *x* in natural language.
-  An example dataset may be the [CoNaLa](https://conala-corpus.github.io/) English to Python generation dataset.
+* **Code Generation:** generates a program *y* in a programming language such as Python
+  given an input command *x* in natural language. An example dataset may be the
+  [CoNaLa](https://conala-corpus.github.io/) English to Python generation dataset.
 
 ## Data Preparation
 
@@ -29,7 +31,8 @@ This is a good movie    这是一部好电影
 
 where the first column represents source text and the 2nd column denotes gold reference.
 
-* (3) `json` (basically, it's a list of dictionaries with two keys: `source` and `reference`)
+* (3) `json` (basically, it's a list of dictionaries with two keys: `source` and
+  `reference`)
 
 ```json
 [
@@ -46,17 +49,20 @@ In this task, your system outputs should be as follows:
 predicted_output_text
 ```
 
-Here is an example system output file for summarization on a subset of the CNN/Daily Mail articles:
+Here is an example system output file for summarization on a subset of the CNN/Daily
+Mail articles:
 
 * [cnndm_mini-bart-output.txt](https://github.com/neulab/ExplainaBoard/blob/main/data/system_outputs/cnndm/cnndm_mini-bart-output.txt)
 
-And here are two examples for machine translation from Slovak to English, an NMT and phrase-based MT system:
+And here are two examples for machine translation from Slovak to English, an NMT and
+phrase-based MT system:
 
 * [ted_multi_slk_eng-nmt-output.txt](https://github.com/neulab/ExplainaBoard/blob/main/data/system_outputs/ted_multi/ted_multi_slk_eng-nmt-output.txt)
 * [ted_multi_slk_eng-pbmt-output.txt](https://github.com/neulab/ExplainaBoard/blob/main/data/system_outputs/ted_multi/ted_multi_slk_eng-pbmt-output.txt)
 
-Here is an example output for code generation. Note that this is in JSON format, and specifically specifies Python as the output language.
-This is important so the code is tokenized properly during evaluation.
+Here is an example output for code generation. Note that this is in JSON format, and
+specifically specifies Python as the output language. This is important so the code is
+tokenized properly during evaluation.
 
 * [conala-baseline-output.json](https://github.com/neulab/ExplainaBoard/blob/main/data/system_outputs/conala/conala-baseline-output.json)
 
@@ -81,10 +87,11 @@ explainaboard --task summarization --dataset cnn_dailymail --system-outputs ./da
 * `--system-outputs`: denote the path of system outputs. Multiple one should be
   separated by space, for example, system1 system2
 * `--dataset`: optional, denotes the dataset name
-* `--metrics`: optional, different metrics should be separated by space. See [more supported metrics](https://github.com/neulab/ExplainaBoard/blob/main/docs/supported_tasks.md#summarization)
-* `report.json`: the generated analysis file with json format. Tips: you can use a json viewer
-  like [this one](http://jsonviewer.stack.hu/) or Python's `python -m json.tool` to convert
-  the JSON into a prettified and readable format.
+* `--metrics`: optional, different metrics should be separated by space. See
+  [more supported metrics](https://github.com/neulab/ExplainaBoard/blob/main/docs/supported_tasks.md#summarization)
+* `report.json`: the generated analysis file with json format. Tips: you can use a json
+  viewer like [this one](http://jsonviewer.stack.hu/) or Python's `python -m json.tool`
+  to convert the JSON into a prettified and readable format.
 
 In addition, you can use a custom dataset, in which case the format should be
 
@@ -102,7 +109,8 @@ explainaboard --task summarization --custom-dataset-paths ./data/system_outputs/
 
 ### Machine Translation
 
-Try it out for translation as below. The examples use a custom dataset that is not included in DataLab at the moment.
+Try it out for translation as below. The examples use a custom dataset that is not
+included in DataLab at the moment.
 
 ```shell
 explainaboard --task machine-translation --custom-dataset-paths ./data/system_outputs/ted_multi/ted_multi_slk_eng-dataset.tsv --system-outputs ./data/system_outputs/ted_multi/ted_multi_slk_eng-nmt-output.txt --metrics bleu comet
@@ -110,7 +118,10 @@ explainaboard --task machine-translation --custom-dataset-paths ./data/system_ou
 
 Note 1: The number of `--custom-dataset-paths` need to match the number of `system-outputs`
 
-Note 2: If you want to perform **pair-wise analysis** for two system outputs on the same reference, you can pass in the paths separated by space, for example, `--system-outputs system1 system2`. Please also pass in the same paths twice for `--custom-dataset-paths`, for example, `--custom-dataset-paths path1 path1`.
+Note 2: If you want to perform **pair-wise analysis** for two system outputs on the same
+reference, you can pass in the paths separated by space, for example,
+`--system-outputs system1 system2`. Please also pass in the same paths twice for
+`--custom-dataset-paths`, for example, `--custom-dataset-paths path1 path1`.
 
 ### Code Generation
 
@@ -136,4 +147,5 @@ for this  task. If you'd like help with this, feel free to open an issue!
 
 **Multi-document Summarization:** ExplainaBoard supports single-document summarization
 and text compression, but not multi-document summarization or other similar tasks like
-retrieval-based QA.  We would welcome help with adding support for this, so similarly open an issue!
+retrieval-based QA.  We would welcome help with adding support for this, so similarly
+open an issue!

--- a/docs/task_extractive_qa.md
+++ b/docs/task_extractive_qa.md
@@ -3,17 +3,19 @@
 Before diving into the detail of this doc, you're strongly recommended to know [some
 important concepts about system analyses](concepts_about_system_analysis.md).
 
-In this file we describe how to analyze models trained on extractive QA datasets, for example
-[`squad`](http://datalab.nlpedia.ai/#/normal_dataset/6163a29beb9872f33252b01b/dataset_samples).
+In this file we describe how to analyze models trained on extractive QA datasets, for
+example [`squad`](http://datalab.nlpedia.ai/#/normal_dataset/6163a29beb9872f33252b01b/dataset_samples).
 
 ## Data Preparation
 
 ### Format of `Dataset` File
 
-* (1) `datalab`: if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
-    you fortunately don't need to prepare the dataset.
+* (1) `datalab`: if your datasets have been supported by
+  [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets), you fortunately
+  don't need to prepare the dataset.
 
-* (2) `json` (basically, it's a list of dictionaries with three keys: `context`, `question`, and `answers`)
+* (2) `json` (basically, it's a list of dictionaries with three keys: `context`,
+  `question`, and `answers`)
 
 ```json
 [
@@ -45,7 +47,10 @@ An example system output file is here:
 
 ## Performing Basic Analysis
 
-The below example loads the `squad` dataset from DataLab. There is an [open issue](https://github.com/neulab/ExplainaBoard/issues/239) that prevents the specification of a dataset split, so this will not work at the moment. But we are working on it.
+The below example loads the `squad` dataset from DataLab. There is an
+[open issue](https://github.com/neulab/ExplainaBoard/issues/239) that prevents the
+specification of a dataset split, so this will not work at the moment. But we are
+working on it.
 
 ```shell
 explainaboard --task qa-extractive --dataset squad --system-outputs MY_FILE > report.json

--- a/docs/task_grammatical_error_correction.md
+++ b/docs/task_grammatical_error_correction.md
@@ -3,8 +3,10 @@
 Before diving into the detail of this doc, you're strongly recommended to know [some
 important concepts about system analyses](concepts_about_system_analysis.md).
 
-Grammatical error correction is the task of correcting different kinds of errors in text, such as spelling errors. If you're interested in how datasets for this task look like, you can
-perform the following command after installing [`DataLab`](https://github.com/ExpressAI/DataLab#installation)
+Grammatical error correction is the task of correcting different kinds of errors in
+text, such as spelling errors. If you're interested in how datasets for this task look
+like, you can perform the following command after installing
+[`DataLab`](https://github.com/ExpressAI/DataLab#installation)
 
 ```python
 from datalabs import load_dataset
@@ -18,13 +20,14 @@ In what follows, we will describe how to analyze grammatical error correction sy
 
 ### Format of `Dataset` File
 
-* (1) `datalab`: if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
-    you fortunately don't need to prepare the dataset.
+* (1) `datalab`: if your datasets have been supported by
+  [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets), you fortunately
+  don't need to prepare the dataset.
 
 ### Format of `System Output` File
 
-In order to perform an analysis of your results, your system outputs should be arranged into following
-format:
+In order to perform an analysis of your results, your system outputs should be arranged
+into following format:
 
 ```
 [
@@ -45,9 +48,10 @@ format:
 
 where
 
-* the `len(start_idx) == len(end_idx) == len(corrections)`, representing how many corrections your
-your systems think should be made
-* the combination of start_idx and end_idx (e.g., (`start_idx[i]`, `end_idx[i]`)) tells the where should be corrected in the original text.
+* the `len(start_idx) == len(end_idx) == len(corrections)`, representing how many
+  corrections your systems think should be made
+* the combination of start_idx and end_idx (e.g., (`start_idx[i]`, `end_idx[i]`)) tells
+  the where should be corrected in the original text.
 * the value of corrections (`corrections[i]`) tells what correction should be made
 
 ## Performing Basic Analysis
@@ -56,7 +60,8 @@ Let's say we have one system output file:
 
 * [rst_2018_quanguojuan1_gec.json](https://github.com/neulab/ExplainaBoard/TBC)
 
-The below example loads the `gaokao2018_np1` dataset (with the subdataset name of `writing-grammar`) from DataLab:
+The below example loads the `gaokao2018_np1` dataset (with the subdataset name of
+`writing-grammar`) from DataLab:
 
 ```shell
 explainaboard --task grammatical-error-correction --dataset gaokao2018_np1 --sub-dataset writing-grammar --metrics SeqCorrectScore --system-outputs ./integration_tests/artifacts/gaokao/rst_2018_quanguojuan1_gec.json > report.json
@@ -64,7 +69,8 @@ explainaboard --task grammatical-error-correction --dataset gaokao2018_np1 --sub
 
 where
 
-* `--task`: denotes the task name, you can find all supported task names [here](https://github.com/neulab/ExplainaBoard/blob/main/docs/cli_interface.md)
+* `--task`: denotes the task name, you can find all supported task names
+  [here](https://github.com/neulab/ExplainaBoard/blob/main/docs/cli_interface.md)
 * `--system-outputs`: denote the path of system outputs. Multiple one should be
   separated by space, for example, system1 system2
 * `--dataset`: denotes the dataset name

--- a/docs/task_kg_link_tail_prediction.md
+++ b/docs/task_kg_link_tail_prediction.md
@@ -3,8 +3,8 @@
 Before diving into the detail of this doc, you're strongly recommended to know [some
 important concepts about system analyses](concepts_about_system_analysis.md).
 
-In this file we describe how to analyze models trained to predict the tail entity on knowledge graph link prediction tasks, for example
-[`fb15k-237`](https://www.microsoft.com/en-us/download/details.aspx?id=52312).
+In this file we describe how to analyze models trained to predict the tail entity on
+knowledge graph link prediction tasks, for example [`fb15k-237`](https://www.microsoft.com/en-us/download/details.aspx?id=52312).
 
 ## Outline
 
@@ -70,7 +70,7 @@ In this task, your system outputs should be as follows:
         "true_rank": 23,
     },
     ...
-    
+
 ]
 ```
 
@@ -79,7 +79,8 @@ where
 * `gold_head`: true head entity
 * `gold_predicate`: true relation
 * `gold_tail`: true tail entity
-* `predict`: it suggest what type of information (e.g., `head`, `predicate`, `tail`) will be predicted
+* `predict`: it suggest what type of information (e.g., `head`, `predicate`, `tail`)
+  will be predicted
 * `predictions`: a list of predictions
 
 Let's say we have one system output file:
@@ -102,7 +103,8 @@ where
 * `--system-outputs`: denote the path of system outputs. Multiple one should be
   separated by space, for example, system1 system2
 * `--dataset`:optional, denotes the dataset name
-* `report.json`: the generated analysis file with json format. Tips: use a json viewer like [`this one`](http://jsonviewer.stack.hu/) for better interpretation.
+* `report.json`: the generated analysis file with json format. Tips: use a json viewer
+  like [`this one`](http://jsonviewer.stack.hu/) for better interpretation.
 
 If the dataset has been supported by [`DataLab`](https://github.com/ExpressAI/DataLab/tree/main/datasets),
 you could also run (the advantage is that more bucketing features will be supported):
@@ -124,9 +126,10 @@ the above one [here](https://datalab-hub.s3.amazonaws.com/predictions/test_distm
 
 ### Visualization Locally
 
-Once the above command has been successfully conducted, histogram figures will be generated automatically in the folder
-`./output/figures/test-kg-prediction-no-user-defined-new/`, where each figure represent a fine-grained evaluation
-results along one features (e.g., relation type).
+Once the above command has been successfully conducted, histogram figures will be
+generated automatically in the folder
+`./output/figures/test-kg-prediction-no-user-defined-new/`, where each figure represent
+a fine-grained evaluation results along one features (e.g., relation type).
 
 We have carefully designed and beautified these figures which
 could be directly applied for paper writing as needed.
@@ -139,7 +142,11 @@ One example is shown below,
 
 ### Data Preparation
 
-ExplainaBoard also allows users to customize features, specifically to provide your own bucketing features, submit a system output containing a declaration of your user-defined features (their names, data types, and number of buckets), along with your predictions on test examples. Make sure each test example contains a key for each feature defined in your configuration. Refer to the following example:
+ExplainaBoard also allows users to customize features, specifically to provide your own
+bucketing features, submit a system output containing a declaration of your user-defined
+features (their names, data types, and number of buckets), along with your predictions
+on test examples. Make sure each test example contains a key for each feature defined in
+your configuration. Refer to the following example:
 
 ```json
 {
@@ -186,11 +193,15 @@ ExplainaBoard also allows users to customize features, specifically to provide y
 }
 ```
 
-Note that you must provide the rank of the true entity in the predictions, for all examples in your system output, in 1-indexed fashion. This is to allow ExplainaBoard to calculate accurate `MeanRank` and `MeanReciprocalRank` metrics when the true entity is not contained in the predictions you provide in the system outputs.
+Note that you must provide the rank of the true entity in the predictions, for all
+examples in your system output, in 1-indexed fashion. This is to allow ExplainaBoard to
+calculate accurate `MeanRank` and `MeanReciprocalRank` metrics when the true entity is
+not contained in the predictions you provide in the system outputs.
 
 ### Perform Analysis with CLI
 
-An example system output is [provided](https://github.com/neulab/ExplainaBoard/blob/main/integration_tests/artifacts/test-kg-prediction-user-defined.json), and you can test it using the following command:
+An example system output is [provided](https://github.com/neulab/ExplainaBoard/blob/main/integration_tests/artifacts/test-kg-prediction-user-defined.json),
+and you can test it using the following command:
 
 ```shell
 explainaboard --task kg-link-tail-prediction --custom-dataset-paths ./data/system_outputs/fb15k-237/data_mini.json --system-outputs ./data/system_outputs/fb15k-237/test-kg-prediction-no-user-defined-new.json > report.json
@@ -256,19 +267,28 @@ sys_info = processor.process(metadata, data.samples)
 The options for the `"sort_by"` option are:
 
 1. `"key"` (default): sort by the bucket's lower boundary, alphabetically, low-to-high.
-2. `"performance_value"`: sort by bucket performance. Since each bucket has multiple metrics associated with it, use the `"sort_by_metric"` to choose which metric to sort on.
+2. `"performance_value"`: sort by bucket performance. Since each bucket has multiple
+   metrics associated with it, use the `"sort_by_metric"` to choose which metric to sort
+   on.
 3. `"n_bucket_samples"`, sort by the number of samples in each bucket.
 
-The `"sort_by_metric"` option is applicable when the `"sort_by"` option is set to `"performance_value"`. The options for the `"sort_by_metric"` option are `"Hits"`, `"MR"`, `"MRR"`, etc: sort by a specific metric name. These names refer to the `metric_name` keyword in your metric definitions (i.e. what you pass into the `"metric_configs"` key in the `metadata` dictionary).
+The `"sort_by_metric"` option is applicable when the `"sort_by"` option is set to
+`"performance_value"`. The options for the `"sort_by_metric"` option are `"Hits"`,
+`"MR"`, `"MRR"`, etc: sort by a specific metric name. These names refer to the
+`metric_name` keyword in your metric definitions (i.e. what you pass into the
+`"metric_configs"` key in the `metadata` dictionary).
 
-The `"sort_by_metric"` option is applicable when the `"sort_by"` option is set to `"performance_value"`. The options for the `"sort_ascending"` option are:
+The `"sort_by_metric"` option is applicable when the `"sort_by"` option is set to
+`"performance_value"`. The options for the `"sort_ascending"` option are:
 
 1. `False` (default): sort high-to-low.
 2. `True`: sort low-to-high; useful for e.g. the `"MeanRank"` metric.
 
 ### Customized Hits K
 
-The value of K in `Hits` metric could also be specified by users when needed. Below is an example of how to use this configuration while performing bucket sorting by the custom metric:
+The value of K in `Hits` metric could also be specified by users when needed. Below is
+an example of how to use this configuration while performing bucket sorting by the
+custom metric:
 
 ```python
 from explainaboard import TaskType, get_loader_class, get_processor_class
@@ -291,7 +311,8 @@ metadata = {
     MeanRankConfig(name='MR'),
   ],
   "sort_by": "performance_value",
-  # or "key" to sort alphabetically by bucket lower boundary, or "n_bucket_samples" to sort by bucket size
+  # or "key" to sort alphabetically by bucket lower boundary, or "n_bucket_samples" to
+  # sort by bucket size
   "sort_by_metric": "Hits3",  # specifies the metric to sort by
   "sort_ascending": False,  # set True when sorting by MeanRank metric
 }
@@ -331,8 +352,8 @@ sys_info = processor.process(metadata, data.samples)
 
 ### Record Other System Detailed Information
 
-The basic idea is that users can specify other system-related information (e.g., hyper-parameters)
-via adding a key-value into `metadata`
+The basic idea is that users can specify other system-related information
+(e.g., hyper-parameters) via adding a key-value into `metadata`
 
 ```python
 metadata = {
@@ -342,11 +363,13 @@ metadata = {
 }
 ```
 
-[Here](https://github.com/neulab/ExplainaBoard/blob/main/integration_tests/test_system_details.py) is a complete code.
+[Here](https://github.com/neulab/ExplainaBoard/blob/main/integration_tests/test_system_details.py)
+is a complete code.
 
 ### Meta/Quantitative Analysis
 
-A preliminary version of the rank-flipping quantitative analysis has been implemented. Example code:
+A preliminary version of the rank-flipping quantitative analysis has been implemented.
+Example code:
 
 ```python
 from explainaboard import RankFlippingMetaAnalysis, TaskType, get_custom_dataset_loader, get_processor_class
@@ -373,7 +396,7 @@ model2_report = processor.process(metadata={'custom_features': data.metadata.cus
 
 # meta-analysis
 meta_analysis = RankFlippingMetaAnalysis(
-    model1_report = model1_report, 
+    model1_report = model1_report,
     model2_report = model2_report
 )
 meta_analysis_results = meta_analysis.run_meta_analysis()
@@ -410,7 +433,7 @@ model2_report = processor.process(metadata={'custom_features': data.metadata.cus
 # meta-analysis
 meta_analysis = RankingMetaAnalysis(
     model_reports = {
-        'rotate':    model1_report, 
+        'rotate':    model1_report,
         'rescal':    model2_report,
         'conve':     model3_report,
         'distmult':  model4_report,

--- a/docs/task_knowledge_graph.md
+++ b/docs/task_knowledge_graph.md
@@ -1,7 +1,7 @@
 # Analysis Example: Knowledge Graph Task
 
-This doc walks through how knowledge graph-based tasks are evaluated interactively using ExplainaBoard
-web application.
+This doc walks through how knowledge graph-based tasks are evaluated interactively using
+ExplainaBoard web application.
 
 ## Prerequisite Docs
 

--- a/docs/task_meta_evaluation.md
+++ b/docs/task_meta_evaluation.md
@@ -23,7 +23,8 @@ We have an example dataset file:
 
 More dataset files can be found at [WMT-DA-20](https://drive.google.com/drive/u/0/folders/1JXpo0yxPLYlNgLbOfP1bzs9z6SOx76Wo).
 
-In order to perform analysis of your results, your system outputs should be a one-column score (the score your metric predicts for the particular example):
+In order to perform analysis of your results, your system outputs should be a one-column
+score (the score your metric predicts for the particular example):
 
 ```
 systemScore1

--- a/docs/task_qa_multiple_choice.md
+++ b/docs/task_qa_multiple_choice.md
@@ -4,8 +4,9 @@ Before diving into the detail of this doc, you're strongly recommended to know [
 important concepts about system analyses](concepts_about_system_analysis.md).
 
 In this file we describe how to analyze multiple-choice QA models.
-We will give an example using the  [fig_qa](http://datalab.nlpedia.ai/normal_dataset/62139f3dc5fa557614d36df2/dataset_metadata) dataset, but other datasets
-can be analyzed in a similar way.
+We will give an example using the
+[fig_qa](http://datalab.nlpedia.ai/normal_dataset/62139f3dc5fa557614d36df2/dataset_metadata)
+dataset, but other datasets can be analyzed in a similar way.
 
 ## Data Preparation
 
@@ -83,8 +84,10 @@ where
 * `--system-outputs`: denote the path of system outputs. Multiple one should be
   separated by space, for example, system1 system2
 * `--dataset`:optional, denotes the dataset name
-* `report.json`: the generated analysis file with json format. You can find the file [here](https://github.com/ExpressAI/ExplainaBoard/blob/main/data/reports/report.json). Tips: use a json viewer
-                  like [this one](http://jsonviewer.stack.hu/) for better interpretation.
+* `report.json`: the generated analysis file with json format. You can find the file
+  [here](https://github.com/ExpressAI/ExplainaBoard/blob/main/data/reports/report.json).
+  Tips: use a json viewer like [this one](http://jsonviewer.stack.hu/) for better
+  interpretation.
 
 Now let's look at the results to see what sort of interesting insights we can
 glean from them.
@@ -101,5 +104,6 @@ explainaboard --task qa-multiple-choice --system-outputs model_1 model_2 > repor
 
 where two system outputs are fed separated by space.
 
-* `report.json`: the generated analysis file with json format, whose schema is similar to the above one with single system evaluation except that
-   all performance values are obtained using the sys1 subtract sys2.
+* `report.json`: the generated analysis file with json format, whose schema is similar
+   to the above one with single system evaluation except that all performance values are
+   obtained using the sys1 subtract sys2.

--- a/docs/task_qa_open_domain.md
+++ b/docs/task_qa_open_domain.md
@@ -4,8 +4,8 @@ Before diving into the detail of this doc, you're strongly recommended to know [
 important concepts about system analyses](concepts_about_system_analysis.md).
 
 In this file we describe how to analyze open-domain QA models.
-We will give an example using the  [natural_questions_comp_gen](https://github.com/ExpressAI/DataLab/blob/main/datasets/natural_questions_comp_gen/natural_questions_comp_gen.py) dataset, but other datasets
-can be analyzed in a similar way.
+We will give an example using the [natural_questions_comp_gen](https://github.com/ExpressAI/DataLab/blob/main/datasets/natural_questions_comp_gen/natural_questions_comp_gen.py)
+dataset, but other datasets can be analyzed in a similar way.
 
 ## Data Preparation
 
@@ -53,9 +53,12 @@ explainaboard --task qa-open-domain --dataset natural_questions_comp_gen   --sys
 
 where
 
-* `--task`: denotes the task name, you can find all supported task names [here](https://github.com/neulab/ExplainaBoard/blob/main/docs/supported_tasks.md)
+* `--task`: denotes the task name, you can find all supported task names
+  [here](https://github.com/neulab/ExplainaBoard/blob/main/docs/supported_tasks.md)
 * `--system-outputs`: denote the path of system outputs. Multiple one should be
   separated by space, for example, system1 system2
 * `--dataset`:denotes the dataset name
-* `report.json`: the generated analysis file with json format. You can find the file [here](https://github.com/ExpressAI/ExplainaBoard/blob/main/data/reports/report.json). Tips: use a json viewer
-                  like [this one](http://jsonviewer.stack.hu/) for better interpretation.
+* `report.json`: the generated analysis file with json format. You can find the file
+  [here](https://github.com/ExpressAI/ExplainaBoard/blob/main/data/reports/report.json).
+  Tips: use a json viewer like [this one](http://jsonviewer.stack.hu/) for better
+  interpretation.

--- a/docs/task_qa_table_text_hybrid.md
+++ b/docs/task_qa_table_text_hybrid.md
@@ -49,9 +49,12 @@ explainaboard --task qa-tat --output-file-type json --dataset tat_qa --system-ou
 
 where
 
-* `--task`: denotes the task name, you can find all supported task names [here](https://github.com/neulab/ExplainaBoard/blob/main/docs/supported_tasks.md)
+* `--task`: denotes the task name, you can find all supported task names
+  [here](https://github.com/neulab/ExplainaBoard/blob/main/docs/supported_tasks.md)
 * `--system-outputs`: denote the path of system outputs. Multiple one should be
   separated by space, for example, system1 system2
 * `--dataset`:denotes the dataset name
-* `report.json`: the generated analysis file with json format. You can find the file [here](https://github.com/ExpressAI/ExplainaBoard/blob/main/data/reports/report.json). Tips: use a json viewer
-                  like [this one](http://jsonviewer.stack.hu/) for better interpretation.
+* `report.json`: the generated analysis file with json format. You can find the file
+  [here](https://github.com/ExpressAI/ExplainaBoard/blob/main/data/reports/report.json).
+  Tips: use a json viewer like [this one](http://jsonviewer.stack.hu/) for better
+  interpretation.

--- a/docs/task_text_classification.md
+++ b/docs/task_text_classification.md
@@ -4,17 +4,20 @@ Before diving into the detail of this doc, you're strongly recommended to know [
 important concepts about system analyses](concepts_about_system_analysis.md).
 
 In this file we describe how to analyze text classification models.
-We will give an example using the `text-classification` [sst2](https://github.com/ExpressAI/ExplainaBoard/tree/main/data/datasets/sst2) dataset, but other datasets
-can be analyzed in a similar way.
+We will give an example using the `text-classification`
+[sst2](https://github.com/ExpressAI/ExplainaBoard/tree/main/data/datasets/sst2) dataset,
+but other datasets can be analyzed in a similar way.
 
 ## Data Preparation
 
 ### Format of `Dataset` File
 
-* (1) `datalab`: if your datasets have been supported by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
-    you fortunately don't need to prepare the dataset.
-  
-* (2) `tsv` (without column names at the first row), see one [example](https://github.com/neulab/ExplainaBoard/blob/main/data/system_outputs/sst2/sst2-dataset.tsv)
+* (1) `datalab`: if your datasets have been supported by
+  [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets), you fortunately
+  don't need to prepare the dataset.
+
+* (2) `tsv` (without column names at the first row), see one
+  [example](https://github.com/neulab/ExplainaBoard/blob/main/data/system_outputs/sst2/sst2-dataset.tsv)
 
 ```python
 I love this movie   positive
@@ -57,7 +60,8 @@ explainaboard --task text-classification --dataset sst2 --system-outputs ./data/
 
 where
 
-* `--task`: denotes the task name, you can find all supported task names [here](https://github.com/neulab/ExplainaBoard/blob/main/docs/cli_interface.md)
+* `--task`: denotes the task name, you can find all supported task names
+  [here](https://github.com/neulab/ExplainaBoard/blob/main/docs/cli_interface.md)
 * `--system-outputs`: denote the path of system outputs. Multiple one should be
   separated by space, for example, system1 system2
 * `--dataset`: denotes the dataset name

--- a/docs/task_text_pair_classification.md
+++ b/docs/task_text_pair_classification.md
@@ -23,7 +23,8 @@ A man playing an electric guitar on stage.   A man is performing for cash.  neut
 ...
 ```
 
-* (3) `json` (basically, it's a list of dictionaries with three keys: `text1`, `text2` and `true_label`)
+* (3) `json` (basically, it's a list of dictionaries with three keys: `text1`, `text2`
+  and `true_label`)
 
 ```json
 [

--- a/docs/web/how_to_make_a_submission.md
+++ b/docs/web/how_to_make_a_submission.md
@@ -3,7 +3,8 @@
 ## Step 1: Sign in and login in
 
 You first need to register an ExplainaBoard account [here](https://explainaboard.inspiredco.ai/).
-(Notably: you don't need to have an account if you just aim to browse some public system results or leaderboard.)
+(Notably: you don't need to have an account if you just aim to browse some public system
+ results or leaderboard.)
 
 ## Step 2: Choose the `Systems` bar and click the `New` button
 
@@ -20,12 +21,19 @@ You first need to register an ExplainaBoard account [here](https://explainaboard
 
 In this form, you need to fill out the following information
 
-* `System Name`: the name of your system (an intuitive and unique name is recommended, for example, `qa_bert_small`)
-* `Task`: select one task that ExplainaBoard supports now. (If your task is not supported yet, you can make an issue
-at [the ExplainaBoard SDK repo](https://github.com/neulab/ExplainaBoard) or contribute by [adding a new task](https://github.com/neulab/ExplainaBoard/blob/main/docs/add_new_tasks.md))
-* `Use custom dataset`: If your system predictions are run based on a dataset that is not supported by ExplainaBoard,
-you need to choose `use custom dataset?` and upload the test set of your dataset. You can find examples of the required format for each task in our [command-line interface examples](https://github.com/neulab/ExplainaBoard/blob/main/docs/cli_interface.md). Otherwise, you just need to choose a dataset from the `Dataset` check box.
+* `System Name`: the name of your system (an intuitive and unique name is recommended,
+  for example, `qa_bert_small`)
+* `Task`: select one task that ExplainaBoard supports now. (If your task is not
+  supported yet, you can make an issue at
+  [the ExplainaBoard SDK repo](https://github.com/neulab/ExplainaBoard) or contribute by
+  [adding a new task](https://github.com/neulab/ExplainaBoard/blob/main/docs/add_new_tasks.md))
+* `Use custom dataset`: If your system predictions are run based on a dataset that is
+  not supported by ExplainaBoard, you need to choose `use custom dataset?` and upload
+  the test set of your dataset. You can find examples of the required format for each
+  task in our [command-line interface examples](https://github.com/neulab/ExplainaBoard/blob/main/docs/cli_interface.md).
+  Otherwise, you just need to choose a dataset from the `Dataset` check box.
 * `Dataset`: Select a dataset that's supported by ExplainaBoard.
 * `Metrics`: Select evaluation metrics
-* `Make it private?`: If chosen, system outputs together with analysis report can only be observed privately. Otherwise, it will be open to the world.
+* `Make it private?`: If chosen, system outputs together with analysis report can only
+  be observed privately. Otherwise, it will be open to the world.
 * `Source code link:` Optional

--- a/docs/web/how_to_make_interactive_evaluation.md
+++ b/docs/web/how_to_make_interactive_evaluation.md
@@ -11,7 +11,9 @@ into different categories based on some pre-defined features.
 For example, according the the text sample's length, system performance could
 be grouped into 4 buckets: [2,12], [13,18], [19,24], [25,52].
 
-If you are interested in more details, [Liu et al.2021](https://aclanthology.org/2021.acl-demo.34.pdf), [Fu et al.2020](http://aclanthology.lst.uni-saarland.de/2020.emnlp-main.489.pdf) are highly recommended.
+If you are interested in more details, [Liu et al.2021](https://aclanthology.org/2021.acl-demo.34.pdf),
+[Fu et al.2020](http://aclanthology.lst.uni-saarland.de/2020.emnlp-main.489.pdf) are
+highly recommended.
 
 When using ExplainaBoard Web, users can customize the number
 of buckets. For example:


### PR DESCRIPTION
Part of #536. This PR re-enables the disabled rule [MD013](https://github.com/markdownlint/markdownlint/blob/main/docs/RULES.md#md013---line-length), and wraps Markdown texts at 88 columns. 

Closes #536.