### PR TITLE
Bump pre-commit/action version to v3.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         with:
           python-version: 3.9
       - name: format
-        uses: pre-commit/action@v2.0.3
+        uses: pre-commit/action@v3.0.0
         with:
           extra_args: black --all-files
   isort:
@@ -67,7 +67,7 @@ jobs:
         with:
           python-version: 3.9
       - name: isort
-        uses: pre-commit/action@v2.0.3
+        uses: pre-commit/action@v3.0.0
         with:
           extra_args: isort --all-files
   lint:
@@ -79,13 +79,13 @@ jobs:
         with:
           python-version: 3.9
       - name: lint
-        uses: pre-commit/action@v2.0.3
+        uses: pre-commit/action@v3.0.0
         with:
           extra_args: flake8 --all-files
       # TODO(odashi): Replace upgrade-type-hints with an appropriate flake8 plugin
       # (e.g., flake8-pep585) if the one got the audience enough.
       - name: lint-pep585-compliant
-        uses: pre-commit/action@v2.0.3
+        uses: pre-commit/action@v3.0.0
         with:
           extra_args: upgrade-type-hints --all-files
   typecheck:
@@ -97,7 +97,7 @@ jobs:
         with:
           python-version: 3.9
       - name: mypy
-        uses: pre-commit/action@v2.0.3
+        uses: pre-commit/action@v3.0.0
         with:
           extra_args: mypy --all-files
   markdownlint:
@@ -109,6 +109,6 @@ jobs:
         with:
           node-version: 18.x
       - name: lint
-        uses: pre-commit/action@v2.0.3
+        uses: pre-commit/action@v3.0.0
         with:
           extra_args: markdownlint-cli2 --all-files


### PR DESCRIPTION
<!-- EDIT THE TITLE FIRST. -->

# Overview

This bumps pre-commit/action version to v3.0.0.

# Details

Currently, we see the following warnings in our workflows:

<img width="2123" alt="Screen Shot 2022-10-16 at 1 32 52" src="https://user-images.githubusercontent.com/1183444/195998214-216d78ae-5346-48c3-85e4-9b7d177d1837.png">

This is because 
* GitHub started to add a warning if a workflow has Actions that run Node 12 since September 22 (See [blog post](https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/) for details).
* `pre-commit/action@v2.0.3` [uses Node 12](https://github.com/pre-commit/action/blob/v2.0.3/action.yml#L12).

The warnings can be removed by updating pre-commit/action to v3.0.0 because v3.0.0 [doesn't depend on Node anymore](https://github.com/pre-commit/action/blob/v3.0.0/action.yml).

# References

# Blocked by

- NA
