### PR TITLE
reload_stat -> use_cache

### DIFF
--- a/data/reports/absa-confidence-report.json
+++ b/data/reports/absa-confidence-report.json
@@ -2,7 +2,6 @@
   "task_name": "aspect-based-sentiment-classification",
   "source_language": "en",
   "target_language": "en",
-  "reload_stat": true,
   "source_tokenizer": {
     "cls_name": "SingleSpaceTokenizer"
   },

--- a/data/reports/report_kg.json
+++ b/data/reports/report_kg.json
@@ -6,7 +6,6 @@
   "dataset_split": null,
   "source_language": null,
   "target_language": null,
-  "reload_stat": true,
   "is_print_case": true,
   "confidence_alpha": 0.05,
   "system_details": null,

--- a/explainaboard/explainaboard_main.py
+++ b/explainaboard/explainaboard_main.py
@@ -245,11 +245,10 @@ def create_parser():
     )
 
     parser.add_argument(
-        "--reload-stat",
-        type=str,
-        required=False,
-        default=None,
-        help="reload precomputed statistics over training set (if exists)",
+        "--no-use-cache",
+        dest="use_cache",
+        action="store_false",
+        help="Disable cached statistics over training set.",
     )
 
     parser.add_argument(
@@ -362,7 +361,7 @@ def main():
     """The main function to be executed."""
     args = create_parser().parse_args()
 
-    reload_stat: bool = False if args.reload_stat == "0" else True
+    use_cache: bool = args.use_cache
     system_outputs: list[str] = args.system_outputs
 
     reports: list[str] | None = args.reports
@@ -479,7 +478,6 @@ def main():
             "split_name": split,
             "source_language": source_language,
             "target_language": target_language,
-            "reload_stat": reload_stat,
             "confidence_alpha": args.confidence_alpha,
             "system_details": system_details,
             "custom_features": system_datasets[0].metadata.custom_features,
@@ -510,6 +508,7 @@ def main():
                 metadata=metadata_copied,
                 sys_output=system_dataset.samples,
                 skip_failed_analyses=args.skip_failed_analyses,
+                use_cache=use_cache,
             )
             reports.append(report)
 

--- a/explainaboard/info.py
+++ b/explainaboard/info.py
@@ -81,14 +81,12 @@ class SysOutputInfo(Serializable):
         dataset_split (str): the name of the split.
         source_language (str): the language of the input
         target_language (str): the language of the output
-        reload_stat (bool): whether to reload the statistics or not
         system_details (dict): a dictionary of system details
         source_tokenizer (Tokenizer): the tokenizer for source sentences
         target_tokenizer (Tokenizer): the tokenizer for target sentences
         analysis_levels: the levels of analysis to perform
     """
 
-    DEFAULT_RELOAD_STAT: ClassVar[bool] = True
     DEFAULT_CONFIDENCE_ALPHA: ClassVar[float] = 0.05
 
     task_name: str | None = None
@@ -98,7 +96,6 @@ class SysOutputInfo(Serializable):
     dataset_split: str | None = None
     source_language: str | None = None
     target_language: str | None = None
-    reload_stat: bool = DEFAULT_RELOAD_STAT
     # NOTE(odashi): confidence_alpha == None has a meaning beyond "unset": it prevents
     # calculating confidence intervals.
     confidence_alpha: float | None = DEFAULT_CONFIDENCE_ALPHA
@@ -182,7 +179,6 @@ class SysOutputInfo(Serializable):
             "dataset_split": self.dataset_split,
             "source_language": self.source_language,
             "target_language": self.target_language,
-            "reload_stat": self.reload_stat,
             "confidence_alpha": self.confidence_alpha,
             "system_details": self.system_details,
             "source_tokenizer": self.source_tokenizer,
@@ -223,9 +219,6 @@ class SysOutputInfo(Serializable):
             dataset_split=_get_value(data, str, "dataset_split"),
             source_language=_get_value(data, str, "source_language"),
             target_language=_get_value(data, str, "target_language"),
-            reload_stat=unwrap_or(
-                _get_value(data, bool, "reload_stat"), cls.DEFAULT_RELOAD_STAT
-            ),
             confidence_alpha=confidence_alpha,
             system_details=system_details,
             source_tokenizer=_get_value(

--- a/explainaboard/info_test.py
+++ b/explainaboard/info_test.py
@@ -100,7 +100,6 @@ class SysOutputInfoTest(unittest.TestCase):
             dataset_split="quux",
             source_language="en",
             target_language="zh",
-            reload_stat=True,
             confidence_alpha=None,
             system_details={"detail": 123},
             source_tokenizer=tokenizer1,
@@ -126,7 +125,6 @@ class SysOutputInfoTest(unittest.TestCase):
             "dataset_split": "quux",
             "source_language": "en",
             "target_language": "zh",
-            "reload_stat": True,
             "system_details": {"detail": 123},
             "source_tokenizer": tokenizer1_serialized,
             "target_tokenizer": tokenizer2_serialized,
@@ -168,7 +166,6 @@ class SysOutputInfoTest(unittest.TestCase):
             self.assertEqual(deserialized.dataset_split, sysout.dataset_split)
             self.assertEqual(deserialized.source_language, sysout.source_language)
             self.assertEqual(deserialized.target_language, sysout.target_language)
-            self.assertEqual(deserialized.reload_stat, sysout.reload_stat)
             self.assertEqual(deserialized.confidence_alpha, sysout.confidence_alpha)
             self.assertEqual(deserialized.system_details, sysout.system_details)
             self.assertIsInstance(deserialized.source_tokenizer, SingleSpaceTokenizer)
@@ -191,7 +188,6 @@ class SysOutputInfoTest(unittest.TestCase):
         self.assertIsNone(deserialized.dataset_split)
         self.assertIsNone(deserialized.source_language)
         self.assertIsNone(deserialized.target_language)
-        self.assertEqual(deserialized.reload_stat, SysOutputInfo.DEFAULT_RELOAD_STAT)
         self.assertEqual(
             deserialized.confidence_alpha, SysOutputInfo.DEFAULT_CONFIDENCE_ALPHA
         )

--- a/integration_tests/artifacts/reports/test-ar_6960.json
+++ b/integration_tests/artifacts/reports/test-ar_6960.json
@@ -6,7 +6,6 @@
     "metric_names": [
         "Accuracy"
     ],
-    "reload_stat": true,
     "is_print_case": true,
     "language": "ar",
     "confidence_alpha": 0.05,

--- a/integration_tests/artifacts/reports/test-de_7213.json
+++ b/integration_tests/artifacts/reports/test-de_7213.json
@@ -6,7 +6,6 @@
     "metric_names": [
         "Accuracy"
     ],
-    "reload_stat": true,
     "is_print_case": true,
     "language": "de",
     "confidence_alpha": 0.05,

--- a/integration_tests/artifacts/reports/test-de_9330.json
+++ b/integration_tests/artifacts/reports/test-de_9330.json
@@ -6,7 +6,6 @@
     "metric_names": [
         "Accuracy"
     ],
-    "reload_stat": true,
     "is_print_case": true,
     "language": "de",
     "confidence_alpha": 0.05,

--- a/integration_tests/artifacts/reports/test-de_9335.json
+++ b/integration_tests/artifacts/reports/test-de_9335.json
@@ -6,7 +6,6 @@
     "metric_names": [
         "Accuracy"
     ],
-    "reload_stat": true,
     "is_print_case": true,
     "language": "de",
     "confidence_alpha": 0.05,

--- a/integration_tests/artifacts/reports/test-en_7676.json
+++ b/integration_tests/artifacts/reports/test-en_7676.json
@@ -6,7 +6,6 @@
     "metric_names": [
         "Accuracy"
     ],
-    "reload_stat": true,
     "is_print_case": true,
     "language": "en",
     "confidence_alpha": 0.05,

--- a/integration_tests/artifacts/reports/test-en_7872.json
+++ b/integration_tests/artifacts/reports/test-en_7872.json
@@ -6,7 +6,6 @@
     "metric_names": [
         "Accuracy"
     ],
-    "reload_stat": true,
     "is_print_case": true,
     "language": "en",
     "confidence_alpha": 0.05,

--- a/integration_tests/artifacts/reports/test-en_8113.json
+++ b/integration_tests/artifacts/reports/test-en_8113.json
@@ -7,7 +7,6 @@
         "F1ScoreQA",
         "ExactMatchQA"
     ],
-    "reload_stat": true,
     "is_print_case": true,
     "language": "en",
     "confidence_alpha": 0.05,

--- a/integration_tests/artifacts/reports/test-en_8235.json
+++ b/integration_tests/artifacts/reports/test-en_8235.json
@@ -7,7 +7,6 @@
         "F1ScoreQA",
         "ExactMatchQA"
     ],
-    "reload_stat": true,
     "is_print_case": true,
     "language": "en",
     "confidence_alpha": 0.05,

--- a/integration_tests/artifacts/reports/test-en_9152.json
+++ b/integration_tests/artifacts/reports/test-en_9152.json
@@ -6,7 +6,6 @@
     "metric_names": [
         "Accuracy"
     ],
-    "reload_stat": true,
     "is_print_case": true,
     "language": "en",
     "confidence_alpha": 0.05,

--- a/integration_tests/artifacts/reports/test-en_9200.json
+++ b/integration_tests/artifacts/reports/test-en_9200.json
@@ -6,7 +6,6 @@
     "metric_names": [
         "Accuracy"
     ],
-    "reload_stat": true,
     "is_print_case": true,
     "language": "en",
     "confidence_alpha": 0.05,

--- a/integration_tests/artifacts/reports/test-es_7377.json
+++ b/integration_tests/artifacts/reports/test-es_7377.json
@@ -6,7 +6,6 @@
     "metric_names": [
         "Accuracy"
     ],
-    "reload_stat": true,
     "is_print_case": true,
     "language": "es",
     "confidence_alpha": 0.05,

--- a/integration_tests/artifacts/reports/test-es_7678.json
+++ b/integration_tests/artifacts/reports/test-es_7678.json
@@ -6,7 +6,6 @@
     "metric_names": [
         "Accuracy"
     ],
-    "reload_stat": true,
     "is_print_case": true,
     "language": "es",
     "confidence_alpha": 0.05,

--- a/integration_tests/artifacts/reports/test-es_7687.json
+++ b/integration_tests/artifacts/reports/test-es_7687.json
@@ -7,7 +7,6 @@
         "F1ScoreQA",
         "ExactMatchQA"
     ],
-    "reload_stat": true,
     "is_print_case": true,
     "language": "es",
     "confidence_alpha": 0.05,

--- a/integration_tests/artifacts/reports/test-es_7698.json
+++ b/integration_tests/artifacts/reports/test-es_7698.json
@@ -7,7 +7,6 @@
         "F1ScoreQA",
         "ExactMatchQA"
     ],
-    "reload_stat": true,
     "is_print_case": true,
     "language": "es",
     "confidence_alpha": 0.05,

--- a/integration_tests/artifacts/reports/test-es_9340.json
+++ b/integration_tests/artifacts/reports/test-es_9340.json
@@ -6,7 +6,6 @@
     "metric_names": [
         "Accuracy"
     ],
-    "reload_stat": true,
     "is_print_case": true,
     "language": "es",
     "confidence_alpha": 0.05,

--- a/integration_tests/artifacts/reports/test-es_9342.json
+++ b/integration_tests/artifacts/reports/test-es_9342.json
@@ -6,7 +6,6 @@
     "metric_names": [
         "Accuracy"
     ],
-    "reload_stat": true,
     "is_print_case": true,
     "language": "es",
     "confidence_alpha": 0.05,

--- a/integration_tests/artifacts/reports/test-fr_9262.json
+++ b/integration_tests/artifacts/reports/test-fr_9262.json
@@ -6,7 +6,6 @@
     "metric_names": [
         "Accuracy"
     ],
-    "reload_stat": true,
     "is_print_case": true,
     "language": "fr",
     "confidence_alpha": 0.05,

--- a/integration_tests/artifacts/reports/test-fr_9332.json
+++ b/integration_tests/artifacts/reports/test-fr_9332.json
@@ -6,7 +6,6 @@
     "metric_names": [
         "Accuracy"
     ],
-    "reload_stat": true,
     "is_print_case": true,
     "language": "fr",
     "confidence_alpha": 0.05,

--- a/integration_tests/artifacts/reports/test-ja_9137.json
+++ b/integration_tests/artifacts/reports/test-ja_9137.json
@@ -6,7 +6,6 @@
     "metric_names": [
         "Accuracy"
     ],
-    "reload_stat": true,
     "is_print_case": true,
     "language": "ja",
     "confidence_alpha": 0.05,

--- a/integration_tests/artifacts/reports/test-ja_9150.json
+++ b/integration_tests/artifacts/reports/test-ja_9150.json
@@ -6,7 +6,6 @@
     "metric_names": [
         "Accuracy"
     ],
-    "reload_stat": true,
     "is_print_case": true,
     "language": "ja",
     "confidence_alpha": 0.05,

--- a/integration_tests/artifacts/reports/test-zh_7117.json
+++ b/integration_tests/artifacts/reports/test-zh_7117.json
@@ -6,7 +6,6 @@
     "metric_names": [
         "Accuracy"
     ],
-    "reload_stat": true,
     "is_print_case": true,
     "language": "zh",
     "confidence_alpha": 0.05,

--- a/integration_tests/artifacts/reports/test-zh_7311.json
+++ b/integration_tests/artifacts/reports/test-zh_7311.json
@@ -6,7 +6,6 @@
     "metric_names": [
         "Accuracy"
     ],
-    "reload_stat": true,
     "is_print_case": true,
     "language": "zh",
     "confidence_alpha": 0.05,

--- a/integration_tests/artifacts/reports/test-zh_7396.json
+++ b/integration_tests/artifacts/reports/test-zh_7396.json
@@ -7,7 +7,6 @@
         "F1ScoreQA",
         "ExactMatchQA"
     ],
-    "reload_stat": true,
     "is_print_case": true,
     "language": "zh",
     "confidence_alpha": 0.05,

--- a/integration_tests/artifacts/reports/test-zh_7443.json
+++ b/integration_tests/artifacts/reports/test-zh_7443.json
@@ -7,7 +7,6 @@
         "F1ScoreQA",
         "ExactMatchQA"
     ],
-    "reload_stat": true,
     "is_print_case": true,
     "language": "zh",
     "confidence_alpha": 0.05,

--- a/integration_tests/artifacts/reports/test-zh_8680.json
+++ b/integration_tests/artifacts/reports/test-zh_8680.json
@@ -6,7 +6,6 @@
     "metric_names": [
         "Accuracy"
     ],
-    "reload_stat": true,
     "is_print_case": true,
     "language": "zh",
     "confidence_alpha": 0.05,

--- a/integration_tests/artifacts/reports/test-zh_8705.json
+++ b/integration_tests/artifacts/reports/test-zh_8705.json
@@ -6,7 +6,6 @@
     "metric_names": [
         "Accuracy"
     ],
-    "reload_stat": true,
     "is_print_case": true,
     "language": "zh",
     "confidence_alpha": 0.05,

--- a/integration_tests/text_classification_test.py
+++ b/integration_tests/text_classification_test.py
@@ -105,7 +105,6 @@ class TextClassificationTest(unittest.TestCase):
             "task_name": TaskType.text_classification.value,
             "metric_names": ["Accuracy", "F1Score"],
             "dataset_name": "ag_news",
-            "reload_stat": False,
         }
         loader = get_loader_class(TaskType.text_classification)(
             self.json_dataset,
@@ -118,7 +117,7 @@ class TextClassificationTest(unittest.TestCase):
         data = loader.load()
 
         processor = get_processor_class(TaskType.text_classification)()
-        sys_info = processor.process(metadata, data)
+        sys_info = processor.process(metadata, data, use_cache=False)
 
         self.assertGreater(len(sys_info.results.analyses), 0)
         self.assertGreater(len(sys_info.results.overall), 0)


### PR DESCRIPTION
<!-- EDIT THE TITLE FIRST. -->

# Overview

Remove `reload_stat` in `SysOutputInfo` and `--reload-stat` CLI option, introduce `--no-use-cache` instead.

# Details

`reload_stat` controls the behavior around the background system and not the `SysOutput`'s interest.
This change introduces `use_cache` option to `Processor.process` to handle the flag directly.

The name `reload_stat` is also confusing: it is unclear which `True` or `False` uses cache.
Since `reload_stat` is a normally-on flag to "use" the cache, using the option name `--no-use-cache` would be more clear.

# References

<!-- EDIT HERE: Put the list of taskboard issues, discussions related to this change. -->

- This is a yak-shaving before #575

# Blocked by

<!-- EDIT HERE IF ANY: Put the list of changes that have to be merged into the repository before merging this change. -->

- NA
