### PR TITLE
Add temporary fix to MetaEvalNLGCITest to fix flakiness

### DIFF
--- a/integration_tests/meta_eval_wmt_da_test.py
+++ b/integration_tests/meta_eval_wmt_da_test.py
@@ -188,8 +188,11 @@ class MetaEvalNLGCITest(unittest.TestCase):
         ci: tuple[float, float] = unwrap(
             corr_metric.calc_confidence_interval(stats, 0.05)
         )
-        self.assertAlmostEqual(ci[0], 0.6488, 2)
-        self.assertAlmostEqual(ci[1], 0.8999, 2)
+        # TODO: This check could be made more rigorous by checking whether the
+        #       confidence interval lies within a reasonable range
+        # See https://github.com/neulab/ExplainaBoard/issues/537
+        self.assertGreater(val, ci[0])
+        self.assertGreater(ci[1], val)
 
     def test_system_level_spearmanr_bootstrap(self) -> None:
 
@@ -205,8 +208,11 @@ class MetaEvalNLGCITest(unittest.TestCase):
         ci: tuple[float, float] = unwrap(
             corr_metric.calc_confidence_interval(stats, 0.05)
         )
-        self.assertAlmostEqual(ci[0], 0.5642, 2)
-        self.assertAlmostEqual(ci[1], 0.9746, 2)
+        # TODO: This check could be made more rigorous by checking whether the
+        #       confidence interval lies within a reasonable range
+        # See https://github.com/neulab/ExplainaBoard/issues/537
+        self.assertGreater(val, ci[0])
+        self.assertGreater(ci[1], val)
 
     def test_dataset_level_spearmanr_bootstrap(self) -> None:
 


### PR DESCRIPTION
This PR adds a workaround to fix the flakiness of `MetaEvalNLGCITest` as discussed in #537. The code change is cherry-picked from #532 (including suggestions by @neubig) because other pull requests get affected by the flakiness and because #532 is still in review.