### PR TITLE
Lint missing '__future__ import annotations' via pre-commit and CI

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,6 @@ repos:
         additional_dependencies:
           - flake8-absolute-import
           - flake8-black>=0.1.1
-          - flake8-future-import
         entry: flake8
         files: '\.py$'
       - id: flake8
@@ -25,6 +24,15 @@ repos:
         entry: flake8
         exclude: '^explainaboard\/third_party\/.*\.py|_test\.py$'
         files: '^explainaboard\/.*\.py$'
+      - id: flake8
+        name: future-import
+        additional_dependencies:
+          - flake8-future-import
+        args:
+          - --select=FI
+        entry: flake8
+        exclude: '^explainaboard\/third_party\/.*\.py'
+        files: '\.py$'
   - repo: https://github.com/pycqa/isort.git
     rev: 5.6.4
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,13 +5,14 @@ repos:
       - id: black
         files: '\.py$'
   - repo: https://gitlab.com/pycqa/flake8.git
-    rev: 4.0.1
+    rev: 5.0.4
     hooks:
       - id: flake8
         name: flake8
         additional_dependencies:
           - flake8-absolute-import
           - flake8-black>=0.1.1
+          - flake8-future-import
         entry: flake8
         files: '\.py$'
       - id: flake8

--- a/docs/example_scripts/get_customized_feature_results.py
+++ b/docs/example_scripts/get_customized_feature_results.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from explainaboard import get_loader_class, get_processor_class, TaskType
 
 

--- a/docs/example_scripts/test_kg.py
+++ b/docs/example_scripts/test_kg.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from typing import cast
 
 from explainaboard import get_loader_class, get_processor_class, TaskType

--- a/explainaboard/__init__.py
+++ b/explainaboard/__init__.py
@@ -1,5 +1,7 @@
 """Package definition for explainaboard."""
 
+from __future__ import annotations
+
 from explainaboard.constants import FileType, Source, TaskType
 from explainaboard.loaders import DatalabLoaderOption, get_loader_class
 from explainaboard.meta_analyses import RankFlippingMetaAnalysis, RankingMetaAnalysis

--- a/explainaboard/analysis/__init__.py
+++ b/explainaboard/analysis/__init__.py
@@ -1,1 +1,3 @@
+# flake8: noqa: FI18
+
 """This directory contains code implementing various analyses."""

--- a/explainaboard/analysis/__init__.py
+++ b/explainaboard/analysis/__init__.py
@@ -1,3 +1,3 @@
-# flake8: noqa: FI18
-
 """This directory contains code implementing various analyses."""
+
+from __future__ import annotations

--- a/explainaboard/analysis/analyses_test.py
+++ b/explainaboard/analysis/analyses_test.py
@@ -1,5 +1,7 @@
 """Tests for explainaboard.analysis.analyses."""
 
+from __future__ import annotations
+
 import textwrap
 import unittest
 

--- a/explainaboard/analysis/case_test.py
+++ b/explainaboard/analysis/case_test.py
@@ -1,5 +1,7 @@
 """Tests for explainaboard.analysis.case."""
 
+from __future__ import annotations
+
 import unittest
 
 from explainaboard.analysis.case import AnalysisCaseCollection

--- a/explainaboard/analysis/feature_funcs_test.py
+++ b/explainaboard/analysis/feature_funcs_test.py
@@ -1,5 +1,6 @@
 """Tests for explainaboard.analysis.feature_funcs."""
 
+from __future__ import annotations
 
 import unittest
 

--- a/explainaboard/analysis/feature_test.py
+++ b/explainaboard/analysis/feature_test.py
@@ -1,5 +1,7 @@
 """Tests for explainaboard.analysis.feature."""
 
+from __future__ import annotations
+
 import unittest
 
 from explainaboard.analysis.feature import DataType, Dict, Sequence, Value

--- a/explainaboard/analysis/performance_test.py
+++ b/explainaboard/analysis/performance_test.py
@@ -1,5 +1,6 @@
 """Tests for explainaboard.analysis.performance."""
 
+from __future__ import annotations
 
 import unittest
 

--- a/explainaboard/config.py
+++ b/explainaboard/config.py
@@ -1,5 +1,7 @@
 """Global configs of the library."""
 
+from __future__ import annotations
+
 TORCH_VERSION = "N/A"
 TORCH_AVAILABLE = False
 

--- a/explainaboard/info_test.py
+++ b/explainaboard/info_test.py
@@ -1,5 +1,7 @@
 """Tests for explainaboard.info."""
 
+from __future__ import annotations
+
 import pathlib
 import tempfile
 import unittest

--- a/explainaboard/loaders/__init__.py
+++ b/explainaboard/loaders/__init__.py
@@ -1,5 +1,6 @@
 """Classes related to loading resources from disk."""
 
+from __future__ import annotations
 
 from explainaboard.loaders import file_loader, loader_factory
 

--- a/explainaboard/loaders/argument_pair_extraction_test.py
+++ b/explainaboard/loaders/argument_pair_extraction_test.py
@@ -1,5 +1,7 @@
 """Tests for explainaboard.loaders.argument_pair_extraction."""
 
+from __future__ import annotations
+
 import unittest
 
 from explainaboard.constants import TaskType

--- a/explainaboard/loaders/aspect_based_sentiment_classification_test.py
+++ b/explainaboard/loaders/aspect_based_sentiment_classification_test.py
@@ -1,5 +1,7 @@
 """Tests for explainaboard.loaders.aspect_based_sentiment_classification."""
 
+from __future__ import annotations
+
 import unittest
 
 from explainaboard.constants import TaskType

--- a/explainaboard/loaders/cloze_generative_test.py
+++ b/explainaboard/loaders/cloze_generative_test.py
@@ -1,5 +1,7 @@
 """Tests for explainaboard.loaders.cloze_generative."""
 
+from __future__ import annotations
+
 import unittest
 
 from explainaboard.constants import TaskType

--- a/explainaboard/loaders/cloze_multiple_choice_test.py
+++ b/explainaboard/loaders/cloze_multiple_choice_test.py
@@ -1,5 +1,7 @@
 """Tests for explainaboard.loaders.cloze_multiple_choice."""
 
+from __future__ import annotations
+
 import unittest
 
 from explainaboard.constants import TaskType

--- a/explainaboard/loaders/conditional_generation_test.py
+++ b/explainaboard/loaders/conditional_generation_test.py
@@ -1,5 +1,7 @@
 """Tests for explainaboard.loaders.conditional_generation."""
 
+from __future__ import annotations
+
 import unittest
 
 from explainaboard.constants import TaskType

--- a/explainaboard/loaders/file_loader_test.py
+++ b/explainaboard/loaders/file_loader_test.py
@@ -1,5 +1,7 @@
 """Tests for explainaboard.loaders.file_loader."""
 
+from __future__ import annotations
+
 from unittest import TestCase
 
 from explainaboard import Source

--- a/explainaboard/loaders/grammatical_error_correction_test.py
+++ b/explainaboard/loaders/grammatical_error_correction_test.py
@@ -1,5 +1,7 @@
 """Tests for explainaboard.loaders.grammatical_error_correction."""
 
+from __future__ import annotations
+
 import unittest
 
 from explainaboard.constants import TaskType

--- a/explainaboard/loaders/kg_link_tail_prediction_test.py
+++ b/explainaboard/loaders/kg_link_tail_prediction_test.py
@@ -1,5 +1,7 @@
 """Tests for explainaboard.loaders.kg_link_tail_prediction."""
 
+from __future__ import annotations
+
 import unittest
 
 from explainaboard.constants import TaskType

--- a/explainaboard/loaders/language_modeling_test.py
+++ b/explainaboard/loaders/language_modeling_test.py
@@ -1,5 +1,7 @@
 """Tests for explainaboard.loaders.language_modeling."""
 
+from __future__ import annotations
+
 import unittest
 
 from explainaboard.constants import TaskType

--- a/explainaboard/loaders/loader_factory_test.py
+++ b/explainaboard/loaders/loader_factory_test.py
@@ -1,5 +1,7 @@
 """Tests for explainaboard.loaders.loader_factory."""
 
+from __future__ import annotations
+
 import unittest
 
 from explainaboard.constants import TaskType

--- a/explainaboard/loaders/meta_evaluation_wmt_da_test.py
+++ b/explainaboard/loaders/meta_evaluation_wmt_da_test.py
@@ -1,5 +1,7 @@
 """Tests for explainaboard.loaders.meta_evaluation_wmt_da."""
 
+from __future__ import annotations
+
 import unittest
 
 from explainaboard.constants import TaskType

--- a/explainaboard/loaders/qa_extractive_test.py
+++ b/explainaboard/loaders/qa_extractive_test.py
@@ -1,5 +1,7 @@
 """Tests for explainaboard.loaders.extractive_qa."""
 
+from __future__ import annotations
+
 import unittest
 
 from explainaboard.constants import TaskType

--- a/explainaboard/loaders/qa_multiple_choice_test.py
+++ b/explainaboard/loaders/qa_multiple_choice_test.py
@@ -1,5 +1,7 @@
 """Tests for explainaboard.loaders.qa_multiple_choice."""
 
+from __future__ import annotations
+
 import unittest
 
 from explainaboard.constants import TaskType

--- a/explainaboard/loaders/qa_open_domain_test.py
+++ b/explainaboard/loaders/qa_open_domain_test.py
@@ -1,5 +1,7 @@
 """Tests for explainaboard.loaders.qa_open_domain."""
 
+from __future__ import annotations
+
 import unittest
 
 from explainaboard.constants import TaskType

--- a/explainaboard/loaders/qa_tat_test.py
+++ b/explainaboard/loaders/qa_tat_test.py
@@ -1,5 +1,7 @@
 """Tests for explainaboard.loaders.qa_tat."""
 
+from __future__ import annotations
+
 import unittest
 
 from explainaboard.constants import TaskType

--- a/explainaboard/loaders/sequence_labeling_test.py
+++ b/explainaboard/loaders/sequence_labeling_test.py
@@ -1,5 +1,7 @@
 """Tests for explainaboard.loaders.sequence_labeling."""
 
+from __future__ import annotations
+
 import unittest
 
 from explainaboard.constants import TaskType

--- a/explainaboard/loaders/tabular_classification_test.py
+++ b/explainaboard/loaders/tabular_classification_test.py
@@ -1,5 +1,7 @@
 """Tests for explainaboard.loaders.tabular_classification."""
 
+from __future__ import annotations
+
 import unittest
 
 from explainaboard.constants import TaskType

--- a/explainaboard/loaders/tabular_regression_test.py
+++ b/explainaboard/loaders/tabular_regression_test.py
@@ -1,5 +1,7 @@
 """Tests for explainaboard.loaders.tabular_regression."""
 
+from __future__ import annotations
+
 import unittest
 
 from explainaboard.constants import TaskType

--- a/explainaboard/loaders/text_classification_test.py
+++ b/explainaboard/loaders/text_classification_test.py
@@ -1,5 +1,7 @@
 """Tests for explainaboard.loaders.text_classification."""
 
+from __future__ import annotations
+
 import unittest
 
 from explainaboard.constants import TaskType

--- a/explainaboard/loaders/text_pair_classification_test.py
+++ b/explainaboard/loaders/text_pair_classification_test.py
@@ -1,5 +1,7 @@
 """Tests for explainaboard.loaders.text_pair_classification."""
 
+from __future__ import annotations
+
 import unittest
 
 from explainaboard.constants import TaskType

--- a/explainaboard/meta_analyses/__init__.py
+++ b/explainaboard/meta_analyses/__init__.py
@@ -1,5 +1,7 @@
 """Package definition for explainaboard.meta_analysis."""
 
+from __future__ import annotations
+
 from explainaboard.meta_analyses.rank_flipping import RankFlippingMetaAnalysis
 from explainaboard.meta_analyses.ranking import RankingMetaAnalysis
 

--- a/explainaboard/metrics/__init__.py
+++ b/explainaboard/metrics/__init__.py
@@ -1,1 +1,3 @@
+# flake8: noqa: FI18
+
 """Code to implement evaluation metrics."""

--- a/explainaboard/metrics/__init__.py
+++ b/explainaboard/metrics/__init__.py
@@ -1,3 +1,3 @@
-# flake8: noqa: FI18
-
 """Code to implement evaluation metrics."""
+
+from __future__ import annotations

--- a/explainaboard/metrics/auxiliary/__init__.py
+++ b/explainaboard/metrics/auxiliary/__init__.py
@@ -1,1 +1,3 @@
+# flake8: noqa: FI18
+
 """Package definition for explainaboard.metrics.auxiliary."""

--- a/explainaboard/metrics/auxiliary/__init__.py
+++ b/explainaboard/metrics/auxiliary/__init__.py
@@ -1,3 +1,3 @@
-# flake8: noqa: FI18
-
 """Package definition for explainaboard.metrics.auxiliary."""
+
+from __future__ import annotations

--- a/explainaboard/metrics/extractive_qa.py
+++ b/explainaboard/metrics/extractive_qa.py
@@ -21,7 +21,7 @@ from explainaboard.utils.preprocessor import ExtractiveQAPreprocessor
 
 
 class ExtractiveQAMetric(Metric):
-    """An abstract class for extractive QA tasks that measures scores after normalization.
+    """Abstract class for extractive QA tasks that measures scores after normalization.
 
     The actual metric must inherit this class and implement the sample_level_metric()
     function.

--- a/explainaboard/processors/__init__.py
+++ b/explainaboard/processors/__init__.py
@@ -1,5 +1,7 @@
 """A package for processors."""
 
+from __future__ import annotations
+
 from explainaboard.processors import processor_factory
 
 get_processor_class = processor_factory.get_processor_class

--- a/explainaboard/processors/sequence_labeling_test.py
+++ b/explainaboard/processors/sequence_labeling_test.py
@@ -1,5 +1,7 @@
 """Tests for explainaboard.processors.sequence_labeling."""
 
+from __future__ import annotations
+
 import unittest
 
 

--- a/explainaboard/resources/__init__.py
+++ b/explainaboard/resources/__init__.py
@@ -1,3 +1,3 @@
-# flake8: noqa: FI18
-
 """Package definition of explainaboard.resources."""
+
+from __future__ import annotations

--- a/explainaboard/resources/__init__.py
+++ b/explainaboard/resources/__init__.py
@@ -1,1 +1,3 @@
+# flake8: noqa: FI18
+
 """Package definition of explainaboard.resources."""

--- a/explainaboard/serialization/__init__.py
+++ b/explainaboard/serialization/__init__.py
@@ -1,5 +1,7 @@
 """Package definition of explainaboard/serialization."""
 
+from __future__ import annotations
+
 from typing import Final
 
 from explainaboard.serialization.registry import TypeRegistry

--- a/explainaboard/serialization/legacy.py
+++ b/explainaboard/serialization/legacy.py
@@ -1,5 +1,7 @@
 """DEPRECATED: do not use this module for new implementations."""
 
+from __future__ import annotations
+
 import copy
 import dataclasses
 from inspect import getsource

--- a/explainaboard/serialization/types_test.py
+++ b/explainaboard/serialization/types_test.py
@@ -1,5 +1,7 @@
 """Tests for explainaboard.serialization.types."""
 
+from __future__ import annotations
+
 import dataclasses
 import unittest
 

--- a/explainaboard/table_schema.py
+++ b/explainaboard/table_schema.py
@@ -30,6 +30,7 @@ can get "answer"
 answer = system_output[A][B]
 """
 
+from __future__ import annotations
 
 from explainaboard import TaskType
 

--- a/explainaboard/utils/__init__.py
+++ b/explainaboard/utils/__init__.py
@@ -1,1 +1,3 @@
+# flake8: noqa: FI18
+
 """Package definition of explainaboard.utils."""

--- a/explainaboard/utils/__init__.py
+++ b/explainaboard/utils/__init__.py
@@ -1,3 +1,3 @@
-# flake8: noqa: FI18
-
 """Package definition of explainaboard.utils."""
+
+from __future__ import annotations

--- a/explainaboard/utils/agreement.py
+++ b/explainaboard/utils/agreement.py
@@ -1,5 +1,7 @@
 """Utility functions to calculate agreement scores."""
 
+from __future__ import annotations
+
 import numpy as np
 
 

--- a/explainaboard/utils/agreement_test.py
+++ b/explainaboard/utils/agreement_test.py
@@ -1,5 +1,7 @@
 """Tests for agreement.py."""
 
+from __future__ import annotations
+
 import unittest
 
 import numpy as np

--- a/explainaboard/utils/basic_words.py
+++ b/explainaboard/utils/basic_words.py
@@ -1,5 +1,7 @@
 """Definition of English basic words."""
 
+from __future__ import annotations
+
 BASIC_WORDS = [
     'a',
     'about',

--- a/explainaboard/utils/io_utils_test.py
+++ b/explainaboard/utils/io_utils_test.py
@@ -1,5 +1,7 @@
 """Tests for io_utils."""
 
+from __future__ import annotations
+
 import os
 import sys
 import tempfile

--- a/explainaboard/utils/load_resources.py
+++ b/explainaboard/utils/load_resources.py
@@ -1,5 +1,7 @@
 """Code for loading resources."""
 
+from __future__ import annotations
+
 import json
 import os
 from typing import Optional

--- a/explainaboard/utils/preprocessor_test.py
+++ b/explainaboard/utils/preprocessor_test.py
@@ -1,5 +1,7 @@
 """Tests for explainaboard.utils.preprocessor."""
 
+from __future__ import annotations
+
 import unittest
 
 from explainaboard.utils.preprocessor import ExtractiveQAPreprocessor, MapPreprocessor

--- a/explainaboard/utils/resources/__init__.py
+++ b/explainaboard/utils/resources/__init__.py
@@ -1,1 +1,3 @@
+# flake8: noqa: FI18
+
 """Package definition for explainaboard.utils.resources."""

--- a/explainaboard/utils/resources/__init__.py
+++ b/explainaboard/utils/resources/__init__.py
@@ -1,3 +1,3 @@
-# flake8: noqa: FI18
-
 """Package definition for explainaboard.utils.resources."""
+
+from __future__ import annotations

--- a/explainaboard/utils/span_utils_bio_span_ops_test.py
+++ b/explainaboard/utils/span_utils_bio_span_ops_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import unittest
 
 from explainaboard.utils.span_utils import BIOSpanOps

--- a/explainaboard/utils/span_utils_bmes_span_ops_test.py
+++ b/explainaboard/utils/span_utils_bmes_span_ops_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import unittest
 
 from explainaboard.utils.span_utils import BMESSpanOps

--- a/explainaboard/utils/span_utils_span_test.py
+++ b/explainaboard/utils/span_utils_span_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import unittest
 
 from explainaboard.utils.span_utils import Span

--- a/explainaboard/utils/tensor_analysis.py
+++ b/explainaboard/utils/tensor_analysis.py
@@ -4,6 +4,8 @@ TODO(gneubig):
   Thes could probably be made easier through using Pandas dataframes or numpy arrays
 """
 
+from __future__ import annotations
+
 import copy
 from typing import Optional
 

--- a/explainaboard/utils/tokenizer_test.py
+++ b/explainaboard/utils/tokenizer_test.py
@@ -1,5 +1,7 @@
 """Tests for explainaboard.utils.tokenizer."""
 
+from __future__ import annotations
+
 import unittest
 
 from explainaboard.serialization.serializers import PrimitiveSerializer

--- a/explainaboard/visualizers/__init__.py
+++ b/explainaboard/visualizers/__init__.py
@@ -1,5 +1,7 @@
 """Package definition of explainaboard.visualizers."""
 
+from __future__ import annotations
+
 from explainaboard.visualizers import performance_gap
 
 get_pairwise_performance_gap = performance_gap.get_pairwise_performance_gap

--- a/integration_tests/__init__.py
+++ b/integration_tests/__init__.py
@@ -1,1 +1,1 @@
-# flake8: noqa: FI18
+from __future__ import annotations

--- a/integration_tests/__init__.py
+++ b/integration_tests/__init__.py
@@ -1,0 +1,1 @@
+# flake8: noqa: FI18

--- a/integration_tests/api_test.py
+++ b/integration_tests/api_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import unittest
 

--- a/integration_tests/argument_pair_extraction_test.py
+++ b/integration_tests/argument_pair_extraction_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import unittest
 

--- a/integration_tests/aspect_based_sentiment_classification_test.py
+++ b/integration_tests/aspect_based_sentiment_classification_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import unittest
 

--- a/integration_tests/bucket_case_test.py
+++ b/integration_tests/bucket_case_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import unittest
 
 from explainaboard.analysis.case import (

--- a/integration_tests/cli_test.py
+++ b/integration_tests/cli_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import logging
 from pathlib import Path
 import tempfile

--- a/integration_tests/cloze_hint_test.py
+++ b/integration_tests/cloze_hint_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import unittest
 

--- a/integration_tests/cloze_multiple_choice_test.py
+++ b/integration_tests/cloze_multiple_choice_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import unittest
 

--- a/integration_tests/dynamic_hits_metric_test.py
+++ b/integration_tests/dynamic_hits_metric_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import unittest
 

--- a/integration_tests/example_code_test.py
+++ b/integration_tests/example_code_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import tempfile
 import unittest
 

--- a/integration_tests/extractive_qa_test.py
+++ b/integration_tests/extractive_qa_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import unittest
 

--- a/integration_tests/grammar_error_correction_test.py
+++ b/integration_tests/grammar_error_correction_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import unittest
 

--- a/integration_tests/kg_link_tail_prediction_test.py
+++ b/integration_tests/kg_link_tail_prediction_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import tempfile
 import unittest

--- a/integration_tests/loaders_test.py
+++ b/integration_tests/loaders_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 from unittest import TestCase
 

--- a/integration_tests/machine_translation_test.py
+++ b/integration_tests/machine_translation_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import dataclasses
 import os
 import unittest

--- a/integration_tests/meta_eval_nlg_test.py
+++ b/integration_tests/meta_eval_nlg_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import unittest
 
 import numpy as np

--- a/integration_tests/meta_eval_wmt_da_test.py
+++ b/integration_tests/meta_eval_wmt_da_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import unittest
 

--- a/integration_tests/multilingual_multitask_test.py
+++ b/integration_tests/multilingual_multitask_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import os
 import unittest

--- a/integration_tests/ner_test.py
+++ b/integration_tests/ner_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import dataclasses
 import os
 from typing import cast

--- a/integration_tests/qa_multiple_choice_test.py
+++ b/integration_tests/qa_multiple_choice_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import unittest
 

--- a/integration_tests/qa_open_domain_test.py
+++ b/integration_tests/qa_open_domain_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import unittest
 

--- a/integration_tests/qa_table_text_hybrid_test.py
+++ b/integration_tests/qa_table_text_hybrid_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import unittest
 
 from explainaboard import FileType, get_processor_class, Source, TaskType

--- a/integration_tests/summarization_test.py
+++ b/integration_tests/summarization_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import unittest
 

--- a/integration_tests/system_details_test.py
+++ b/integration_tests/system_details_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import json
 import os
 import unittest

--- a/integration_tests/table_schema_test.py
+++ b/integration_tests/table_schema_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import unittest
 
 from explainaboard import TaskType

--- a/integration_tests/text_classification_test.py
+++ b/integration_tests/text_classification_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import dataclasses
 import os
 import unittest

--- a/integration_tests/text_pair_classification_test.py
+++ b/integration_tests/text_pair_classification_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import unittest
 

--- a/integration_tests/tokenizers_test.py
+++ b/integration_tests/tokenizers_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import unittest
 
 from explainaboard.utils.tokenizer import SacreBleuTokenizer, SingleSpaceTokenizer

--- a/integration_tests/word_segmentation_test.py
+++ b/integration_tests/word_segmentation_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import unittest
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,7 +47,7 @@ console_scripts =
 [flake8]
 application-import-names = explainaboard
 exclude = __pycache__, datasets
-extend-ignore = E203, W503
+extend-ignore = E203, W503, FI10, FI11, FI12, FI13, FI14, FI15, FI16, FI17, FI58
 filename = ./explainaboard/*.py, ./setup.py
 max-line-length = 88
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ console_scripts =
 
 [flake8]
 application-import-names = explainaboard
-exclude = __pycache__, datasets
+exclude = __pycache__, datasets, explainaboard/third_party/*
 extend-ignore = E203, W503, FI10, FI11, FI12, FI13, FI14, FI15, FI16, FI17, FI58
 filename = ./explainaboard/*.py, ./setup.py
 max-line-length = 88

--- a/setup.cfg
+++ b/setup.cfg
@@ -46,7 +46,7 @@ console_scripts =
 
 [flake8]
 application-import-names = explainaboard
-exclude = __pycache__, datasets, explainaboard/third_party/*
+exclude = __pycache__, datasets
 extend-ignore = E203, W503, FI10, FI11, FI12, FI13, FI14, FI15, FI16, FI17, FI58
 filename = ./explainaboard/*.py, ./setup.py
 max-line-length = 88

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from setuptools import setup
 
 setup()

--- a/version.py
+++ b/version.py
@@ -1,3 +1,5 @@
+# flake8: noqa: FI18
+
 """Version information of ExplainaBoard."""
 
 __version__ = "0.11.2"

--- a/version.py
+++ b/version.py
@@ -1,5 +1,5 @@
-# flake8: noqa: FI18
-
 """Version information of ExplainaBoard."""
+
+from __future__ import annotations
 
 __version__ = "0.11.2"


### PR DESCRIPTION
<!-- EDIT THE TITLE FIRST. -->

# Overview

<!-- EDIT HERE:
Write a brief overview of this change in a few sentences.
-->

This PR introduces a flake8 plugin, [flake8-future-import](https://pypi.org/project/flake8-future-import/) to automatically check missing `__future__ import annotations`.

# Details

Currently, some code requires `__future__ import annotations` to use type annotation (e.g., [PEP 604](https://peps.python.org/pep-0604/) available in Python 3.10) across Python 3.8, 3.9, and 3.10. It's more consistent to add the import for every Python file except third party, but it's easy to forget to add it without CI. That's where flake8-future-import comes in.

flake8-future-import enables flake8 to check the import automatically. This PR adds a new pre-commit hook dedicated to the plugin to exclude third-party code from the check.  I added error codes to the config file to silence flake8 so that flake8 doesn't check features other than `annotations`, because the plugin is designed to lint all the features by default.
Note that this PR bumps flake8 version to use the latest version of the plugin.

# References

# Blocked by

- NA
