### PR TITLE
file format doc with existing examples

### DIFF
--- a/docs/add_new_tasks.md
+++ b/docs/add_new_tasks.md
@@ -151,8 +151,20 @@ For example, the following information can be added for text classification task
     ),
 ```
 
-## Finally, create a Unittest module for your task
+## Create a Unittest module for your task
 
 (1) Create a new python file `test_text_classification.py` in the folder `integration_tests/`
 
 (2) Implement unit tests for this task referencing that of other similar tasks
+
+## Finally, add documentation for your task
+
+(1) Create a documentation `task_<your_task>.md` in the `docs` folder which should include
+    information like task description, file formats, analysis options and etc.
+    Here is an [example](./task_text_classification.md).
+
+(2) Supplement [task_file_formats.md](./task_file_formats.md)
+    with your task doc and example files.
+
+(3) Supplement [cli_interface.md](./cli_interface.md)
+    with your task description and CLI examples.

--- a/docs/task_file_format_summarization.md
+++ b/docs/task_file_format_summarization.md
@@ -1,0 +1,59 @@
+# File Formats Supported by Different Tasks
+
+Here is the list of the file formats supported by different tasks.
+
+For dataset files, if your datasets have been supported
+by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
+you fortunately don't need to prepare the dataset.
+Otherwise, you can upload your custom datasets in the supported formats.
+
+You may refer to the example files for more specific formats,
+    or click on the task link for more explanation.
+
+To upload custom features and analysis, please refer to this [instruction](./add_custom_features.md).
+
+| Task                | File Type   | File Format | Example File |
+|---------------------|-------------|-------------|--------------|
+| [conditional generation (machine translation/summarization)](./task_conditional_generation.md) | dataset | TSV | [cnndm_mini-dataset.tsv](../data/system_outputs/cnndm/cnndm_mini-dataset.tsv) |
+|                     |        | JSON | [conala-dataset.json](../data/system_outputs/conala/conala-dataset.json) |
+|                     | output | JSON | [conala-baseline-output.json](../data/system_outputs/conala/conala-baseline-output.json) |
+|                     |        | TXT | [cnndm_mini-bart-output.txt](../data/system_outputs/cnndm/cnndm_mini-bart-output.txt) |
+| [text classification](./task_text_classification.md) | dataset | TSV | [sst2-dataset.tsv](../data/system_outputs/sst2/sst2-dataset.tsv) |
+|                     |        | JSON | [text-classification-dataset.json](../integration_tests/artifacts/text_classification/dataset.json) |
+|                     | output | JSON | [text-classification-output.json](../integration_tests/artifacts/text_classification/output_user_metadata.json) |
+|                     |        | TXT | [sst2-lstm-output.txt](../data/system_outputs/sst2/sst2-lstm-output.txt) |
+| sequence labeling (NER/word segmentation/chunking) | dataset | CoNLL | [conll2003-dataset.conll](../data/system_outputs/conll2003/conll2003-dataset.conll) |
+|                     | output | CoNLL | [conll2003-elmo-output.conll](../data/system_outputs/conll2003/conll2003-elmo-output.conll) |
+|                     |        | JSON | |
+| cloze multiple choice | dataset | JSON |  |
+|                     | output | JSON |  |
+| cloze generative | dataset | JSON |  |
+|                     | output | JSON |  |
+| [QA (extractive)](./task_extractive_qa.md) | dataset | JSON | [squad_mini-dataset.json](../data/system_outputs/squad/squad_mini-dataset.json) |
+|                     | output | JSON | [squad_mini-example-output.json](../data/system_outputs/squad/squad_mini-example-output.json) |
+| [QA (MCQ)](./task_qa_multiple_choice.md) | dataset | JSON | [fig_qa-dataset.json](../data/system_outputs/fig_qa/fig_qa-dataset.json) |
+|                     | output | JSON | [fig_qa-bert-output.json](../data/system_outputs/fig_qa/fig_qa-bert-output.json) |
+| [QA (open domain)](./task_qa_open_domain.md) | dataset | JSON | |
+|                     | output | TXT | [test.dpr.nq.txt](../data/system_outputs/qa_open_domain/test.dpr.nq.txt) |
+| [aspect-based sentiment analysis](./task_aspect_based_sentiment_classification.md) | dataset | TSV | [absa-dataset.tsv](../data/system_outputs/absa/absa-dataset.tsv) |
+|                     |        | JSON | |
+|                     | output | JSON | [absa-example-output-confidence.json](../data/system_outputs/absa/absa-example-output-confidence.json) |
+|                     |        | TXT | [absa-example-output.txt](../data/system_outputs/absa/absa-example-output.txt) |
+| [grammatical error correction](./task_grammatical_error_correction.md) | dataset | JSON |  |
+|                     | output | JSON |  |
+| [text pair classification](./task_text_pair_classification.md) | dataset | TSV | [snli-dataset.tsv](../data/system_outputs/snli/snli-dataset.tsv) |
+|                     |        | JSON |  |
+|                     | output | JSON |  |
+|                     |        | TXT | [snli-roberta-output.txt](../data/system_outputs/snli/snli-roberta-output.txt) |
+| [knowledge graph link tail prediction](./task_kg_link_tail_prediction.md) | dataset | JSON |  |
+|                     | output | JSON |  |
+| language modeling | dataset | JSON |  |
+|                     |        | TXT |  |
+|                     | output | JSON |  |
+|                     |        | TXT |  |
+| tabular classification | dataset | JSON | [sst2-tabclass-dataset.json](../data/system_outputs/sst2_tabclass/sst2-tabclass-dataset.json) |
+|                     | output | JSON |  |
+|                     |        | TXT |  |
+| tabular regression | dataset | JSON | [sst2-tabreg-dataset.json](../data/system_outputs/sst2_tabreg/sst2-tabreg-dataset.json) |
+|                     | output | JSON |  |
+|                     |        | TXT | [sst2-tabreg-lstm-output.txt](../data/system_outputs/sst2_tabreg/sst2-tabreg-lstm-output.txt) |

--- a/docs/task_file_formats.md
+++ b/docs/task_file_formats.md
@@ -7,7 +7,7 @@ by [datalab](https://github.com/ExpressAI/DataLab/tree/main/datasets),
 you fortunately don't need to prepare the dataset.
 Otherwise, you can upload your custom datasets in the supported formats.
 
-You may refer to the example files for more specific formats,
+You may refer to the example files for more specific information about the formats,
     or click on the task link for more explanation.
 
 To upload custom features and analysis, please refer to this [instruction](./add_custom_features.md).


### PR DESCRIPTION
# Overview

This PR aims to create a summarization for the file formats supported by all the tasks. The [issue](https://github.com/neulab/explainaboard_client/issues/24) is filed in explainaboard_client, but since there are many example files and docs in this repo, I add the file format doc here and prepare to link this doc to the CLI.  

# Blocked by

Currently, the list contains the tasks shown in the web dropdown list and has links to existing task docs and example files. However, there are some issues to solve to make the doc more comprehensive and updated.
* More example files to add. Some tasks specify one format in the task doc, but the processor supports more formats without examples. 
* Miss task docs for sequence labeling, cloze, language modeling, tabular classification/regression. 
* Outdated task_kg_link_tail_prediction.md and task_knowledge_graph.md.
* Argument pair extraction (APE) is not supported in the web. 

# Next step

Create example files to fill in the list.