### PR TITLE
Remove obsolete docstring from get_processor_class

### DIFF
--- a/explainaboard/processors/processor_factory.py
+++ b/explainaboard/processors/processor_factory.py
@@ -84,7 +84,6 @@ def get_processor_class(task: TaskType) -> type[Processor]:
 
     Raises:
         ValueError: if the given task is not supported.
-        TypeError: if the obtained class is not a subclass of Processor class.
     """
     try:
         cls = _TASK_TYPE_TO_PROCESSOR[task]


### PR DESCRIPTION
<!-- EDIT THE TITLE FIRST. -->

# Overview

This PR removes obsolete docstring in `get_processor_class`.

# Details

Working in #434, `get_processor_class` was once implemented to raise `TypeError`. We eventually removed the code during review because it turned out unnecessary. However, I forgot to remove the corresponding docstring. This PR removes the leftover from that PR.

# References

- #434

# Blocked by

- NA
