### PR TITLE
Refer to loaders_test.py instead of test_loaders.py

### DIFF
--- a/docs/add_new_tasks.md
+++ b/docs/add_new_tasks.md
@@ -59,7 +59,7 @@ class TextClassificationLoader(Loader):
     Validate and Reformat system output file with tsv format:
     text \t true_label \t predicted_label
     usage:
-        please refer to `test_loaders.py`
+        please refer to `loaders_test.py`
     """
 
     def load(self) -> Iterable[Dict]:

--- a/explainaboard/loaders/argument_pair_extraction.py
+++ b/explainaboard/loaders/argument_pair_extraction.py
@@ -16,7 +16,7 @@ class ArgumentPairExtractionLoader(Loader):
     """A loader for argument pair extraction.
 
     usage:
-        please refer to `test_loaders.py`
+        please refer to `loaders_test.py`
     """
 
     @classmethod

--- a/explainaboard/loaders/aspect_based_sentiment_classification.py
+++ b/explainaboard/loaders/aspect_based_sentiment_classification.py
@@ -18,7 +18,7 @@ class AspectBasedSentimentClassificationLoader(Loader):
     """Loader for the aspect based sentiment classification task.
 
     usage:
-        please refer to `test_loaders.py`
+        please refer to `loaders_test.py`
     """
 
     @classmethod

--- a/explainaboard/loaders/conditional_generation.py
+++ b/explainaboard/loaders/conditional_generation.py
@@ -18,7 +18,7 @@ class ConditionalGenerationLoader(Loader):
     """Loader for the conditional generation task.
 
     usage:
-        please refer to `test_loaders.py`
+        please refer to `loaders_test.py`
     """
 
     OUTPUT_FIELDS = ["source", "reference"]

--- a/explainaboard/loaders/grammatical_error_correction.py
+++ b/explainaboard/loaders/grammatical_error_correction.py
@@ -16,7 +16,7 @@ class GrammaticalErrorCorrectionLoader(Loader):
     """Loader for the grammatical error correction task.
 
     usage:
-        please refer to `test_loaders.py`
+        please refer to `loaders_test.py`
     """
 
     JSON_FIELDS: list[str | tuple[str, str]] = ["text", "edits"]

--- a/explainaboard/loaders/kg_link_tail_prediction.py
+++ b/explainaboard/loaders/kg_link_tail_prediction.py
@@ -21,7 +21,7 @@ class KgLinkTailPredictionLoader(Loader):
     """Loader for the knowledge graph link prediction task.
 
     usage:
-        please refer to `test_loaders.py`
+        please refer to `loaders_test.py`
 
     NOTE: kg task has a system output format that's different from all the
     other tasks. Samples are stored in a dict instead of a list so we have

--- a/explainaboard/loaders/language_modeling.py
+++ b/explainaboard/loaders/language_modeling.py
@@ -17,7 +17,7 @@ class LanguageModelingLoader(Loader):
     """Loader for the language modeling task.
 
     usage:
-        please refer to `test_loaders.py`
+        please refer to `loaders_test.py`
     """
 
     @classmethod

--- a/explainaboard/loaders/meta_evaluation_wmt_da.py
+++ b/explainaboard/loaders/meta_evaluation_wmt_da.py
@@ -17,7 +17,7 @@ class MetaEvaluationWMTDALoader(Loader):
     """Loader for the natural language generation task.
 
     usage:
-        please refer to `test_loaders.py`
+        please refer to `loaders_test.py`
     """
 
     @classmethod

--- a/explainaboard/loaders/sequence_labeling.py
+++ b/explainaboard/loaders/sequence_labeling.py
@@ -17,7 +17,7 @@ class SeqLabLoader(Loader):
     """Loader for the sequence labeling task.
 
     usage:
-        please refer to `test_loaders.py`
+        please refer to `loaders_test.py`
     """
 
     @classmethod

--- a/explainaboard/loaders/tabular_classification.py
+++ b/explainaboard/loaders/tabular_classification.py
@@ -17,7 +17,7 @@ class TabularClassificationLoader(Loader):
     """Loader for the tabular classification task.
 
     usage:
-        please refer to `test_loaders.py`
+        please refer to `loaders_test.py`
     """
 
     @classmethod

--- a/explainaboard/loaders/tabular_regression.py
+++ b/explainaboard/loaders/tabular_regression.py
@@ -17,7 +17,7 @@ class TabularRegressionLoader(Loader):
     """Loader for the tabular regression task.
 
     usage:
-        please refer to `test_loaders.py`
+        please refer to `loaders_test.py`
     """
 
     @classmethod

--- a/explainaboard/loaders/text_classification.py
+++ b/explainaboard/loaders/text_classification.py
@@ -18,7 +18,7 @@ class TextClassificationLoader(Loader):
     """Loader for the text classification task.
 
     usage:
-        please refer to `test_loaders.py`
+        please refer to `loaders_test.py`
     """
 
     @classmethod

--- a/explainaboard/loaders/text_pair_classification.py
+++ b/explainaboard/loaders/text_pair_classification.py
@@ -18,7 +18,7 @@ class TextPairClassificationLoader(Loader):
     """Loader for the text pair classification task.
 
     usage:
-        please refer to `test_loaders.py`
+        please refer to `loaders_test.py`
     """
 
     @classmethod


### PR DESCRIPTION
# Overview

This PR fixes the documentation which refers to non-existent file, `test_loaders.py`.

# Details

`test_loaders.py` was renamed to `loaders_test.py in #405. The documentation needs to refer to the renamed one.

# References

# Blocked by

- NA
