### PR TITLE
Add error for metaeval

### DIFF
--- a/explainaboard/metrics/meta_evaluation.py
+++ b/explainaboard/metrics/meta_evaluation.py
@@ -146,3 +146,102 @@ class CorrelationNLG(Metric):
                 val = self._calc_metric_from_aggregate_single(single_stat)
                 ret_metric[i] = val
             return ret_metric
+
+
+@dataclass
+@common_registry.register("RootMeanSquaredErrorMetaEvalConfig")
+class RootMeanSquaredErrorMetaEvalConfig(MetricConfig):
+    """Configuration for RootMeanSquaredErrorMetaEval.
+
+    Attributes:
+        negative: If True, the root mean squared error is multiplied by -1.
+    """
+
+    negative: bool = False
+
+    def to_metric(self) -> Metric:
+        """See MetricConfig.to_metric."""
+        return RootMeanSquaredErrorMetaEval(self)
+
+
+class RootMeanSquaredErrorMetaEval(Metric):
+    """Calculate the root mean squared error of continuous values."""
+
+    def calc_stats_from_data(self, true_data: list, pred_data) -> MetricStats:
+        """See Metric.calc_stats_from_data."""
+        error = np.array(
+            [
+                (sum((x - y) * (x - y) for x, y in zip(xs, ys)), len(xs))
+                for xs, ys in zip(true_data, pred_data)
+            ]
+        )
+        return SimpleMetricStats(error)
+
+    def is_simple_average(self, stats: MetricStats):
+        """See Metric.is_simple_average."""
+        return False
+
+    def _calc_metric_from_aggregate(
+        self, agg_stats: np.ndarray, config: MetricConfig | None = None
+    ) -> np.ndarray:
+        """See Metric.calc_metric_from_aggregate."""
+        if agg_stats.shape[-1] != 2:
+            raise ValueError("Invalid shape for aggregate stats {agg_stats.shape}")
+        avg_stats = (
+            agg_stats[:, 0] / agg_stats[:, 1]
+            if agg_stats.ndim == 2
+            else agg_stats[0] / agg_stats[1]
+        )
+        error = np.sqrt(avg_stats)
+        if narrow(RootMeanSquaredErrorMetaEvalConfig, self.config).negative:
+            error = -error
+        return error
+
+
+@dataclass
+@common_registry.register("AbsoluteErrorMetaEvalConfig")
+class AbsoluteErrorMetaEvalConfig(MetricConfig):
+    """Configuration for AbsoluteErrorMetaEval.
+
+    Attributes:
+        negative: If True, the absolute error is multiplied by -1.
+    """
+
+    negative: bool = False
+
+    def to_metric(self) -> Metric:
+        """See MetricConfig.to_metric."""
+        return AbsoluteErrorMetaEval(self)
+
+
+class AbsoluteErrorMetaEval(Metric):
+    """Calculate the absolute error of continuous values."""
+
+    def calc_stats_from_data(self, true_data: list, pred_data: list) -> MetricStats:
+        """See Metric.calc_stats_from_data."""
+        error = np.array(
+            [
+                (sum(abs(x - y) for x, y in zip(xs, ys)), len(xs))
+                for xs, ys in zip(true_data, pred_data)
+            ]
+        )
+        return SimpleMetricStats(error)
+
+    def is_simple_average(self, stats: MetricStats):
+        """See Metric.is_simple_average."""
+        return False
+
+    def _calc_metric_from_aggregate(
+        self, agg_stats: np.ndarray, config: MetricConfig | None = None
+    ) -> np.ndarray:
+        """See Metric.calc_metric_from_aggregate."""
+        if agg_stats.shape[-1] != 2:
+            raise ValueError("Invalid shape for aggregate stats {agg_stats.shape}")
+        error = (
+            agg_stats[:, 0] / agg_stats[:, 1]
+            if agg_stats.ndim == 2
+            else agg_stats[0] / agg_stats[1]
+        )
+        if narrow(AbsoluteErrorMetaEvalConfig, self.config).negative:
+            error = -error
+        return error

--- a/explainaboard/metrics/meta_evaluation.py
+++ b/explainaboard/metrics/meta_evaluation.py
@@ -154,7 +154,8 @@ class RootMeanSquaredErrorMetaEvalConfig(MetricConfig):
     """Configuration for RootMeanSquaredErrorMetaEval.
 
     Attributes:
-        negative: If True, the root mean squared error is multiplied by -1.
+        negative: If True, the root mean squared error is multiplied by -1. This makes
+            higher values of the metric correspond to better performance.
     """
 
     negative: bool = False
@@ -204,7 +205,8 @@ class AbsoluteErrorMetaEvalConfig(MetricConfig):
     """Configuration for AbsoluteErrorMetaEval.
 
     Attributes:
-        negative: If True, the absolute error is multiplied by -1.
+        negative: If True, the absolute error is multiplied by -1.  This makes
+            higher values of the metric correspond to better performance.
     """
 
     negative: bool = False

--- a/explainaboard/metrics/meta_evaluation_test.py
+++ b/explainaboard/metrics/meta_evaluation_test.py
@@ -1,0 +1,110 @@
+"""Tests for explainaboard.metrics.meta_evaluation"""
+
+from __future__ import annotations
+
+import math
+import unittest
+
+from explainaboard.metrics.meta_evaluation import (
+    AbsoluteErrorMetaEval,
+    AbsoluteErrorMetaEvalConfig,
+    RootMeanSquaredErrorMetaEval,
+    RootMeanSquaredErrorMetaEvalConfig,
+)
+from explainaboard.metrics.metric import Score
+from explainaboard.utils.typing_utils import narrow
+
+
+class RootMeanSquaredErrorMetaEvalConfigTest(unittest.TestCase):
+    def test_serialize(self) -> None:
+        self.assertEqual(
+            RootMeanSquaredErrorMetaEvalConfig().serialize(),
+            {
+                "source_language": None,
+                "target_language": None,
+                "negative": False,
+            },
+        )
+
+    def test_deserialize(self) -> None:
+        self.assertEqual(
+            RootMeanSquaredErrorMetaEvalConfig.deserialize({}),
+            RootMeanSquaredErrorMetaEvalConfig(),
+        )
+
+    def test_to_metric(self) -> None:
+        self.assertIsInstance(
+            RootMeanSquaredErrorMetaEvalConfig().to_metric(),
+            RootMeanSquaredErrorMetaEval,
+        )
+
+
+class RootMeanSquaredErrorMetaEvalTest(unittest.TestCase):
+    def test_basic_calculation(self) -> None:
+        absolute_error = narrow(
+            RootMeanSquaredErrorMetaEval,
+            RootMeanSquaredErrorMetaEvalConfig().to_metric(),
+        )
+        expected = [[1.0, 3.0, 1.0], [3.0]]
+        actual = [[1.4, 2.8, 1.4], [2.8]]
+        metric_result = absolute_error.evaluate(expected, actual)
+        value = metric_result.get_value(Score, "score").value
+        self.assertAlmostEqual(value, math.sqrt(0.1))
+
+    def test_negative(self) -> None:
+        absolute_error = narrow(
+            RootMeanSquaredErrorMetaEval,
+            RootMeanSquaredErrorMetaEvalConfig(negative=True).to_metric(),
+        )
+        expected = [[1.0], [3.0, 1.0, 3.0]]
+        actual = [[1.4], [2.8, 1.4, 2.8]]
+        metric_result = absolute_error.evaluate(expected, actual)
+        value = metric_result.get_value(Score, "score").value
+        self.assertAlmostEqual(value, -math.sqrt(0.1))
+
+
+class AbsoluteErrorMetaEvalConfigTest(unittest.TestCase):
+    def test_serialize(self) -> None:
+        self.assertEqual(
+            AbsoluteErrorMetaEvalConfig().serialize(),
+            {
+                "source_language": None,
+                "target_language": None,
+                "negative": False,
+            },
+        )
+
+    def test_deserialize(self) -> None:
+        self.assertEqual(
+            AbsoluteErrorMetaEvalConfig.deserialize({}),
+            AbsoluteErrorMetaEvalConfig(),
+        )
+
+    def test_to_metric(self) -> None:
+        self.assertIsInstance(
+            AbsoluteErrorMetaEvalConfig().to_metric(),
+            AbsoluteErrorMetaEval,
+        )
+
+
+class AbsoluteErrorMetaEvalTest(unittest.TestCase):
+    def test_basic_calculation(self) -> None:
+        absolute_error = narrow(
+            AbsoluteErrorMetaEval, AbsoluteErrorMetaEvalConfig().to_metric()
+        )
+        expected = [[1.0, 2.0], [3.0]]
+        actual = [[1.5, 2.0], [3.7]]
+        metric_result = absolute_error.evaluate(expected, actual)
+        value = metric_result.get_value(Score, "score").value
+        self.assertAlmostEqual(value, 0.4)
+
+    def test_negative(self) -> None:
+        absolute_error = narrow(
+            AbsoluteErrorMetaEval,
+            AbsoluteErrorMetaEvalConfig(negative=True).to_metric(),
+        )
+        expected = [[1.0], [2.0, 3.0]]
+        actual = [[1.5], [2.0, 3.7]]
+        metric_result = absolute_error.evaluate(expected, actual)
+        value = metric_result.get_value(Score, "score").value
+        self.assertAlmostEqual(value, -0.4)

--- a/explainaboard/processors/meta_evaluation_nlg.py
+++ b/explainaboard/processors/meta_evaluation_nlg.py
@@ -11,7 +11,11 @@ from explainaboard.analysis.analyses import Analysis, AnalysisLevel
 from explainaboard.analysis.feature import FeatureType
 from explainaboard.analysis.feature_funcs import count_tokens
 from explainaboard.info import SysOutputInfo
-from explainaboard.metrics.meta_evaluation import CorrelationNLGConfig
+from explainaboard.metrics.meta_evaluation import (
+    AbsoluteErrorMetaEvalConfig,
+    CorrelationNLGConfig,
+    RootMeanSquaredErrorMetaEvalConfig,
+)
 from explainaboard.metrics.metric import MetricConfig
 from explainaboard.processors.processor import Processor
 from explainaboard.utils.language_utils import (
@@ -106,6 +110,12 @@ class MetaEvaluationNLGProcessor(Processor):
             ),
             "SpearmanDatasetLevelCorr": CorrelationNLGConfig(
                 group_by="dataset", correlation_type="spearmanr"
+            ),
+            "NegativeAbsoluteError": AbsoluteErrorMetaEvalConfig(
+                negative=True,
+            ),
+            "NegativeRMSE": RootMeanSquaredErrorMetaEvalConfig(
+                negative=True,
             ),
         }
 


### PR DESCRIPTION
# Overview

This allows error metrics to be applied to meta-evaluation, where each example is a list of lists of floats.

# References

- Similarly to https://github.com/neulab/ExplainaBoard/pull/609 this also supports negative error.

# Blocked by

- NA
