### PR TITLE
refactor bucketing modules

### DIFF
--- a/explainaboard/analysis/bucketing_test.py
+++ b/explainaboard/analysis/bucketing_test.py
@@ -1,0 +1,25 @@
+"""Tests for explainaboard.analysis.bucketing."""
+
+from __future__ import annotations
+
+import unittest
+
+from explainaboard.analysis.bucketing import (
+    continuous,
+    discrete,
+    fixed,
+    get_bucketing_method,
+)
+
+
+class ModuleTest(unittest.TestCase):
+    def test_get_bucketing_method(self) -> None:
+        self.assertIs(get_bucketing_method("continuous"), continuous)
+        self.assertIs(get_bucketing_method("discrete"), discrete)
+        self.assertIs(get_bucketing_method("fixed"), fixed)
+
+    def test_get_bucketing_method_invalid(self) -> None:
+        with self.assertRaisesRegex(
+            ValueError, r"^No bucketing method associated to name='xxx'$"
+        ):
+            get_bucketing_method("xxx")


### PR DESCRIPTION
<!-- EDIT THE TITLE FIRST. -->

# Overview

Refactors `explainaboard.analysis.bucketing` module to improve maintainability.

# Details

This module is originally accessed via introspection to get inner functions with unclear function signatures, which breaks typing information and make the maintenance hard. This change introduces:

- Give the config type `SerializableData` (we must be able to serialize this data because this is stored in `Analysis`)
- Add `BucketingFn` protocol type to give the correct typing information of functions
- Set None as default values.

# References

<!-- EDIT HERE: Put the list of taskboard issues, discussions related to this change. -->

- #446

# Blocked by

<!-- EDIT HERE IF ANY: Put the list of changes that have to be merged into the repository before merging this change. -->

- NA
- (or link to PRs)
