### PR TITLE
Add negative error

### DIFF
--- a/explainaboard/metrics/continuous.py
+++ b/explainaboard/metrics/continuous.py
@@ -23,7 +23,8 @@ class RootMeanSquaredErrorConfig(MetricConfig):
     """Configuration for RootMeanSquaredError.
 
     Attributes:
-        negative: If True, the root mean squared error is multiplied by -1.
+        negative: If True, the root mean squared error is multiplied by -1. This makes
+            higher values of the metric correspond to better performance.
     """
 
     negative: bool = False
@@ -64,7 +65,8 @@ class AbsoluteErrorConfig(MetricConfig):
     """Configuration for AbsoluteError.
 
     Attributes:
-        negative: If True, the absolute error is multiplied by -1.
+        negative: If True, the absolute error is multiplied by -1. This makes higher
+            values of the metric correspond to better performance.
     """
 
     negative: bool = False

--- a/explainaboard/metrics/continuous.py
+++ b/explainaboard/metrics/continuous.py
@@ -14,12 +14,19 @@ from explainaboard.metrics.metric import (
     SimpleMetricStats,
 )
 from explainaboard.serialization import common_registry
+from explainaboard.utils.typing_utils import narrow
 
 
 @dataclass
 @common_registry.register("RootMeanSquaredErrorConfig")
 class RootMeanSquaredErrorConfig(MetricConfig):
-    """Configuration for RootMeanSquaredError."""
+    """Configuration for RootMeanSquaredError.
+
+    Attributes:
+        negative: If True, the root mean squared error is multiplied by -1.
+    """
+
+    negative: bool = False
 
     def to_metric(self) -> Metric:
         """See MetricConfig.to_metric."""
@@ -45,13 +52,22 @@ class RootMeanSquaredError(Metric):
         """See Metric.calc_metric_from_aggregate."""
         if agg_stats.shape[-1] != 1:
             raise ValueError("Invalid shape for aggregate stats {agg_stats.shape}")
-        return np.sqrt(np.squeeze(agg_stats, axis=-1))
+        error = np.sqrt(np.squeeze(agg_stats, axis=-1))
+        if narrow(RootMeanSquaredErrorConfig, self.config).negative:
+            error = -error
+        return error
 
 
 @dataclass
 @common_registry.register("AbsoluteErrorConfig")
 class AbsoluteErrorConfig(MetricConfig):
-    """Configuration for AbsoluteError."""
+    """Configuration for AbsoluteError.
+
+    Attributes:
+        negative: If True, the absolute error is multiplied by -1.
+    """
+
+    negative: bool = False
 
     def to_metric(self) -> Metric:
         """See MetricConfig.to_metric."""
@@ -64,4 +80,6 @@ class AbsoluteError(Metric):
     def calc_stats_from_data(self, true_data: list, pred_data: list) -> MetricStats:
         """See Metric.calc_stats_from_data."""
         error = np.array([abs(x - y) for x, y in zip(true_data, pred_data)])
+        if narrow(AbsoluteErrorConfig, self.config).negative:
+            error = -error
         return SimpleMetricStats(error)

--- a/explainaboard/metrics/continuous_test.py
+++ b/explainaboard/metrics/continuous_test.py
@@ -10,6 +10,8 @@ from explainaboard.metrics.continuous import (
     RootMeanSquaredError,
     RootMeanSquaredErrorConfig,
 )
+from explainaboard.metrics.metric import Score
+from explainaboard.utils.typing_utils import narrow
 
 
 class RootMeanSquaredErrorConfigTest(unittest.TestCase):
@@ -19,6 +21,7 @@ class RootMeanSquaredErrorConfigTest(unittest.TestCase):
             {
                 "source_language": None,
                 "target_language": None,
+                "negative": False,
             },
         )
 
@@ -42,6 +45,7 @@ class AbsoluteErrorConfigTest(unittest.TestCase):
             {
                 "source_language": None,
                 "target_language": None,
+                "negative": False,
             },
         )
 
@@ -56,3 +60,14 @@ class AbsoluteErrorConfigTest(unittest.TestCase):
             AbsoluteErrorConfig().to_metric(),
             AbsoluteError,
         )
+
+
+class AbsoluteErrorTest(unittest.TestCase):
+
+    def test_basic_calculation(self) -> None:
+        absolute_error = narrow(AbsoluteError, AbsoluteErrorConfig().to_metric())
+        expected = [1.0, 2.0, 3.0]
+        actual = [1.5, 2.0, 3.7]
+        metric_result = absolute_error.evaluate(expected, actual)
+        value = metric_result.get_value(Score, "score").value
+        self.assertAlmostEqual(value, 0.4)

--- a/explainaboard/metrics/continuous_test.py
+++ b/explainaboard/metrics/continuous_test.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 import unittest
 
 from explainaboard.metrics.continuous import (
@@ -38,6 +39,28 @@ class RootMeanSquaredErrorConfigTest(unittest.TestCase):
         )
 
 
+class RootMeanSquaredErrorTest(unittest.TestCase):
+    def test_basic_calculation(self) -> None:
+        absolute_error = narrow(
+            RootMeanSquaredError, RootMeanSquaredErrorConfig().to_metric()
+        )
+        expected = [1.0, 3.0]
+        actual = [1.4, 2.8]
+        metric_result = absolute_error.evaluate(expected, actual)
+        value = metric_result.get_value(Score, "score").value
+        self.assertAlmostEqual(value, math.sqrt(0.1))
+
+    def test_negative(self) -> None:
+        absolute_error = narrow(
+            RootMeanSquaredError, RootMeanSquaredErrorConfig(negative=True).to_metric()
+        )
+        expected = [1.0, 3.0]
+        actual = [1.4, 2.8]
+        metric_result = absolute_error.evaluate(expected, actual)
+        value = metric_result.get_value(Score, "score").value
+        self.assertAlmostEqual(value, -math.sqrt(0.1))
+
+
 class AbsoluteErrorConfigTest(unittest.TestCase):
     def test_serialize(self) -> None:
         self.assertEqual(
@@ -63,7 +86,6 @@ class AbsoluteErrorConfigTest(unittest.TestCase):
 
 
 class AbsoluteErrorTest(unittest.TestCase):
-
     def test_basic_calculation(self) -> None:
         absolute_error = narrow(AbsoluteError, AbsoluteErrorConfig().to_metric())
         expected = [1.0, 2.0, 3.0]
@@ -71,3 +93,13 @@ class AbsoluteErrorTest(unittest.TestCase):
         metric_result = absolute_error.evaluate(expected, actual)
         value = metric_result.get_value(Score, "score").value
         self.assertAlmostEqual(value, 0.4)
+
+    def test_negative(self) -> None:
+        absolute_error = narrow(
+            AbsoluteError, AbsoluteErrorConfig(negative=True).to_metric()
+        )
+        expected = [1.0, 2.0, 3.0]
+        actual = [1.5, 2.0, 3.7]
+        metric_result = absolute_error.evaluate(expected, actual)
+        value = metric_result.get_value(Score, "score").value
+        self.assertAlmostEqual(value, -0.4)


### PR DESCRIPTION
# Overview

This adds the ability to flip error-based evaluation metrics such as MAE and RMSE to be negative, so that higher values are better.

It also adds tests for MAE and RMSE, which did not exist before.

# Blocked by

- NA

