### PR TITLE
Add dataset level meta eval metric

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ repos:
         exclude: '^explainaboard\/third_party\/.*\.py'
         files: '\.py$'
   - repo: https://github.com/pycqa/isort.git
-    rev: 5.6.4
+    rev: 5.12.0
     hooks:
       - id: isort
         files: '\.py$'

--- a/explainaboard/processors/meta_evaluation_nlg.py
+++ b/explainaboard/processors/meta_evaluation_nlg.py
@@ -101,6 +101,12 @@ class MetaEvaluationNLGProcessor(Processor):
             "PearsonSystemLevelCorr": CorrelationNLGConfig(
                 group_by="system", correlation_type="pearsonr"
             ),
+            "PearsonDatasetLevelCorr": CorrelationNLGConfig(
+                group_by="dataset", correlation_type="pearsonr"
+            ),
+            "SpearmanDatasetLevelCorr": CorrelationNLGConfig(
+                group_by="dataset", correlation_type="spearmanr"
+            ),
         }
 
     # --- Feature functions accessible by ExplainaboardBuilder._get_feature_func()

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ console_scripts =
 [flake8]
 application-import-names = explainaboard
 exclude = __pycache__, datasets
-extend-ignore = E203, W503, FI10, FI11, FI12, FI13, FI14, FI15, FI16, FI17, FI58
+extend-ignore = E203, BLK100, W503, FI10, FI11, FI12, FI13, FI14, FI15, FI16, FI17, FI58
 filename = ./explainaboard/*.py, ./setup.py
 max-line-length = 88
 

--- a/version.py
+++ b/version.py
@@ -2,4 +2,4 @@
 
 from __future__ import annotations
 
-__version__ = "0.12.4"
+__version__ = "0.12.5"


### PR DESCRIPTION
<!-- EDIT THE TITLE FIRST. -->

# Overview
This PR adds dataset-level measures for the mete-evaluation processor. So that metrics such as factuality could be evaluated.

# References
* issue: https://github.com/inspired-co/taskboard/issues/308

