### PR TITLE
Set the time limit for integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
           python -m nltk.downloader punkt
       - name: test
         run: bash cicd/run_integration_tests.sh
+        timeout-minutes: 30
   format:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Sometimes integration tests are taking more than 1 hour ([example](https://github.com/neulab/ExplainaBoard/actions/runs/3214414670)). That's a symptom that there is something wrong with 
ExplainaBoard, resources ExplainaBoard fetches for testing, or ExplainaBoard's dependencies. The fact that the tests are taking time is not economical, and becomes a drain on productivity. We should set the time limit for the tests, and raise a timeout error if the tests exceed the time limit to prevent the tests from getting slower and slower. This PR explicitly sets the time limit of 30 minutes for the step to run integration tests. The default setting is [360 minutes](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idtimeout-minutes), which is too long.
