### PR TITLE
merge custom features/analyses from dataset and system output file

### DIFF
--- a/explainaboard/loaders/file_loader.py
+++ b/explainaboard/loaders/file_loader.py
@@ -115,6 +115,7 @@ class FileLoaderMetadata:
         self.task_name = other.task_name or self.task_name
         self.supported_tasks = other.supported_tasks or self.supported_tasks
         for level, features in other.custom_features.items():
+            self.custom_features.setdefault(level, {})
             self.custom_features[level].update(features)
         self.custom_analyses.extend(other.custom_analyses)
 

--- a/explainaboard/loaders/file_loader.py
+++ b/explainaboard/loaders/file_loader.py
@@ -100,7 +100,9 @@ class FileLoaderMetadata:
     def merge(self, other: FileLoaderMetadata) -> None:
         """Merge the information from the two pieces of metadata.
 
-        In the case that the two conflict, the passed-in metadata get preference.
+        In the case that the two conflict, the passed-in metadata get preference
+        with the exception of `custom_features` and `custom_analyses`. For those
+        two fields, self is updated/extended with the values from other.
         """
         # TODO(gneubig): This should be changed into a for loop
         self.system_name = other.system_name or self.system_name
@@ -112,8 +114,9 @@ class FileLoaderMetadata:
         self.supported_languages = other.supported_languages or self.supported_languages
         self.task_name = other.task_name or self.task_name
         self.supported_tasks = other.supported_tasks or self.supported_tasks
-        self.custom_features = other.custom_features or self.custom_features
-        self.custom_analyses = other.custom_analyses or self.custom_analyses
+        for level, features in other.custom_features.items():
+            self.custom_features[level].update(features)
+        self.custom_analyses.extend(other.custom_analyses)
 
     @classmethod
     def from_dict(cls, data: dict) -> FileLoaderMetadata:


### PR DESCRIPTION
<!-- EDIT THE TITLE FIRST. -->

# Overview

<!-- EDIT HERE:
Write a brief overview of this change in a few sentences.
-->
`custom_features` and `custom_analyses` can come from both the dataset and the user (system output file). This PR updates `FileLoaderMetadata.merge()` so user-defined custom features/analyses don't override the ones defined for the datasets.

# Details

<!-- EDIT HERE:
Write a detailed description of this change,
including backgrounds, approaches, and any other information that are related to this change.
-->

# References

<!-- EDIT HERE: Put the list of taskboard issues, discussions related to this change. -->

# Blocked by

<!-- EDIT HERE IF ANY: Put the list of changes that have to be merged into the repository before merging this change. -->

- NA