### PR TITLE
Use ~= operator to declare dependencies

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,8 +19,10 @@ classifiers =
 [options]
 packages = find:
 include_package_data = True
+# NOTE: we cannot use ~= operator for datalabs for now since transitive dependencies
+# introduced cause different types of issues across Python versions in CI.
 install_requires =
-    datalabs~=0.4.14
+    datalabs>=0.4.9
     eaas~=0.3.9
     lexicalrichness~=0.2.0
     matplotlib~=3.6.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ classifiers =
 packages = find:
 include_package_data = True
 install_requires =
+    datalabs~=0.4.14
     eaas~=0.3.9
     lexicalrichness~=0.2.0
     matplotlib~=3.6.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,19 +20,19 @@ classifiers =
 packages = find:
 include_package_data = True
 install_requires =
-    datalabs>=0.4.9
-    eaas>=0.3.9
-    lexicalrichness!=0.1.6
-    matplotlib
-    nltk>=3.2
-    numpy
-    sacrebleu
-    scikit-learn
-    scipy
-    seqeval
-    spacy
-    tqdm
-    wheel
+    datalabs~=0.4.14
+    eaas~=0.3.9
+    lexicalrichness~=0.2.0
+    matplotlib~=3.6.1
+    nltk~=3.7
+    numpy~=1.23.4
+    sacrebleu~=2.2.1
+    scikit-learn~=1.1.2
+    scipy~=1.9.2
+    seqeval~=1.2.2
+    spacy~=3.4.1
+    tqdm~=4.64.1
+    wheel~=0.37.1
 
 [options.extras_require]
 dev = pre-commit

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,6 @@ classifiers =
 packages = find:
 include_package_data = True
 install_requires =
-    datalabs~=0.4.14
     eaas~=0.3.9
     lexicalrichness~=0.2.0
     matplotlib~=3.6.1


### PR DESCRIPTION
# Overview

<!-- EDIT HERE:
Write a brief overview of this change in a few sentences.
-->

This PR uses `~=` operator when declaring dependencies on particular versions.

# Details

<!-- EDIT HERE:
Write a detailed description of this change,
including backgrounds, approaches, and any other information that are related to this change.
-->

Versions were determined based on the downloaded versions in the [latest run of CI job](https://github.com/neulab/ExplainaBoard/actions/runs/3248992542/jobs/5330871326).

# References

- #472

# Blocked by

- NA
