### PR TITLE
Add text-to-SQL loader

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .[text_to_sql]
+          pip install .
           python -m spacy download en_core_web_sm
           python -m nltk.downloader punkt
       - name: test
@@ -40,7 +40,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .[text_to_sql]
+          pip install .
           python -m spacy download en_core_web_sm
           python -m nltk.downloader punkt
       - name: test

--- a/explainaboard/constants.py
+++ b/explainaboard/constants.py
@@ -32,6 +32,7 @@ class TaskType(str, Enum):
     ranking_with_context = "ranking-with-context"
     argument_pair_identification = "argument-pair-identification"
     meta_evaluation_nlg = "meta-evaluation-nlg"
+    text_to_sql = "text-to-sql"
 
     @staticmethod
     def list() -> list[str]:

--- a/explainaboard/loaders/loader_factory.py
+++ b/explainaboard/loaders/loader_factory.py
@@ -31,6 +31,7 @@ from explainaboard.loaders.tabular_classification import TabularClassificationLo
 from explainaboard.loaders.tabular_regression import TabularRegressionLoader
 from explainaboard.loaders.text_classification import TextClassificationLoader
 from explainaboard.loaders.text_pair_classification import TextPairClassificationLoader
+from explainaboard.loaders.text_to_sql import TextToSQLLoader
 
 _LOADERS: dict[TaskType, type[Loader]] = {
     TaskType.argument_pair_extraction: ArgumentPairExtractionLoader,
@@ -60,6 +61,7 @@ _LOADERS: dict[TaskType, type[Loader]] = {
     TaskType.meta_evaluation_nlg: MetaEvaluationNLGLoader,
     TaskType.argument_pair_identification: RankingwithContextLoader,
     TaskType.ranking_with_context: RankingwithContextLoader,
+    TaskType.text_to_sql: TextToSQLLoader,
 }
 
 

--- a/explainaboard/loaders/text_to_sql.py
+++ b/explainaboard/loaders/text_to_sql.py
@@ -1,0 +1,44 @@
+"""Loaders for the text-to-SQL task."""
+from __future__ import annotations
+
+from explainaboard.constants import FileType
+from explainaboard.loaders.file_loader import (
+    FileLoader,
+    FileLoaderField,
+    JSONFileLoader,
+    TextFileLoader,
+)
+from explainaboard.loaders.loader import Loader
+
+
+class TextToSQLLoader(Loader):
+    """Loader for the text_to_SQL task.
+
+    usage:
+        please refer to `loaders_test.py`
+    """
+
+    @classmethod
+    def default_dataset_file_type(cls) -> FileType:
+        """See Loader.default_dataset_file_type."""
+        return FileType.json
+
+    @classmethod
+    def default_dataset_file_loaders(cls) -> dict[FileType, FileLoader]:
+        """See Loader.default_dataset_file_loaders."""
+        return {
+            FileType.json: JSONFileLoader(
+                [
+                    FileLoaderField("question", "question", str),
+                    FileLoaderField("query", "true_sql", str),
+                    FileLoaderField("db_id", "db_id", str),
+                ]
+            ),
+        }
+
+    @classmethod
+    def default_output_file_loaders(cls) -> dict[FileType, FileLoader]:
+        """See Loader.default_output_file_loaders."""
+        return {
+            FileType.text: TextFileLoader("predicted_sql", str),
+        }

--- a/explainaboard/loaders/text_to_sql_test.py
+++ b/explainaboard/loaders/text_to_sql_test.py
@@ -1,0 +1,17 @@
+"""Tests for explainaboard.loaders.text_to_sql."""
+
+from __future__ import annotations
+
+import unittest
+
+from explainaboard.constants import TaskType
+from explainaboard.loaders.loader_factory import get_loader_class
+from explainaboard.loaders.text_to_sql import TextToSQLLoader
+
+
+class TextToSQLLoaderTest(unittest.TestCase):
+    def test_get_loader_class(self) -> None:
+        self.assertIs(
+            get_loader_class(TaskType.text_to_sql),
+            TextToSQLLoader,
+        )

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,10 +33,11 @@ install_requires =
     spacy
     tqdm
     wheel
+    pysqlite3
+    sqlparse>=0.4.2
 
 [options.extras_require]
 dev = pre-commit
-text_to_sql = pysqlite3; sqlparse>=0.4.2
 
 [options.package_data]
 explainaboard.resources = *.json


### PR DESCRIPTION
# Overall
The second step of adding the text-to-SQL task in https://github.com/neulab/ExplainaBoard/pull/580 
# Details
Standard input files in the text-to-SQL task use a JSON file containing the database id, question, and gold query in each example.  Standard output files are text files, where each line has a predicted query.