### PR TITLE
Fix Processor._customize_analyses

### DIFF
--- a/explainaboard/analysis/analyses.py
+++ b/explainaboard/analysis/analyses.py
@@ -859,3 +859,22 @@ class AnalysisLevel(Serializable):
             features=features,
             metric_configs=metric_configs,
         )
+
+    @final
+    def replace_metric_configs(
+        self, metric_configs: dict[str, MetricConfig]
+    ) -> AnalysisLevel:
+        """Creates a new AnalysisLevel with replacing the set of MetricConfigs.
+
+        Args:
+            metric_configs:
+                New dict of MetricConfigs to replace the original member.
+
+        Returns:
+            A new MetricConfigs with the replaced metric_configs.
+        """
+        return AnalysisLevel(
+            name=self.name,
+            features=self.features,
+            metric_configs=metric_configs,
+        )

--- a/explainaboard/analysis/analyses_test.py
+++ b/explainaboard/analysis/analyses_test.py
@@ -525,3 +525,15 @@ class AnalysisLevelTest(unittest.TestCase):
         }
         self.assertEqual(serializer.serialize(level), level_serialized)
         self.assertEqual(serializer.deserialize(level_serialized), level)
+
+    def test_replace_metric_configs(self) -> None:
+        level = AnalysisLevel(
+            name="test", features={}, metric_configs={"foo": AccuracyConfig()}
+        )
+        new_level = level.replace_metric_configs({"bar": AccuracyConfig()})
+        self.assertIsNot(level, new_level)
+        self.assertIn("foo", level.metric_configs)
+        self.assertNotIn("bar", level.metric_configs)
+        self.assertNotIn("foo", new_level.metric_configs)
+        self.assertIn("bar", new_level.metric_configs)
+        self.assertIsNot(level.metric_configs["foo"], new_level.metric_configs["bar"])

--- a/explainaboard/metrics/metric.py
+++ b/explainaboard/metrics/metric.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import abc
+import copy
 from dataclasses import dataclass
 from typing import Any, final, Optional, TypeVar
 
@@ -221,6 +222,28 @@ class MetricConfig(SerializableDataclass, metaclass=abc.ABCMeta):
             Instantiated Metric object.
         """
         ...
+
+    @final
+    def replace_languages(
+        self, source_language: str | None, target_language: str | None
+    ) -> MetricConfig:
+        """Creates a new MetricConfig with specified source/target languages.
+
+        Args:
+            source_language: New source language.
+            target_language: New target language.
+
+        Returns:
+            A new MetricConfig object, in which source/target_language are replaced to
+            the new config, while other values are maintained.
+        """
+        # NOTE(odashi): Since this class can be inherited, we need to collect every
+        # member not listed in this class.
+        # TODO(odashi): Avoid copy.
+        copied = copy.deepcopy(self)
+        copied.source_language = source_language
+        copied.target_language = target_language
+        return copied
 
 
 class MetricStats(metaclass=abc.ABCMeta):

--- a/explainaboard/metrics/metric_test.py
+++ b/explainaboard/metrics/metric_test.py
@@ -191,6 +191,19 @@ class MetricResultTest(unittest.TestCase):
         self.assertIs(result.get_value_or_none(ConfidenceInterval, "baz"), ci)
 
 
+class MetricConfigTest(unittest.TestCase):
+    def test_replace_languages(self) -> None:
+        config = _DummyMetricConfig(source_language="xx", target_language="yy")
+        new_config = config.replace_languages(
+            source_language="aa", target_language="bb"
+        )
+        self.assertIsNot(new_config, config)
+        self.assertEqual(config.source_language, "xx")
+        self.assertEqual(config.target_language, "yy")
+        self.assertEqual(new_config.source_language, "aa")
+        self.assertEqual(new_config.target_language, "bb")
+
+
 class MetricTest(unittest.TestCase):
     def test_aggregate_stats_1dim(self) -> None:
         metric = _DummyMetric(_DummyMetricConfig("test"))
@@ -406,7 +419,6 @@ class MetricTest(unittest.TestCase):
         result = metric.evaluate_from_stats(stats, confidence_alpha=0.05)
         self.assertEqual(result.get_value(Score, "score").value, 3.0)
         ci = result.get_value(ConfidenceInterval, "score_ci")
-        print(dataclasses.asdict(ci))
         # TODO(odahsi): According to the current default settings of bootstrapping,
         # estimated confidence intervals tends to become very wide for small data
         self.assertAlmostEqual(ci.low, 1.8)

--- a/explainaboard/processors/processor.py
+++ b/explainaboard/processors/processor.py
@@ -528,7 +528,10 @@ class Processor(metaclass=abc.ABCMeta):
         metric_configs = metadata.get("metric_configs")
         if metric_configs is not None:
             metric_configs_dict = {
-                "example": cast(dict[str, MetricConfig], metric_configs)
+                "example": {
+                    narrow(str, k): narrow(MetricConfig, v)  # type: ignore
+                    for k, v in metric_configs.items()
+                }
             }
         else:
             metric_configs_dict = {}


### PR DESCRIPTION
<!-- EDIT THE TITLE FIRST. -->

# Overview

This PR restores the previous behavior in `Processor._customize_analyses`.

# Details

`Processor._customize_analyses` was changed resently to "add" given metrics to default metrics, but the original behavior was "replace" it with the given metrics. This change restores the original behavior.
This change also introduces `MetricConfig.replace_languages` and `AnalysisLevel.replace_metric_configs` functions, which creates a new object by copying self with replacing several members.

# References

# Blocked by

<!-- EDIT HERE IF ANY: Put the list of changes that have to be merged into the repository before merging this change. -->

- NA
