### PR TITLE
Drop python 3.8 support.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.8', '3.9', '3.10' ]
+        python-version: [ '3.9', '3.10' ]
     steps:
       - uses: actions/checkout@v3
       - name: Install Python ${{ matrix.python-version }}
@@ -30,7 +30,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.8', '3.9', '3.10' ]
+        python-version: [ '3.9', '3.10' ]
     steps:
       - uses: actions/checkout@v3
       - name: Install Python ${{ matrix.python-version }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,6 +13,7 @@ repos:
         additional_dependencies:
           - flake8-absolute-import
           - flake8-black>=0.1.1
+          - flake8-pep585>=0.1.6
         entry: flake8
         files: '\.py$'
       - id: flake8

--- a/explainaboard/analysis/bucketing.py
+++ b/explainaboard/analysis/bucketing.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import Hashable, Iterable, Sequence
 
 # List and Tuple is required for the first argument of narrow().
-from typing import Any, cast, List, Protocol, Tuple
+from typing import Any, cast, Protocol
 
 import numpy as np
 
@@ -168,16 +168,16 @@ def fixed(
     if bucket_number is None or bucket_setting is None:
         raise ValueError("bucket_number and bucket_setting must be set.")
 
-    interval_or_names = cast(List[Hashable], bucket_setting)
+    interval_or_names = cast(list[Hashable], bucket_setting)
     if len(interval_or_names) == 0:
         raise ValueError("Can not determine bucket keys.")
 
     features = [x[1] for x in sample_features]
 
     if isinstance(interval_or_names[0], str):
-        names = cast(List[str], interval_or_names)
+        names = cast(list[str], interval_or_names)
         name2idx: dict[str, list[int]] = {k: [] for k in names}
-        name_features = cast(List[str], features)
+        name_features = cast(list[str], features)
 
         for idx, name in enumerate(name_features):
             if name in names:
@@ -185,9 +185,9 @@ def fixed(
 
         return [AnalysisCaseCollection(samples=v, name=k) for k, v in name2idx.items()]
     else:
-        intervals = cast(List[Tuple[float, float]], interval_or_names)
+        intervals = cast(list[tuple[float, float]], interval_or_names)
         interval2idx: dict[tuple[float, float], list[int]] = {k: [] for k in intervals}
-        interval_features = cast(List[float], features)
+        interval_features = cast(list[float], features)
 
         for idx, interval in enumerate(interval_features):
             key = _find_range(intervals, interval)

--- a/explainaboard/loaders/file_loader.py
+++ b/explainaboard/loaders/file_loader.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
+from collections.abc import Callable, Iterable
 import copy
 import csv
 import dataclasses
@@ -10,18 +10,7 @@ from dataclasses import dataclass, field
 from io import StringIO
 import itertools
 import json
-from typing import (
-    Any,
-    cast,
-    ClassVar,
-    final,
-    Iterable,
-    Optional,
-    Sized,
-    Type,
-    TypeVar,
-    Union,
-)
+from typing import Any, cast, ClassVar, final, Optional, Sized, TypeVar, Union
 
 from datalabs import DatasetDict, IterableDatasetDict, load_dataset
 from datalabs.features.features import ClassLabel, Sequence
@@ -33,7 +22,7 @@ from explainaboard.serialization.serializers import PrimitiveSerializer
 from explainaboard.utils.load_resources import get_customized_features
 from explainaboard.utils.typing_utils import narrow
 
-DType = Union[Type[int], Type[float], Type[str], Type[dict], Type[list]]
+DType = Union[type[int], type[float], type[str], type[dict], type[list]]
 T = TypeVar("T")
 
 

--- a/explainaboard/metrics/f1_score.py
+++ b/explainaboard/metrics/f1_score.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 import itertools
-from typing import cast, Tuple
+from typing import cast
 
 import numpy as np
 
@@ -170,7 +170,7 @@ class APEF1Score(Metric):
 
         for tags, pred_tags in zip(true_data, pred_data):
             gold_spans, pred_spans = cast(
-                Tuple[set, set], gen_argument_pairs(tags, pred_tags)
+                tuple[set, set], gen_argument_pairs(tags, pred_tags)
             )
             stats.append(
                 [len(gold_spans), len(pred_spans), len(gold_spans & pred_spans)]

--- a/explainaboard/processors/argument_pair_extraction.py
+++ b/explainaboard/processors/argument_pair_extraction.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
-from typing import Any, cast, List
+from typing import Any, cast
 
 from explainaboard import TaskType
 from explainaboard.analysis import feature
@@ -183,8 +183,8 @@ class ArgumentPairExtractionProcessor(Processor):
             true_spans, pred_spans = self._argument_pair_ops.get_argument_pairs(
                 output["true_tags"], output["pred_tags"], sentences
             )
-            true_spans = cast(List[ArgumentPair], true_spans)
-            pred_spans = cast(List[ArgumentPair], pred_spans)
+            true_spans = cast(list[ArgumentPair], true_spans)
+            pred_spans = cast(list[ArgumentPair], pred_spans)
             # merge the spans together
             merged_spans: dict[tuple[int, int, int, int], ArgumentPair] = {}
             for span in true_spans:
@@ -238,4 +238,4 @@ class ArgumentPairExtractionProcessor(Processor):
             for name, config in analysis_level.metric_configs.items()
         }
 
-        return cast(List[AnalysisCase], cases), metric_stats
+        return cast(list[AnalysisCase], cases), metric_stats

--- a/explainaboard/processors/sequence_labeling.py
+++ b/explainaboard/processors/sequence_labeling.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import abc
 from collections.abc import Iterable
 import copy
-from typing import Any, cast, List
+from typing import Any, cast
 
 from explainaboard.analysis import feature
 from explainaboard.analysis.analyses import (
@@ -294,7 +294,7 @@ class SeqLabProcessor(Processor):
             name: config.to_metric().calc_stats_from_data(true_data, pred_data)
             for name, config in analysis_level.metric_configs.items()
         }
-        return cast(List[AnalysisCase], cases), metric_stats
+        return cast(list[AnalysisCase], cases), metric_stats
 
     def get_econ_efre_dic(
         self, words: list[str], bio_tags: list[str]

--- a/explainaboard/serialization/types.py
+++ b/explainaboard/serialization/types.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import abc
 import dataclasses
-from typing import Dict, final, List, Tuple, Union
+from typing import final, Union
 
 # TODO(odashi):
 # Recursive type is supported by only the head of mypy:
@@ -18,9 +18,9 @@ PrimitiveData = Union[  # type: ignore
     int,
     float,
     str,
-    List["PrimitiveData"],  # type: ignore
-    Tuple["PrimitiveData", ...],  # type: ignore
-    Dict[str, "PrimitiveData"],  # type: ignore
+    list["PrimitiveData"],  # type: ignore
+    tuple["PrimitiveData", ...],  # type: ignore
+    dict[str, "PrimitiveData"],  # type: ignore
 ]
 
 # Type of elements in Serializable objects.
@@ -30,9 +30,9 @@ SerializableData = Union[  # type: ignore
     int,
     float,
     str,
-    List["SerializableData"],  # type: ignore
-    Tuple["SerializableData", ...],  # type: ignore
-    Dict[str, "SerializableData"],  # type: ignore
+    list["SerializableData"],  # type: ignore
+    tuple["SerializableData", ...],  # type: ignore
+    dict[str, "SerializableData"],  # type: ignore
     "Serializable",
 ]
 

--- a/explainaboard/utils/span_utils.py
+++ b/explainaboard/utils/span_utils.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import abc
 from dataclasses import dataclass
-from typing import Any, cast, List, Optional
+from typing import Any, cast, Optional
 
 from explainaboard.analysis.feature_funcs import cap_feature
 
@@ -265,8 +265,8 @@ class ArgumentPairOps:
             A list of gold spans and predicted spans.
         """
         gold_spans, pred_spans = gen_argument_pairs(true_tags, pred_tags, sentences)
-        gold_spans_list = cast(List[ArgumentPair], gold_spans)
-        pred_spans_list = cast(List[ArgumentPair], pred_spans)
+        gold_spans_list = cast(list[ArgumentPair], gold_spans)
+        pred_spans_list = cast(list[ArgumentPair], pred_spans)
         return gold_spans_list, pred_spans_list
 
 


### PR DESCRIPTION
<!-- EDIT THE TITLE FIRST. -->

# Overview

This change drops Python 3.8 support from this repository.

# Details

Drop Python 3.8 runner from the CIs, and add `flake8-pep585` plugin to restrict new type aliases.
`setup.cfg` is unchanged because it does not contain the 3.8 tag.

# References

- Fixes #586

# Blocked by

<!-- EDIT HERE IF ANY: Put the list of changes that have to be merged into the repository before merging this change. -->

- NA
