### PR TITLE
update isort version to fix ci error

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ repos:
         exclude: '^explainaboard\/third_party\/.*\.py'
         files: '\.py$'
   - repo: https://github.com/pycqa/isort.git
-    rev: 5.6.4
+    rev: 5.12.0
     hooks:
       - id: isort
         files: '\.py$'

--- a/docs/example_scripts/get_customized_feature_results.py
+++ b/docs/example_scripts/get_customized_feature_results.py
@@ -6,7 +6,6 @@ from explainaboard import get_loader_class, get_processor_class, TaskType
 # This code details (1) how to evaluate your systems using ExplainaBoard
 # programmatically (2)how to get results of your customized features
 def get_customized_results(dataset, customized_features):
-
     customized_features_performance = {}
 
     task = TaskType.kg_link_tail_prediction
@@ -26,7 +25,6 @@ def get_customized_results(dataset, customized_features):
 
     # get overall results of different metrics
     for metric_name, metric_info in sys_info.results.overall.items():  # type: ignore
-
         metric_name = metric_info.metric_name
         value = metric_info.value
         confidence_score_low = metric_info.confidence_score_low

--- a/explainaboard/explainaboard_main.py
+++ b/explainaboard/explainaboard_main.py
@@ -95,7 +95,6 @@ def analyze_reports(args):
     score_tensor = {}
     for report in reports:
         with open(report) as fin:
-
             report_dict = json.load(fin)
 
             system_name = report_dict["system_name"]
@@ -527,7 +526,6 @@ def main():
                     logger.info(analysis.generate_report())
 
             if output_dir:
-
                 # save report to `output_dir_reports`
                 x_file_name = os.path.basename(system_full_path).split(".")[0]
                 report.write_to_directory(output_dir_reports, f"{x_file_name}.json")

--- a/explainaboard/meta_analyses/rank_flipping.py
+++ b/explainaboard/meta_analyses/rank_flipping.py
@@ -138,7 +138,6 @@ class RankFlippingMetaAnalysis(MetaAnalysis):
         """
         paired_score_examples = []
         for m1_bucket, m2_bucket in zip(model1_buckets, model2_buckets):
-
             # bucket info (feature name, bucket interval, bucket name, bucket size)
             # should match exactly
             if m1_bucket["feature_name"] != m2_bucket["feature_name"]:

--- a/explainaboard/meta_analyses/ranking.py
+++ b/explainaboard/meta_analyses/ranking.py
@@ -159,7 +159,6 @@ class RankingMetaAnalysis(MetaAnalysis):
         )
         bucket_names = []
         for bucket_id in range(num_buckets):
-
             buckets_per_model = [
                 model_sysout[bucket_id] for model_sysout in model_sysouts
             ]

--- a/explainaboard/meta_analyses/utils.py
+++ b/explainaboard/meta_analyses/utils.py
@@ -28,11 +28,9 @@ def report_to_sysout(report: SysOutputInfo) -> list[dict]:
 
         # feature_perfs has `n_buckets` elements, each corresponding to a single bucket
         for bucket in details.bucket_performances:
-
             # loop through and record all the metrics that describe this bucket
             example_features: dict[str, Any] = {}
             for metric_name, metric_result in bucket.results.items():
-
                 example_features["feature_name"] = result.name
                 example_features["bucket_interval"] = bucket.bucket_interval
                 example_features["bucket_name"] = bucket.bucket_name

--- a/explainaboard/metrics/meta_evaluation.py
+++ b/explainaboard/metrics/meta_evaluation.py
@@ -94,7 +94,6 @@ class CorrelationNLG(Metric):
                 )
             )
         else:
-
             raise ValueError(
                 f"group_by with the value {config.group_by} hasn't been supported."
             )

--- a/explainaboard/metrics/qa_table_text_hybrid.py
+++ b/explainaboard/metrics/qa_table_text_hybrid.py
@@ -36,7 +36,6 @@ class QATatMetric(Metric):
         """See Metric.calc_stats_from_data."""
         stat_list = []
         for true_answer_info, pred_answer_info in zip(true_data, pred_data):
-
             prediction = pred_answer_info["predicted_answer"]
             prediction = prediction if isinstance(prediction, list) else [prediction]
 

--- a/explainaboard/processors/conditional_generation.py
+++ b/explainaboard/processors/conditional_generation.py
@@ -442,7 +442,6 @@ class ConditionalGenerationProcessor(Processor):
 
     @staticmethod
     def _match_toks(toks: TokenSeq, other_toks: TokenSeq):
-
         # Find tokens in other set
         other_tok_list = defaultdict(list)
         for i, tok in enumerate(other_toks):

--- a/explainaboard/processors/kg_link_tail_prediction.py
+++ b/explainaboard/processors/kg_link_tail_prediction.py
@@ -173,7 +173,6 @@ class KGLinkTailPredictionProcessor(Processor):
         dict_tail: dict[str, int] = {}
 
         for sample in progress(samples):
-
             tail = sample["true_tail_decipher"]
             dict_tail[tail] = dict_tail.get(tail, 0) + 1
 
@@ -233,7 +232,6 @@ class KGLinkTailPredictionProcessor(Processor):
 
     # --- Feature functions accessible by ExplainaboardBuilder._get_feature_func()
     def _get_entity_type_level(self, existing_features: dict):
-
         # entities not found in `entity_type_level_map` get bucketed to this value.
         # in FB15k, "0" is the same as the most generic entity type, "Thing".
         default_level = "0"

--- a/explainaboard/processors/sequence_labeling.py
+++ b/explainaboard/processors/sequence_labeling.py
@@ -191,7 +191,6 @@ class SeqLabProcessor(Processor):
         return data_point["pred_tags"]
 
     def _statistics_func(self, samples: Iterable[Any], sys_info: SysOutputInfo):
-
         tokens_sequences = []
         tags_sequences = []
 

--- a/explainaboard/processors/text_pair_classification.py
+++ b/explainaboard/processors/text_pair_classification.py
@@ -157,7 +157,6 @@ class TextPairClassificationProcessor(Processor):
         return {"Accuracy": AccuracyConfig()}
 
     def _statistics_func(self, samples: Iterable[Any], sys_info: SysOutputInfo):
-
         samples_list = list(samples)
         source_vocab, source_vocab_rank = accumulate_vocab_from_samples(
             samples_list,

--- a/explainaboard/third_party/text_to_sql_test_suit_eval/evaluation.py
+++ b/explainaboard/third_party/text_to_sql_test_suit_eval/evaluation.py
@@ -808,7 +808,6 @@ def evaluate(glist, plist, config):
                 )
 
             if etype in ["all", "exec"]:
-
                 # sqlite has error for some illegal sqls. add a trick to avoid it
                 if (
                     "players.player_id = players.player_id" in p_str

--- a/explainaboard/third_party/text_to_sql_test_suit_eval/exec_eval.py
+++ b/explainaboard/third_party/text_to_sql_test_suit_eval/exec_eval.py
@@ -229,7 +229,6 @@ def eval_exec_match(
     else:
         preds = [p_str]
     for pred in preds:
-
         pred_passes = 1
         # compare the gold and predicted denotations on each database in the directory
         # wrap with progress bar if required

--- a/explainaboard/utils/span_utils.py
+++ b/explainaboard/utils/span_utils.py
@@ -46,7 +46,6 @@ def gen_argument_pairs(
     pred_spans_set = set()
 
     for token_idx, token in enumerate(true_tags):
-
         gold_label = _get_argument_label(token)
         prefix = token.split("-")[0]
 
@@ -89,7 +88,6 @@ def gen_argument_pairs(
                     )
 
     for token_idx, token in enumerate(true_tags):
-
         gold_label = _get_argument_label(token)
         prefix = token.split("-")[0]
         next_label = (

--- a/explainaboard/utils/span_utils_bio_span_ops_test.py
+++ b/explainaboard/utils/span_utils_bio_span_ops_test.py
@@ -7,7 +7,6 @@ from explainaboard.utils.span_utils import BIOSpanOps
 
 class BIOSpanOpsTest(unittest.TestCase):
     def test_get_spans(self):
-
         tags = ["O", "O", "B-LOC", "I-LOC", "O", "B-LOC"]
         toks = ["I", "love", "New", "York", "and", "Beijing"]
 
@@ -21,7 +20,6 @@ class BIOSpanOpsTest(unittest.TestCase):
         self.assertEqual(span_tag_list, ["LOC", "LOC"])
 
     def test_get_matched_spans(self):
-
         # Span a
         tags = ["O", "O", "B-LOC", "I-LOC", "O", "B-LOC"]
         toks = ["I", "love", "New", "York", "and", "Beijing"]

--- a/explainaboard/utils/span_utils_bmes_span_ops_test.py
+++ b/explainaboard/utils/span_utils_bmes_span_ops_test.py
@@ -7,7 +7,6 @@ from explainaboard.utils.span_utils import BMESSpanOps
 
 class BMESSpanOpsTest(unittest.TestCase):
     def test_get_spans(self):
-
         tags = ["S", "B", "E", "B", "E"]
         toks = ["我", "喜", "欢", "纽", "约"]
 
@@ -21,7 +20,6 @@ class BMESSpanOpsTest(unittest.TestCase):
         self.assertEqual(span_tag_list, ["S", "BE", "BE"])
 
     def test_get_matched_spans(self):
-
         # Span a
         tags = ["S", "B", "E", "B", "E"]
         toks = ["我", "喜", "欢", "纽", "约"]

--- a/integration_tests/argument_pair_extraction_test.py
+++ b/integration_tests/argument_pair_extraction_test.py
@@ -12,7 +12,6 @@ from explainaboard.metrics.metric import Score
 
 
 class ArgumentPairExtractionTest(unittest.TestCase):
-
     artifact_path = os.path.join(test_artifacts_path, "argument_pair_extraction")
 
     def test_datalab_loader(self):

--- a/integration_tests/bucket_case_test.py
+++ b/integration_tests/bucket_case_test.py
@@ -11,7 +11,6 @@ from explainaboard.analysis.case import (
 
 class AnalysisCaseClassTest(unittest.TestCase):
     def test_bucket_class_class(self):
-
         my_bucket_seq = AnalysisCase(sample_id=0, features={})
         # print(asdict(my_bucket_seq))
         # {'sample_id': '0'}

--- a/integration_tests/machine_translation_test.py
+++ b/integration_tests/machine_translation_test.py
@@ -63,7 +63,6 @@ class MachineTranslationTest(unittest.TestCase):
         self.assertGreater(len(sys_info.results.overall), 0)
 
     def test_default_features_dont_modify_condgen(self):
-
         condgen_processor = get_processor_class(TaskType.conditional_generation)()
         mt_processor = get_processor_class(TaskType.machine_translation)()
 

--- a/integration_tests/meta_eval_nlg_test.py
+++ b/integration_tests/meta_eval_nlg_test.py
@@ -9,12 +9,10 @@ from explainaboard.utils.typing_utils import narrow, unwrap
 
 
 class MetaEvalNLGInvalidValueTest(unittest.TestCase):
-
     true_data = [[1, 2, 3, 4, 5], [2, 1, 4, 5, 2], [5, 4, 3, 2, 1]]
     pred_data = [[2, 1, 3, 4, 5], [2, 4, 5, 5, 2], [5, 3, 4, 2, 1]]
 
     def test_illegal_correlation_type_calc_stats_from_data(self) -> None:
-
         nlg_corr_config = CorrelationNLGConfig(
             group_by="sample", correlation_type="illegal"
         )
@@ -33,7 +31,6 @@ class MetaEvalNLGInvalidValueTest(unittest.TestCase):
             corr_metric._calc_metric_from_aggregate_single(stats_arr)
 
     def test_illegal_group_type_calc_stats_from_data(self) -> None:
-
         nlg_corr_config = CorrelationNLGConfig(
             group_by="illegal", correlation_type="spearmanr"
         )
@@ -61,7 +58,6 @@ class MetaEvalNLGTest(unittest.TestCase):
     pred_data = [[2, 1, 3, 4, 5], [2, 4, 5, 5, 2], [5, 3, 4, 2, 1]]
 
     def test_sample_level_spearmanr(self) -> None:
-
         nlg_corr_config = CorrelationNLGConfig(
             group_by="sample", correlation_type="spearmanr"
         )
@@ -73,7 +69,6 @@ class MetaEvalNLGTest(unittest.TestCase):
         self.assertAlmostEqual(val, 0.8162952, 3)
 
     def test_sample_level_kendalltau(self) -> None:
-
         nlg_corr_config = CorrelationNLGConfig(
             group_by="sample", correlation_type="kendalltau"
         )
@@ -84,7 +79,6 @@ class MetaEvalNLGTest(unittest.TestCase):
         self.assertAlmostEqual(val, 0.69046817, 3)
 
     def test_sample_level_pearsonr(self) -> None:
-
         nlg_corr_config = CorrelationNLGConfig(
             group_by="sample", correlation_type="pearsonr"
         )
@@ -95,7 +89,6 @@ class MetaEvalNLGTest(unittest.TestCase):
         self.assertAlmostEqual(val, 0.820707397, 3)
 
     def test_system_level_spearmanr(self) -> None:
-
         nlg_corr_config = CorrelationNLGConfig(
             group_by="system", correlation_type="spearmanr"
         )
@@ -106,7 +99,6 @@ class MetaEvalNLGTest(unittest.TestCase):
         self.assertAlmostEqual(val, 0.815789, 3)
 
     def test_system_level_kendalltau(self) -> None:
-
         nlg_corr_config = CorrelationNLGConfig(
             group_by="system", correlation_type="kendalltau"
         )
@@ -117,7 +109,6 @@ class MetaEvalNLGTest(unittest.TestCase):
         self.assertAlmostEqual(val, 0.66666, 3)
 
     def test_dataset_level_spearmanr(self) -> None:
-
         true_data = [[1], [2], [3], [4], [5]]
         pred_data = [[1], [2], [3], [4], [5]]
 
@@ -132,12 +123,10 @@ class MetaEvalNLGTest(unittest.TestCase):
 
 
 class MetaEvalNLGCITest(unittest.TestCase):
-
     true_data = [[1, 2, 3, 4, 5], [2, 1, 4, 5, 2], [5, 4, 3, 2, 1]]
     pred_data = [[2, 1, 3, 4, 5], [2, 4, 5, 5, 2], [5, 3, 4, 2, 1]]
 
     def test_sample_level_spearmanr_bootstrap(self) -> None:
-
         nlg_corr_config = CorrelationNLGConfig(
             group_by="sample", correlation_type="spearmanr"
         )
@@ -154,7 +143,6 @@ class MetaEvalNLGCITest(unittest.TestCase):
         self.assertAlmostEqual(ci[1], 0.8999, 2)
 
     def test_system_level_spearmanr_bootstrap(self) -> None:
-
         nlg_corr_config = CorrelationNLGConfig(
             group_by="system", correlation_type="spearmanr"
         )
@@ -171,7 +159,6 @@ class MetaEvalNLGCITest(unittest.TestCase):
         self.assertAlmostEqual(ci[1], 0.9746, 2)
 
     def test_dataset_level_spearmanr_bootstrap(self) -> None:
-
         true_data = [[1], [2], [3], [4], [5]]
         pred_data = [[1], [2], [3], [4], [5]]
 

--- a/integration_tests/multilingual_multitask_test.py
+++ b/integration_tests/multilingual_multitask_test.py
@@ -68,7 +68,6 @@ class MultilingualMultiTaskTest(unittest.TestCase):
         reports = []
         metadata = {}
         for loader, system_output, task in zip(loaders, system_outputs, tasks):
-
             metadata.update(loader.user_defined_metadata_configs)
 
             report = get_processor_class(task)().process(
@@ -89,7 +88,6 @@ class MultilingualMultiTaskTest(unittest.TestCase):
         score_tensor = {}
         for report in reports:
             with open(report) as fin:
-
                 report_dict = json.load(fin)
 
                 system_name = report_dict["system_name"]

--- a/integration_tests/resources_test.py
+++ b/integration_tests/resources_test.py
@@ -7,7 +7,6 @@ from explainaboard.utils.load_resources import get_customized_features
 
 class ResourcesTest(unittest.TestCase):
     def test_get_customized_features(self):
-
         self.assertEqual(
             {
                 "custom_features": {

--- a/integration_tests/span_utils_test.py
+++ b/integration_tests/span_utils_test.py
@@ -7,12 +7,10 @@ from explainaboard.utils.span_utils import BIOSpanOps
 
 class SpanUtilsTest(unittest.TestCase):
     def test_bio_spans_simple(self):
-
         spans = BIOSpanOps().get_spans_simple(["O", "B-PER", "I-PER", "B-ORG", "O"])
         self.assertEqual([("PER", 1, 3), ("ORG", 3, 4)], spans)
 
     def test_bio_spans(self):
-
         spans = BIOSpanOps().get_spans(
             ["O", "B-PER", "I-PER", "B-ORG", "O"],
             ["said", "Elon", "Musk", "Tesla", "CEO"],
@@ -23,12 +21,10 @@ class SpanUtilsTest(unittest.TestCase):
         self.assertEqual([(1, 3), (3, 4)], span_poss)
 
     def test_malformed_bio_spans_simple(self):
-
         spans = BIOSpanOps().get_spans_simple(["I-PER", "O", "O", "I-ORG", "I-ORG"])
         self.assertEqual([("PER", 0, 1), ("ORG", 3, 5)], spans)
 
     def test_malformed_bio_spans(self):
-
         spans = BIOSpanOps().get_spans(
             ["I-PER", "O", "O", "I-ORG", "I-ORG"],
             ["Biden", "at", "the", "U.S.", "Congress"],

--- a/integration_tests/summarization_test.py
+++ b/integration_tests/summarization_test.py
@@ -60,7 +60,6 @@ class SummarizationTest(unittest.TestCase):
         self.assertGreater(len(sys_info.results.overall), 0)
 
     def test_default_features_dont_modify_condgen(self):
-
         condgen_processor = get_processor_class(TaskType.conditional_generation)()
         sum_processor = get_processor_class(TaskType.summarization)()
 
@@ -79,7 +78,6 @@ class SummarizationTest(unittest.TestCase):
     # Commented out following code since it's too slow for unittest
     @unittest.skipUnless("test_sum" in OPTIONAL_TEST_SUITES, reason="time consuming")
     def test_datalab_loader(self):
-
         json_output_customized = cache_api.cache_online_file(
             "https://storage.googleapis.com/inspired-public-data/"
             "explainaboard/task_data/summarization/cnndm-bart-output.txt",

--- a/integration_tests/table_schema_test.py
+++ b/integration_tests/table_schema_test.py
@@ -8,7 +8,6 @@ from explainaboard.table_schema import table_schemas
 
 class TableSchemaTest(unittest.TestCase):
     def test_table_schemas(self):
-
         self.assertEqual(len(table_schemas[TaskType.text_classification]), 3)
 
         self.assertEqual(len(table_schemas[TaskType.summarization]), 3)

--- a/integration_tests/text_pair_classification_test.py
+++ b/integration_tests/text_pair_classification_test.py
@@ -45,7 +45,6 @@ class TextPairClassificationTest(unittest.TestCase):
         )
 
     def test_snli(self):
-
         metadata = {
             "task_name": TaskType.text_classification.value,
             "metric_names": ["Accuracy"],
@@ -67,7 +66,6 @@ class TextPairClassificationTest(unittest.TestCase):
         self.assertGreater(len(sys_info.results.overall), 0)
 
     def test_paws_fra(self):
-
         metadata = {
             "task_name": TaskType.text_classification.value,
             "metric_names": ["Accuracy"],

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ console_scripts =
 [flake8]
 application-import-names = explainaboard
 exclude = __pycache__, datasets
-extend-ignore = E203, BLK100, W503, FI10, FI11, FI12, FI13, FI14, FI15, FI16, FI17, FI58
+extend-ignore = E203, W503, FI10, FI11, FI12, FI13, FI14, FI15, FI16, FI17, FI58
 filename = ./explainaboard/*.py, ./setup.py
 max-line-length = 88
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ console_scripts =
 [flake8]
 application-import-names = explainaboard
 exclude = __pycache__, datasets
-extend-ignore = E203, W503, FI10, FI11, FI12, FI13, FI14, FI15, FI16, FI17, FI58
+extend-ignore = E203, BLK100, W503, FI10, FI11, FI12, FI13, FI14, FI15, FI16, FI17, FI58
 filename = ./explainaboard/*.py, ./setup.py
 max-line-length = 88
 


### PR DESCRIPTION
<!-- EDIT THE TITLE FIRST. -->

# Overview
This PR update the isort version to `5.12.0` to fix the ci error.

--- update------
When upgrade the sort, a lot of new errors appeared, for example,
```
explainaboard/processors/conditional_generation.py:445:1: BLK100 Black would make changes.
explainaboard/processors/kg_link_tail_prediction.py:176:1: BLK100 Black would make changes.
explainaboard/processors/sequence_labeling.py:194:1: BLK100 Black would make changes.
explainaboard/processors/text_pair_classification.py:160:1: BLK100 Black would make changes.
explainaboard/third_party/text_to_sql_test_suit_eval/evaluation.py:811:1: BLK100 Black would make
```
I fixed it currently by adding `ignore BLK100` tag.