### PR TITLE
Use ~= operator to declare the version of scipy

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,7 @@ install_requires =
     numpy
     sacrebleu
     scikit-learn
-    scipy
+    scipy~=1.9.2
     seqeval
     spacy
     tqdm


### PR DESCRIPTION
<!-- EDIT THE TITLE FIRST. -->

# Overview

This PR uses `~=` operator to pin the version of `scipy`.

# Details

The main purpose of this PR is to unblock #403 rather than resolving #472. To unblock #403, we need to pin a version of scipy to 1.9.0 or newer. Note that this PR uses `~=` operator for scipy only. The other dependencies cannot be used due to https://github.com/neulab/ExplainaBoard/issues/472#issuecomment-1279138341.

# References

- #472

# Blocked by

- NA