### PR TITLE
Deal with the case when correlation is NaN for meta evaluation task

### DIFF
--- a/explainaboard/metrics/meta_evaluation.py
+++ b/explainaboard/metrics/meta_evaluation.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-import math
 from typing import Any, Optional, Union
 
 import numpy as np
@@ -122,14 +121,14 @@ class CorrelationNLG(Metric):
         config = narrow(CorrelationNLGConfig, self.config)
         corr_func = config.get_correlation_func(config.correlation_type)
         if config.group_by == "dataset":
-            val = replace_nan(corr_func(single_stat[:, 0], single_stat[0:, 1])[0], 0)
+            val = replace_nan(corr_func(single_stat[:, 0], single_stat[0:, 1])[0], 0.0)
         elif config.group_by == "sample":
             val = np.mean(single_stat)
         elif config.group_by == "system":
             n_systems = int(single_stat.shape[-1] / 2)
             true_scores = np.sum(single_stat[:, 0:n_systems], axis=0)
             pred_scores = np.sum(single_stat[:, n_systems:], axis=0)
-            val = replace_nan(corr_func(true_scores, pred_scores)[0], 0)
+            val = replace_nan(corr_func(true_scores, pred_scores)[0], 0.0)
         else:
             raise ValueError(
                 f"group_by with the value {config.group_by} hasn't been supported."
@@ -387,6 +386,5 @@ class PearsonCorrelationWMTDA(CorrelationWMTDAMetric):
 
         assert len(system_score) == len(manual_score)
 
-        res = stats.pearsonr(system_score, manual_score)[0]
-        val = 0 if math.isnan(res) else res
+        val = replace_nan(stats.pearsonr(system_score, manual_score)[0], 0.0)
         return val

--- a/explainaboard/metrics/meta_evaluation.py
+++ b/explainaboard/metrics/meta_evaluation.py
@@ -3,10 +3,10 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import math
 from typing import Any, Optional, Union
 
 import numpy as np
-import math
 from scipy import stats
 
 from explainaboard.metrics.metric import (
@@ -78,8 +78,9 @@ class CorrelationNLG(Metric):
             return SimpleMetricStats(
                 np.array(
                     [
-                        0 if math.isnan(corr_func(true, pred)[0]) else
-                        corr_func(true, pred)[0]
+                        0
+                        if math.isnan(corr_func(true, pred)[0])
+                        else corr_func(true, pred)[0]
                         for true, pred in zip(true_data, pred_data)
                     ]
                 )

--- a/explainaboard/utils/py_utils.py
+++ b/explainaboard/utils/py_utils.py
@@ -1,0 +1,10 @@
+"""Utility functions for basic python libraries."""
+
+from __future__ import annotations
+
+import math
+
+
+def replace_nan(value: float, default: float) -> float:
+    """Replace value with a default value if it is NaN, otherwise, keep it unchanged."""
+    return default if math.isnan(value) else value

--- a/explainaboard/utils/py_utils_test.py
+++ b/explainaboard/utils/py_utils_test.py
@@ -2,8 +2,9 @@
 
 from __future__ import annotations
 
-import unittest
 import math
+import unittest
+
 from explainaboard.utils.py_utils import replace_nan
 
 

--- a/explainaboard/utils/py_utils_test.py
+++ b/explainaboard/utils/py_utils_test.py
@@ -1,0 +1,14 @@
+"""Tests for py_utils.py."""
+
+from __future__ import annotations
+
+import unittest
+import math
+from explainaboard.utils.py_utils import replace_nan
+
+
+class ReplaceNanTest(unittest.TestCase):
+    def test_replace_nan(self):
+        self.assertEqual(replace_nan(math.nan, 10), 10)
+
+        self.assertEqual(replace_nan(1, 10), 1)

--- a/explainaboard/utils/py_utils_test.py
+++ b/explainaboard/utils/py_utils_test.py
@@ -9,7 +9,7 @@ from explainaboard.utils.py_utils import replace_nan
 
 
 class ReplaceNanTest(unittest.TestCase):
-    def test_replace_nan(self):
-        self.assertEqual(replace_nan(math.nan, 10), 10)
+    def test_replace_nan(self) -> None:
+        self.assertEqual(replace_nan(math.nan, 10.0), 10.0)
 
-        self.assertEqual(replace_nan(1, 10), 1)
+        self.assertEqual(replace_nan(1.0, 10.0), 1.0)

--- a/version.py
+++ b/version.py
@@ -2,4 +2,4 @@
 
 from __future__ import annotations
 
-__version__ = "0.12.2"
+__version__ = "0.12.3"


### PR DESCRIPTION
<!-- EDIT THE TITLE FIRST. -->

# Overview

Currently, the correlation value of the meta-evaluation task could be NaN, which will break downstream applications. This PR fix this by setting them to 0.

 
